### PR TITLE
Fix code highlighting when navigating to different pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2140,6 +2140,17 @@
         "write-file-atomic": "^2.3.0"
       }
     },
+    "@mapbox/rehype-prism": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/rehype-prism/-/rehype-prism-0.3.0.tgz",
+      "integrity": "sha512-7v0J6p5fYYqet/IslGYNOPIbtjLkVkGg2JY5w5mpFpdmj2vwr/6g6+Y0mElLVy3cndMN/ACxtSUAeriRpjAlXA==",
+      "dev": true,
+      "requires": {
+        "hast-util-to-string": "^1.0.0",
+        "refractor": "^2.3.0",
+        "unist-util-visit": "^1.1.3"
+      }
+    },
     "@mdx-js/loader": {
       "version": "0.16.6",
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-0.16.6.tgz",
@@ -5212,9 +5223,9 @@
       "dev": true
     },
     "clipboard": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
-      "integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
+      "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -5381,6 +5392,15 @@
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
+      }
+    },
+    "comma-separated-tokens": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.5.tgz",
+      "integrity": "sha512-Cg90/fcK93n0ecgYTAz1jaA3zvnQ0ExlmKY1rdbyHqAx6BHxwoJc+J7HDu0iuQ7ixEs1qaa+WyQ6oeuBpYP1iA==",
+      "dev": true,
+      "requires": {
+        "trim": "0.0.1"
       }
     },
     "commander": {
@@ -9612,6 +9632,30 @@
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "hast-util-parse-selector": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.1.tgz",
+      "integrity": "sha512-Xyh0v+nHmQvrOqop2Jqd8gOdyQtE8sIP9IQf7mlVDqp924W4w/8Liuguk2L2qei9hARnQSG2m+wAOCxM7npJVw==",
+      "dev": true
+    },
+    "hast-util-to-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-1.0.1.tgz",
+      "integrity": "sha512-EC6awGe0ZMUNYmS2hMVaKZxvjVtQA4RhXjtgE20AxGG49MM7OUUfaHc6VcVYv2YwzNlrZQGe5teimCxW1Rk+fA==",
+      "dev": true
+    },
+    "hastscript": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.0.0.tgz",
+      "integrity": "sha512-xJtuJ8D42Xtq5yJrnDg/KAIxl2cXBXKoiIJwmWX9XMf8113qHTGl/Bf7jEsxmENJ4w6q4Tfl8s/Y6mEZo8x8qw==",
+      "dev": true,
+      "requires": {
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.2.0",
+        "property-information": "^5.0.1",
+        "space-separated-tokens": "^1.0.0"
       }
     },
     "he": {
@@ -14872,12 +14916,12 @@
       }
     },
     "prismjs": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.6.0.tgz",
-      "integrity": "sha1-EY2V+3pm26InLjQ7NF9SNmWds2U=",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.15.0.tgz",
+      "integrity": "sha512-Lf2JrFYx8FanHrjoV5oL8YHCclLQgbJcVZR+gikGGMqz6ub5QVWDTM6YIwm3BuPxM/LOV+rKns3LssXNLIf+DA==",
       "dev": true,
       "requires": {
-        "clipboard": "^1.5.5"
+        "clipboard": "^2.0.0"
       }
     },
     "private": {
@@ -14967,6 +15011,15 @@
       "requires": {
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
+      }
+    },
+    "property-information": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.0.1.tgz",
+      "integrity": "sha512-nAtBDVeSwFM3Ot/YxT7s4NqZmqXI7lLzf46BThvotEtYf2uk2yH0ACYuWQkJ7gxKs49PPtKVY0UlDGkyN9aJlw==",
+      "dev": true,
+      "requires": {
+        "xtend": "^4.0.1"
       }
     },
     "proto-list": {
@@ -15518,6 +15571,29 @@
         "prismjs": "1.6",
         "prop-types": "^15.5.8",
         "unescape": "^0.2.0"
+      },
+      "dependencies": {
+        "clipboard": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
+          "integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "good-listener": "^1.2.2",
+            "select": "^1.1.2",
+            "tiny-emitter": "^2.0.0"
+          }
+        },
+        "prismjs": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.6.0.tgz",
+          "integrity": "sha1-EY2V+3pm26InLjQ7NF9SNmWds2U=",
+          "dev": true,
+          "requires": {
+            "clipboard": "^1.5.5"
+          }
+        }
       }
     },
     "react-modal": {
@@ -16017,6 +16093,17 @@
       "requires": {
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
+      }
+    },
+    "refractor": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.6.2.tgz",
+      "integrity": "sha512-AMNEGkhaXfhoa0/0mW0bHdfizDJnuHDK29/D5oQaKICf6DALQ+kDEHW/36oDHCdfva4XrZ+cdMhRvPsTI4OIjA==",
+      "dev": true,
+      "requires": {
+        "hastscript": "^5.0.0",
+        "parse-entities": "^1.1.2",
+        "prismjs": "~1.15.0"
       }
     },
     "regenerate": {
@@ -17297,6 +17384,15 @@
       "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
       "dev": true
     },
+    "space-separated-tokens": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.2.tgz",
+      "integrity": "sha512-G3jprCEw+xFEs0ORweLmblJ3XLymGGr6hxZYTYZjIlvDti9vOBUjRQa1Rzjt012aRrocKstHwdNi+F7HguPsEA==",
+      "dev": true,
+      "requires": {
+        "trim": "0.0.1"
+      }
+    },
     "spdx-correct": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -17387,7 +17483,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@babel/preset-env": "^7.2.0",
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
+    "@mapbox/rehype-prism": "^0.3.0",
     "@mdx-js/loader": "^0.16.6",
     "@storybook/addon-actions": "^4.0.12",
     "@storybook/addon-knobs": "^4.0.12",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 
+const rehypePrism = require("@mapbox/rehype-prism");
 const CaseSensitivePathsPlugin = require("case-sensitive-paths-webpack-plugin");
 const path = require("path");
 const TerserPlugin = require("terser-webpack-plugin");
@@ -44,7 +45,18 @@ module.exports = {
         exclude: /node_modules/,
         use: { loader: "babel-loader?cacheDirectory" },
       },
-      { test: /\.mdx$/, use: ["babel-loader?cacheDirectory", "@mdx-js/loader"] },
+      {
+        test: /\.mdx$/,
+        use: [
+          "babel-loader?cacheDirectory",
+          {
+            loader: "@mdx-js/loader",
+            options: {
+              hastPlugins: [rehypePrism],
+            },
+          },
+        ],
+      },
       { test: /\.md$/, loader: "raw-loader" },
       { test: /\.svg$/, loader: "react-svg-loader" },
       { test: /\.ne$/, loader: "nearley-loader" },


### PR DESCRIPTION
The code highlighting for markdown code blocks is lost when navigating to a different page. Fixed by adding rehypePrism plugin (Ref: https://github.com/mdx-js/mdx/issues/253). 

Before:
![then](https://user-images.githubusercontent.com/10999093/50316187-78213f00-046a-11e9-93bf-62dc2d41bf9e.gif)

After:
![now](https://user-images.githubusercontent.com/10999093/50316185-75bee500-046a-11e9-9989-7fa370ec8bc1.gif)