### PR TITLE
Export commands and build types

### DIFF
--- a/packages/regl-worldview/rollup.config.js
+++ b/packages/regl-worldview/rollup.config.js
@@ -75,4 +75,15 @@ export default [
     external: isExternal,
     plugins: [babel(getBabelOptions({ useESModules: false }))],
   },
+  // build types.js for easy grouping of type imports
+  {
+    input: "src/types/index.js",
+    output: {
+      file: "dist/types.js",
+      format: "es",
+      name: libraryName,
+    },
+    external: isExternal,
+    plugins: [babel(getBabelOptions({ useESModules: false }))],
+  },
 ];

--- a/packages/regl-worldview/src/commands/Cones.js
+++ b/packages/regl-worldview/src/commands/Cones.js
@@ -13,7 +13,8 @@ import { createCylinderGeometry } from "./Cylinders";
 
 const { points, sideFaces, endCapFaces } = createCylinderGeometry(30, true);
 
+export const cones = fromGeometry(points, sideFaces.concat(endCapFaces));
 // prettier-ignore
-const Cylinders = makeCommand<BaseShape>('Cylinders', fromGeometry(points, sideFaces.concat(endCapFaces)));
+const Cylinders = makeCommand<BaseShape>('Cylinders', cones );
 
 export default Cylinders;

--- a/packages/regl-worldview/src/commands/Cubes.js
+++ b/packages/regl-worldview/src/commands/Cubes.js
@@ -10,41 +10,41 @@ import type { Cube } from "../types";
 import fromGeometry from "../utils/fromGeometry";
 import { makeCommand } from "./Command";
 
+export const cubes = fromGeometry(
+  [
+    // bottom face corners
+    [-0.5, -0.5, -0.5],
+    [-0.5, 0.5, -0.5],
+    [0.5, -0.5, -0.5],
+    [0.5, 0.5, -0.5],
+    // top face corners
+    [-0.5, -0.5, 0.5],
+    [-0.5, 0.5, 0.5],
+    [0.5, -0.5, 0.5],
+    [0.5, 0.5, 0.5],
+  ],
+  [
+    // bottom
+    [0, 1, 2],
+    [1, 2, 3],
+    // top
+    [4, 5, 6],
+    [5, 6, 7],
+    // left
+    [0, 2, 4],
+    [2, 4, 6],
+    // right
+    [1, 3, 5],
+    [3, 5, 7],
+    //front
+    [2, 3, 6],
+    [3, 6, 7],
+    //back
+    [0, 1, 4],
+    [1, 4, 5],
+  ]
+);
 // prettier-ignore
-const Cubes = makeCommand<Cube>('Cubes',
-  fromGeometry(
-    [
-      // bottom face corners
-      [-0.5, -0.5, -0.5],
-      [-0.5, 0.5, -0.5],
-      [0.5, -0.5, -0.5],
-      [0.5, 0.5, -0.5],
-      // top face corners
-      [-0.5, -0.5, 0.5],
-      [-0.5, 0.5, 0.5],
-      [0.5, -0.5, 0.5],
-      [0.5, 0.5, 0.5],
-    ],
-    [
-      // bottom
-      [0, 1, 2],
-      [1, 2, 3],
-      // top
-      [4, 5, 6],
-      [5, 6, 7],
-      // left
-      [0, 2, 4],
-      [2, 4, 6],
-      // right
-      [1, 3, 5],
-      [3, 5, 7],
-      //front
-      [2, 3, 6],
-      [3, 6, 7],
-      //back
-      [0, 1, 4],
-      [1, 4, 5],
-    ]
-  ));
+const Cubes = makeCommand<Cube>('Cubes', cubes);
 
 export default Cubes;

--- a/packages/regl-worldview/src/commands/Cylinders.js
+++ b/packages/regl-worldview/src/commands/Cylinders.js
@@ -44,7 +44,8 @@ export function createCylinderGeometry(numSegments: number, cone: boolean) {
 
 const { points, sideFaces, endCapFaces } = createCylinderGeometry(30, false);
 
+export const cylinders = fromGeometry(points, sideFaces.concat(endCapFaces));
 // prettier-ignore
-const Cylinders = makeCommand<Cylinder>('Cylinders', fromGeometry(points, sideFaces.concat(endCapFaces)));
+const Cylinders = makeCommand<Cylinder>('Cylinders', cylinders);
 
 export default Cylinders;

--- a/packages/regl-worldview/src/commands/Spheres.js
+++ b/packages/regl-worldview/src/commands/Spheres.js
@@ -51,6 +51,7 @@ for (let j = 0; j < NUM_MERIDIANS; j++) {
   faces.push([pt, prevPt, 1]);
 }
 
-const Spheres = makeCommand<SphereList>("Spheres", fromGeometry(points, faces));
+export const spheres = fromGeometry(points, faces);
+const Spheres = makeCommand<SphereList>("Spheres", spheres);
 
 export default Spheres;

--- a/packages/regl-worldview/src/commands/Triangles.js
+++ b/packages/regl-worldview/src/commands/Triangles.js
@@ -118,7 +118,7 @@ const vertexColors = (regl) =>
   });
 
 // command to render triangle lists optionally supporting vertex colors for each triangle
-export const triangleList = (regl: Regl) => {
+export const triangles = (regl: Regl) => {
   const single = regl(singleColor(regl));
   const vertex = regl(vertexColors(regl));
   return (props: any) => {
@@ -139,6 +139,6 @@ export const triangleList = (regl: Regl) => {
 };
 
 // prettier-ignore
-const Triangles = makeCommand<TriangleList>('Triangles', triangleList);
+const Triangles = makeCommand<TriangleList>('Triangles', triangles);
 
 export default Triangles;

--- a/packages/regl-worldview/src/commands/index.js
+++ b/packages/regl-worldview/src/commands/index.js
@@ -10,14 +10,14 @@ export { default as Command, SimpleCommand, makeCommand } from "./Command";
 
 // Primitives
 export { default as Arrows } from "./Arrows";
-export { default as Cones } from "./Cones";
-export { default as Cubes } from "./Cubes";
-export { default as Cylinders } from "./Cylinders";
+export { default as Cones, cones } from "./Cones";
+export { default as Cubes, cubes } from "./Cubes";
+export { default as Cylinders, cylinders } from "./Cylinders";
 export { default as Grid } from "./Grid";
-export { default as Lines } from "./Lines";
-export { default as Points } from "./Points";
-export { default as Spheres } from "./Spheres";
-export { default as Triangles } from "./Triangles";
+export { default as Lines, lines } from "./Lines";
+export { default as Points, points } from "./Points";
+export { default as Spheres, spheres } from "./Spheres";
+export { default as Triangles, triangles } from "./Triangles";
 
 // Composed shapes
 export { default as Axes } from "./Axes";


### PR DESCRIPTION
- Export regl commands for reusability 
- Build a separate type file so we could use `import type { Vec3, Arrow } from 'regl-worldview/dist/types'` 