### PR TITLE
Fix flow exports

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,6 @@
 [ignore]
 .*\.ignore\.js
+dist
 
 [include]
 

--- a/lerna.json
+++ b/lerna.json
@@ -5,6 +5,6 @@
   "devDependencies": {
     "lerna": "^3.4.3"
   },
-  "version": "0.0.3",
+  "version": "0.0.3-flow",
   "npmClient": "npm"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,10 +1,8 @@
 {
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "devDependencies": {
     "lerna": "^3.4.3"
   },
-  "version": "0.0.3-flow",
+  "version": "0.0.3",
   "npmClient": "npm"
 }

--- a/packages/regl-worldview/flow/index.js.flow
+++ b/packages/regl-worldview/flow/index.js.flow
@@ -1,3 +1,10 @@
 // @flow
-export * from "../src/types/index.js";
-export { default } from "../src/Worldview";
+
+//  Copyright (c) 2018-present, GM Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+export * from "../src/index";
+export { default } from "../src/index";

--- a/packages/regl-worldview/index.js
+++ b/packages/regl-worldview/index.js
@@ -1,2 +1,0 @@
-export * from "./src";
-export default from "./src";

--- a/packages/regl-worldview/index.js
+++ b/packages/regl-worldview/index.js
@@ -1,0 +1,10 @@
+//  Copyright (c) 2018-present, GM Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+// DON"T REMOVE THIS FILE
+// This is for the docs, stories, and linter to work
+export * from "./src";
+export default from "./src";

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "browser": "dist/index.esm.js",
+  "unpkg": "dist/index.umd.js",
   "files": [
     "src",
     "dist",

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.0.3-flow",
+  "version": "0.0.3",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.0.3",
+  "version": "0.0.3-flow",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/packages/regl-worldview/rollup.config.js
+++ b/packages/regl-worldview/rollup.config.js
@@ -55,12 +55,7 @@ export default [
       name: libraryName,
     },
     external: isExternal,
-    plugins: [
-      babel(getBabelOptions({ useESModules: false })),
-      copy({
-        "flow/index.js.flow": "dist/index.cjs.js.flow",
-      }),
-    ],
+    plugins: [babel(getBabelOptions({ useESModules: false }))],
   },
   {
     input,
@@ -73,7 +68,7 @@ export default [
     plugins: [
       babel(getBabelOptions({ useESModules: false })),
       copy({
-        "flow/index.js.flow": "dist/index.esm.js.flow",
+        "flow/index.js.flow": "dist/index.js.flow",
       }),
     ],
   },

--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -9,10 +9,9 @@
 import debounce from "lodash/debounce";
 import createREGL from "regl";
 
-import type { CameraState } from "./camera/CameraStore";
 import { camera, CameraStore } from "./camera/index";
 import Command from "./commands/Command";
-import type { Dimensions, RawCommand, CompiledReglCommand, CameraCommand, Vec4 } from "./types";
+import type { Dimensions, RawCommand, CompiledReglCommand, CameraCommand, Vec4, CameraState } from "./types";
 import { getIdFromColor } from "./utils/commandUtils";
 import { getRayFromClick } from "./utils/Raycast";
 


### PR DESCRIPTION
Somehow flow doesn't pick up `index.esm.js.flow` and `index.js.flow` works. It's nice since we don't have to write two flow files separately for es and cjs. 

Test plan:
Published a testing npm version, and tested with our internal package that flow types can be imported correctly using the following synttax:
`import { type Vec3 } from 'regl-worldview';`

