### PR TITLE
Make docs deployable to Github Pages

### DIFF
--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -16,6 +16,6 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <script src="/dist/docs.js"></script>
+    <script src="dist/docs.js"></script>
   </body>
 </html>

--- a/docs/src/App.js
+++ b/docs/src/App.js
@@ -6,7 +6,7 @@
 
 import { MDXProvider } from "@mdx-js/tag";
 import React, { useState } from "react";
-import { BrowserRouter as Router, Route, Link, Redirect } from "react-router-dom";
+import { HashRouter as Router, Route, Link, Redirect } from "react-router-dom";
 import styled from "styled-components";
 
 import Logo from "./Logo";

--- a/package-lock.json
+++ b/package-lock.json
@@ -8100,6 +8100,12 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
+    "email-addresses": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.0.3.tgz",
+      "integrity": "sha512-kUlSC06PVvvjlMRpNIl3kR1NRXLEe86VQ7N0bQeaCZb2g+InShCeHQp/JvyYNTugMnRN2NvJhHlc3q12MWbbpg==",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
@@ -9324,6 +9330,33 @@
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true
+    },
+    "filename-reserved-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
+      "integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
+      "dev": true
+    },
+    "filenamify": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
+      "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
+      "dev": true,
+      "requires": {
+        "filename-reserved-regex": "^1.0.0",
+        "strip-outer": "^1.0.0",
+        "trim-repeated": "^1.0.0"
+      }
+    },
+    "filenamify-url": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-1.0.0.tgz",
+      "integrity": "sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=",
+      "dev": true,
+      "requires": {
+        "filenamify": "^1.0.0",
+        "humanize-url": "^1.0.0"
+      }
     },
     "fileset": {
       "version": "2.0.3",
@@ -10847,6 +10880,63 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "gh-pages": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-2.0.1.tgz",
+      "integrity": "sha512-uFlk3bukljeiWKQ2XvPfjcSi/ou7IfoDf2p+Fj672saLAr8bnOdFVqI/JSgrSgInKpCg5BksxEwGUl++dbg8Dg==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.1",
+        "commander": "^2.18.0",
+        "email-addresses": "^3.0.1",
+        "filenamify-url": "^1.0.0",
+        "fs-extra": "^7.0.0",
+        "globby": "^6.1.0",
+        "graceful-fs": "^4.1.11",
+        "rimraf": "^2.6.2"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
     "git-raw-commits": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.0.tgz",
@@ -11663,6 +11753,16 @@
       "dev": true,
       "requires": {
         "ms": "^2.0.0"
+      }
+    },
+    "humanize-url": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz",
+      "integrity": "sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=",
+      "dev": true,
+      "requires": {
+        "normalize-url": "^1.0.0",
+        "strip-url-auth": "^1.0.0"
       }
     },
     "husky": {
@@ -23306,6 +23406,21 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
+      }
+    },
+    "strip-url-auth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-url-auth/-/strip-url-auth-1.0.1.tgz",
+      "integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=",
+      "dev": true
+    },
     "strong-log-transformer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.0.0.tgz",
@@ -24026,6 +24141,15 @@
       "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true
+    },
+    "trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
+      }
     },
     "trim-right": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "flow-copy-source": "^2.0.2",
     "flow-mono-cli": "^1.4.3",
     "flow-typed": "^2.5.1",
+    "gh-pages": "^2.0.1",
     "gl-matrix": "^2.8.1",
     "husky": "^1.2.0",
     "jest": "^23.6.0",
@@ -88,14 +89,13 @@
   "dependencies": {},
   "scripts": {
     "bootstrap": "npm install && lerna exec npm install",
-    "build": "lerna run build",
+    "build": "lerna run build && webpack",
     "watch": "lerna run watch --parallel",
     "clean": "lerna run clean",
     "lint": "eslint . --max-warnings=0 &&  prettier -l '**/*.css' --ignore-path .eslintignore",
     "lint:fix": "eslint . --fix && prettier --write '**/*.css' --ignore-path .eslintignore",
     "test": "NODE_ENV=test jest --config jest/jest.config.js",
     "link": "lerna link --force-local",
-    "docs": "webpack-dev-server",
     "update-version": "lerna publish --skip-git --skip-npm --force-publish '*'",
     "check-packages": "yarn clean && yarn compile && yarn test && yarn lint",
     "publish-packages": "./scripts/publish",
@@ -103,7 +103,9 @@
     "build-storybook": "build-storybook",
     "flow": "flow",
     "flow-mono": "flow-mono create-symlinks ./dist/.flowconfig",
-    "flow-mono-install": "flow-mono install-types"
+    "flow-mono-install": "flow-mono install-types",
+    "docs": "webpack-dev-server",
+    "docs-deploy": "gh-pages -d docs/public"
   },
   "workspaces": [
     "packages/*"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
     docs: "./docs/src/index.js",
   },
   output: {
-    path: path.resolve(`${__dirname}/dist`),
+    path: path.resolve(`${__dirname}/docs/public/dist`),
     publicPath: "/dist/",
     pathinfo: true,
     filename: "[name].js",
@@ -102,7 +102,6 @@ module.exports = {
   performance: { hints: false },
   devServer: {
     contentBase: path.resolve(`${__dirname}/docs/public`),
-    historyApiFallback: true,
     hot: true,
   },
 };


### PR DESCRIPTION
Using a HashRouter instead of BrowserRouter, otherwise we’d have to
somehow deal with 404s (using something like
https://github.com/rafrex/spa-github-pages or so, but that seems pretty
hacky).

Test plan: it works: https://cruise-automation.github.io/webviz