### PR TITLE
Generate sourcemaps for all builds

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,6 +5,6 @@
   "devDependencies": {
     "lerna": "^3.4.3"
   },
-  "version": "0.0.4",
+  "version": "0.0.4-alpha",
   "npmClient": "npm"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16526,6 +16526,18 @@
         "rollup-pluginutils": "^2.0.1"
       }
     },
+    "rollup-plugin-uglify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-6.0.0.tgz",
+      "integrity": "sha512-XtzZd159QuOaXNvcxyBcbUCSoBsv5YYWK+7ZwUyujSmISst8avRfjWlp7cGu8T2O52OJnpEBvl+D4WLV1k1iQQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "jest-worker": "^23.2.0",
+        "serialize-javascript": "^1.5.0",
+        "uglify-js": "^3.4.9"
+      }
+    },
     "rollup-pluginutils": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz",
@@ -17375,7 +17387,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16526,6 +16526,18 @@
         "rollup-pluginutils": "^2.0.1"
       }
     },
+    "rollup-plugin-terser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-3.0.0.tgz",
+      "integrity": "sha512-Ed9zRD7OoCBnh0XGlEAJle5TCUsFXMLClwKzZWnS1zbNO4MelHjfCSdFZxCAdH70M40nhZ1nRrY2GZQJhSMcjA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "jest-worker": "^23.2.0",
+        "serialize-javascript": "^1.5.0",
+        "terser": "^3.8.2"
+      }
+    },
     "rollup-pluginutils": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16526,18 +16526,6 @@
         "rollup-pluginutils": "^2.0.1"
       }
     },
-    "rollup-plugin-uglify": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-6.0.0.tgz",
-      "integrity": "sha512-XtzZd159QuOaXNvcxyBcbUCSoBsv5YYWK+7ZwUyujSmISst8avRfjWlp7cGu8T2O52OJnpEBvl+D4WLV1k1iQQ==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "jest-worker": "^23.2.0",
-        "serialize-javascript": "^1.5.0",
-        "uglify-js": "^3.4.9"
-      }
-    },
     "rollup-pluginutils": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "rollup-plugin-peer-deps-external": "^2.2.0",
     "rollup-plugin-replace": "^2.1.0",
+    "rollup-plugin-terser": "^3.0.0",
     "sass-loader": "^7.1.0",
     "seedrandom": "^2.4.4",
     "storybook-chrome-screenshot": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "rollup-plugin-peer-deps-external": "^2.2.0",
     "rollup-plugin-replace": "^2.1.0",
+    "rollup-plugin-uglify": "^6.0.0",
     "sass-loader": "^7.1.0",
     "seedrandom": "^2.4.4",
     "storybook-chrome-screenshot": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "rollup-plugin-peer-deps-external": "^2.2.0",
     "rollup-plugin-replace": "^2.1.0",
-    "rollup-plugin-uglify": "^6.0.0",
     "sass-loader": "^7.1.0",
     "seedrandom": "^2.4.4",
     "storybook-chrome-screenshot": "^1.4.0",

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.0.4-alpha",
+  "version": "0.0.4",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.0.4",
+  "version": "0.0.4-alpha",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/packages/regl-worldview/rollup.config.js
+++ b/packages/regl-worldview/rollup.config.js
@@ -10,7 +10,7 @@ import copy from "rollup-plugin-copy";
 import resolve from "rollup-plugin-node-resolve";
 import peerDepsExternal from "rollup-plugin-peer-deps-external";
 import replace from "rollup-plugin-replace";
-import { uglify } from "rollup-plugin-uglify";
+import { terser } from "rollup-plugin-terser";
 
 import pkg from "./package.json";
 
@@ -47,7 +47,7 @@ export default [
       babel(getBabelOptions({ useESModules: true })),
       commonjs({ include: "node_modules/**" }),
       replace({ "process.env.NODE_ENV": JSON.stringify("development") }),
-      uglify(),
+      terser(),
     ],
   },
   {

--- a/packages/regl-worldview/rollup.config.js
+++ b/packages/regl-worldview/rollup.config.js
@@ -10,6 +10,7 @@ import copy from "rollup-plugin-copy";
 import resolve from "rollup-plugin-node-resolve";
 import peerDepsExternal from "rollup-plugin-peer-deps-external";
 import replace from "rollup-plugin-replace";
+import { uglify } from "rollup-plugin-uglify";
 
 import pkg from "./package.json";
 
@@ -34,6 +35,7 @@ export default [
       format: "iife", // Browser only
       name: libraryName,
       globals,
+      sourcemap: true,
     },
     external: Object.keys(globals),
     plugins: [
@@ -45,6 +47,7 @@ export default [
       babel(getBabelOptions({ useESModules: true })),
       commonjs({ include: "node_modules/**" }),
       replace({ "process.env.NODE_ENV": JSON.stringify("development") }),
+      uglify(),
     ],
   },
   {
@@ -53,6 +56,7 @@ export default [
       file: pkg.main,
       format: "cjs",
       name: libraryName,
+      sourcemap: true,
     },
     external: isExternal,
     plugins: [babel(getBabelOptions({ useESModules: false }))],
@@ -63,6 +67,7 @@ export default [
       file: pkg.module,
       format: "es",
       name: libraryName,
+      sourcemap: true,
     },
     external: isExternal,
     plugins: [


### PR DESCRIPTION
Generate sourcemaps for all build files and uglify umd build. 

![image](https://user-images.githubusercontent.com/10999093/50140994-32425c00-025b-11e9-9cb4-2b6756a9f2cc.png)

![sourcemaps](https://user-images.githubusercontent.com/10999093/50171364-15337a80-02a7-11e9-871f-55c6056a28f3.gif)
Ref: https://developers.google.com/web/tools/chrome-devtools/javascript/source-maps 