### PR TITLE
Update vscode settings for flow

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
   "editor.formatOnSave": true,
-  "eslint.autoFixOnSave": true
+  "eslint.autoFixOnSave": true,
+  "flow.useNPMPackagedFlow": true,
+  "javascript.validate.enable": false
 }


### PR DESCRIPTION
Flow didn't work "out of the box" for me with this repo in vscode.  I think it might be useful to ship these vscode settings along w/ the library to disable the "types cannot be used within a .ts file" warning make sure the flow server being used is the version installed w/ the repo.