### PR TITLE
Fix deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,4 +40,4 @@ jobs:
             - "d5:b8:7b:18:02:16:f1:90:6c:6d:34:b7:71:55:ae:b4"
       - deploy:
           name: "deploy docs if on master"
-          command: if [ $CIRCLE_BRANCH = "master" ]; then git config --global user.email "$GH_EMAIL" && git config --global user.name "$GH_NAME" && npm run docs-deploy; fi
+          command: if [ $CIRCLE_BRANCH = "master" ]; then git config --global user.email "$GH_EMAIL" && git config --global user.name "$GH_NAME" && sudo chown -R circleci:circleci . && npm run docs-deploy; fi


### PR DESCRIPTION
I broke this in #30 because the files created by the docker images are
owned by the `root` user. This is easily fixed by a `chown` command.

Test plan: removed the check for being on the master branch temporarily
to test this, and seems to work:
https://circleci.com/gh/cruise-automation/webviz/170