### PR TITLE
Fix the building of regl-worldview

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,3 +39,7 @@ jobs:
       - run:
           name: "npm test"
           command: npm test
+
+      - run:
+          name: "npm run build"
+          command: npm run build

--- a/packages/regl-worldview/babel.config.js
+++ b/packages/regl-worldview/babel.config.js
@@ -1,0 +1,12 @@
+//  Copyright (c) 2018-present, GM Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+const baseConfig = require("../../babel.config");
+
+module.exports = {
+  ...baseConfig,
+  plugins: baseConfig.plugins.filter((plugin) => plugin !== "@babel/plugin-transform-modules-commonjs"),
+};

--- a/packages/regl-worldview/rollup.config.js
+++ b/packages/regl-worldview/rollup.config.js
@@ -12,7 +12,7 @@ import replace from "rollup-plugin-replace";
 
 import pkg from "./package.json";
 
-// Additional optitons applied on top of babel.config.js
+// Additional options applied on top of babel.config.js
 const getBabelOptions = ({ useESModules }) => ({
   exclude: "**/node_modules/**",
   runtimeHelpers: true,


### PR DESCRIPTION
I broke this earlier when updating babel.config.js. Looks like this
fixes it. I wonder if we can further simplify the rollup config, but
for now I’m going to leave it at this.

Test plan: added build step to Circle CI.