### PR TITLE
Remove styled-components dependency from regl-worldview

### DIFF
--- a/packages/regl-worldview/package-lock.json
+++ b/packages/regl-worldview/package-lock.json
@@ -4,49 +4,10 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"asap": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-		},
-		"base64-js": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
-		},
 		"batch-processor": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
 			"integrity": "sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg="
-		},
-		"buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-			"integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
-			"requires": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4"
-			}
-		},
-		"core-js": {
-			"version": "1.2.7",
-			"resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-		},
-		"css-color-keywords": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-			"integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
-		},
-		"css-to-react-native": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.2.2.tgz",
-			"integrity": "sha512-w99Fzop1FO8XKm0VpbQp3y5mnTnaS+rtCvS+ylSEOK76YXO5zoHQx/QMB1N54Cp+Ya9jB9922EHrh14ld4xmmw==",
-			"requires": {
-				"css-color-keywords": "^1.0.0",
-				"fbjs": "^0.8.5",
-				"postcss-value-parser": "^3.3.0"
-			}
 		},
 		"earcut": {
 			"version": "2.1.3",
@@ -61,55 +22,10 @@
 				"batch-processor": "^1.0.0"
 			}
 		},
-		"encoding": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"requires": {
-				"iconv-lite": "~0.4.13"
-			}
-		},
-		"fbjs": {
-			"version": "0.8.17",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-			"requires": {
-				"core-js": "^1.0.0",
-				"isomorphic-fetch": "^2.1.1",
-				"loose-envify": "^1.0.0",
-				"object-assign": "^4.1.0",
-				"promise": "^7.1.1",
-				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.18"
-			}
-		},
 		"gl-matrix": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-2.8.1.tgz",
 			"integrity": "sha512-0YCjVpE3pS5XWlN3J4X7AiAx65+nqAI54LndtVFnQZB6G/FVLkZH8y8V6R3cIoOQR4pUdfwQGd1iwyoXHJ4Qfw=="
-		},
-		"has-flag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-		},
-		"hoist-non-react-statics": {
-			"version": "2.5.5",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-		},
-		"iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			}
-		},
-		"ieee754": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-			"integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
 		},
 		"invariant": {
 			"version": "2.2.4",
@@ -117,20 +33,6 @@
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"requires": {
 				"loose-envify": "^1.0.0"
-			}
-		},
-		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-		},
-		"isomorphic-fetch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-			"requires": {
-				"node-fetch": "^1.0.1",
-				"whatwg-fetch": ">=0.10.0"
 			}
 		},
 		"js-tokens": {
@@ -151,15 +53,6 @@
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
-		"node-fetch": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-			"requires": {
-				"encoding": "^0.1.11",
-				"is-stream": "^1.0.1"
-			}
-		},
 		"normalize-wheel": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
@@ -169,19 +62,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-		},
-		"postcss-value-parser": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
-		},
-		"promise": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"requires": {
-				"asap": "~2.0.3"
-			}
 		},
 		"prop-types": {
 			"version": "15.6.2",
@@ -202,11 +82,6 @@
 				"prop-types": "^15.5.8"
 			}
 		},
-		"react-is": {
-			"version": "16.6.3",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.3.tgz",
-			"integrity": "sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA=="
-		},
 		"regl": {
 			"version": "1.3.9",
 			"resolved": "https://registry.npmjs.org/regl/-/regl-1.3.9.tgz",
@@ -216,60 +91,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
 			"integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc="
-		},
-		"safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-		},
-		"styled-components": {
-			"version": "3.4.10",
-			"resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.4.10.tgz",
-			"integrity": "sha512-TA8ip8LoILgmSAFd3r326pKtXytUUGu5YWuqZcOQVwVVwB6XqUMn4MHW2IuYJ/HAD81jLrdQed8YWfLSG1LX4Q==",
-			"requires": {
-				"buffer": "^5.0.3",
-				"css-to-react-native": "^2.0.3",
-				"fbjs": "^0.8.16",
-				"hoist-non-react-statics": "^2.5.0",
-				"prop-types": "^15.5.4",
-				"react-is": "^16.3.1",
-				"stylis": "^3.5.0",
-				"stylis-rule-sheet": "^0.0.10",
-				"supports-color": "^3.2.3"
-			}
-		},
-		"stylis": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
-			"integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
-		},
-		"stylis-rule-sheet": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-			"integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
-		},
-		"supports-color": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-			"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-			"requires": {
-				"has-flag": "^1.0.0"
-			}
-		},
-		"ua-parser-js": {
-			"version": "0.7.19",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-			"integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
-		},
-		"whatwg-fetch": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
 		}
 	}
 }

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -32,7 +32,6 @@
     "normalize-wheel": "1.0.1",
     "react-container-dimensions": "1.3.3",
     "regl": "^1.3.1",
-    "reselect": "^3.0.1",
-    "styled-components": "^3.3.0"
+    "reselect": "^3.0.1"
   }
 }

--- a/packages/regl-worldview/rollup.config.js
+++ b/packages/regl-worldview/rollup.config.js
@@ -22,10 +22,7 @@ const getBabelOptions = ({ useESModules }) => ({
 const input = "src/index.js";
 const libraryName = "ReglWorldview";
 
-// HACK: add 'stream' field for styled-components SSR build.
-// Another issue about loading multiple instances:
-// https://www.styled-components.com/docs/faqs#why-am-i-getting-a-warning-about-several-instances-of-module-on-the-page
-const globals = { react: "React", "react-dom": "ReactDOM", stream: "undefined" };
+const globals = { react: "React", "react-dom": "ReactDOM" };
 const isExternal = (id) => !id.startsWith(".") && !id.startsWith("/");
 
 export default [
@@ -45,13 +42,7 @@ export default [
         browser: true,
       }),
       babel(getBabelOptions({ useESModules: true })),
-      commonjs({
-        include: "node_modules/**",
-        // Make styled components work: https://github.com/styled-components/styled-components/issues/1654
-        namedExports: {
-          "node_modules/react-is/index.js": ["isElement", "isValidElementType", "ForwardRef"],
-        },
-      }),
+      commonjs({ include: "node_modules/**" }),
       replace({ "process.env.NODE_ENV": JSON.stringify("development") }),
     ],
   },

--- a/packages/regl-worldview/src/commands/Text.js
+++ b/packages/regl-worldview/src/commands/Text.js
@@ -7,7 +7,6 @@
 //  You may not use this file except in compliance with the License.
 
 import React from "react";
-import styled from "styled-components";
 
 import type { Point, CameraCommand, Dimensions, Color, Pose, Scale } from "../types";
 import { getCSSColor } from "../utils/commandUtils";
@@ -22,23 +21,34 @@ type TextMarker = {
   text: string,
 };
 
-const StyledContainer = styled.div`
-  > span {
-    position: absolute;
-    white-space: nowrap;
-    z-index: 100;
-    pointer-events: none;
-    top: 0;
-    left: 0;
-    will-change: transform;
-    > span {
+let cssHasBeenInserted = false;
+function insertGlobalCss() {
+  if (cssHasBeenInserted) {
+    return;
+  }
+  const style = document.createElement("style");
+  style.innerHTML = `
+    .regl-worldview-text-wrapper {
+      position: absolute;
+      white-space: nowrap;
+      z-index: 100;
+      pointer-events: none;
+      top: 0;
+      left: 0;
+      will-change: transform;
+    }
+    .regl-worldview-text-inner {
       position: relative;
       left: -50%;
       top: -0.5em;
       white-space: pre-line;
     }
+  `;
+  if (document.body) {
+    document.body.appendChild(style);
   }
-`;
+  cssHasBeenInserted = true;
+}
 
 class TextElement {
   wrapper = document.createElement("span");
@@ -47,6 +57,9 @@ class TextElement {
   _color = "";
 
   constructor() {
+    insertGlobalCss();
+    this.wrapper.className = "regl-worldview-text-wrapper";
+    this._inner.className = "regl-worldview-text-inner";
     this.wrapper.appendChild(this._inner);
     this._inner.appendChild(this._text);
   }
@@ -155,7 +168,7 @@ export default class Text extends React.Component<Props> {
   render() {
     return (
       <React.Fragment>
-        <StyledContainer ref={this._textContainerRef} />
+        <div ref={this._textContainerRef} />
         <WorldviewReactContext.Consumer>
           {(ctx: ?WorldviewContextType) => {
             if (ctx) {

--- a/packages/regl-worldview/src/stories/Container.js
+++ b/packages/regl-worldview/src/stories/Container.js
@@ -8,29 +8,9 @@
 /* eslint-disable flowtype/no-types-missing-file-annotation */
 
 import React from "react";
-import styled from "styled-components";
 
 import Worldview, { type Props } from "../index";
 import inScreenshotTests from "./inScreenshotTests";
-
-const WorldviewWrapper = styled.div`
-  position: relative;
-  width: 100%;
-  height: 100%;
-`;
-
-const TextWrapper = styled.div`
-  position: absolute;
-  pointer-events: none;
-  width: 100%;
-  bottom: 8px;
-  left: 8px
-  z-index: 1;
-  overflow: hidden;
-  font-size: 0.8rem;
-  color: gray;
-  white-space: pre-line;
-`;
 
 export default class Container extends React.Component<Props> {
   state = {
@@ -51,8 +31,24 @@ export default class Container extends React.Component<Props> {
       .join("\n");
 
     return (
-      <WorldviewWrapper>
-        {!this.props.hideState && <TextWrapper>{worldviewCamStateInfo}</TextWrapper>}
+      <div style={{ position: "relative", width: "100%", height: "100%" }}>
+        {!this.props.hideState && (
+          <div
+            style={{
+              position: "absolute",
+              pointerEvents: "none",
+              width: "100%",
+              bottom: "8px",
+              left: "8p",
+              zIndex: "1",
+              overflow: "hidden",
+              fontSize: "0.8rem",
+              color: "gray",
+              whiteSpace: "pre-line",
+            }}>
+            {worldviewCamStateInfo}
+          </div>
+        )}
         <Worldview
           {...this.props}
           hideDebug={inScreenshotTests()}
@@ -61,7 +57,7 @@ export default class Container extends React.Component<Props> {
           onCameraStateChange={this.onCameraStateChange}>
           {this.props.children}
         </Worldview>
-      </WorldviewWrapper>
+      </div>
     );
   }
 }

--- a/packages/regl-worldview/src/stories/FloatingBox.js
+++ b/packages/regl-worldview/src/stories/FloatingBox.js
@@ -4,15 +4,21 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 
-import styled from "styled-components";
+import React from "react";
 
-export default styled.div`
-  position: absolute;
-  border: 1px solid white;
-  background-color: grey;
-  top: 10px;
-  left: 10px;
-  padding: 10px;
-  display: flex;
-  flex-direction: column;
-`;
+export default function FloatingBox() {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        border: "1px solid white",
+        backgroundColor: "grey",
+        top: 10,
+        left: 10,
+        padding: 10,
+        display: "flex",
+        flexDirection: "column",
+      }}
+    />
+  );
+}

--- a/packages/regl-worldview/src/stories/hitmap.js
+++ b/packages/regl-worldview/src/stories/hitmap.js
@@ -6,8 +6,7 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 
-import React from "react";
-import styled from "styled-components";
+import * as React from "react";
 
 import { getCSSColor } from "../utils/commandUtils";
 import FloatingBox from "./FloatingBox";
@@ -24,24 +23,26 @@ import Worldview, {
   type SphereList,
 } from "..";
 
-export const StyledContainer = styled.div`
-  position: absolute;
-  white-space: nowrap;
-  z-index: 100;
-  pointer-events: none;
-  top: 0;
-  left: 0;
-  will-change: transform;
-  padding: 0.8rem;
-  background: #24bbcaa3;
-  max-width: 240px;
-  color: #fff;
-  white-space: pre-line;
-  > div {
-    position: relative;
-    white-space: pre-line;
-  }
-`;
+export function StyledContainer(props: {| children: React.Node, style: Object |}) {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        zIndex: 100,
+        pointerEvents: "none",
+        top: 0,
+        left: 0,
+        willChange: "transform",
+        padding: "0.8rem",
+        background: "#24bbcaa3",
+        maxWidth: "240px",
+        color: "#fff",
+        whiteSpace: "pre-line",
+        ...props.style,
+      }}
+    />
+  );
+}
 
 const p = (x, y = x, z = x) => ({ x, y, z });
 type RGBA = {
@@ -291,7 +292,7 @@ export default function() {
                     transform: `translate(${left.toFixed()}px,${top.toFixed()}px)`,
                   }}>
                   <h2 style={{ color: getCSSColor(color), fontSize: "2rem" }}>{title}</h2>
-                  <div>{text}</div>
+                  <div style={{ position: "relative", whiteSpace: "pre-line" }}>{text}</div>
                   <a
                     style={{ pointerEvents: "visible" }}
                     href="https://google.com/"


### PR DESCRIPTION
We only had a few minor dependencies on it, but it caused a bunch of
problems, ranging from hacks in the Rollup config, to having to keep
the version in sync with the version in the root of the repo (for docs).
So I figured I’d just remove it.

Test plan: verified manually that stories and docs work properly now.
The rest is somewhat covered by CI.