### PR TITLE
Better positioning of error message

### DIFF
--- a/docs/src/jsx/CodeEditor.js
+++ b/docs/src/jsx/CodeEditor.js
@@ -11,6 +11,7 @@ import styled, { css } from "styled-components";
 const StyledProvider = styled(LiveProvider)`
   overflow: hidden;
   margin-bottom: 60px;
+  position: relative;
 `;
 
 const LiveWrapper = styled.div`
@@ -59,6 +60,9 @@ const StyledError = styled(LiveError)`
   padding: 1rem;
   background: #f24366;
   color: white;
+  position: absolute;
+  top: 0;
+  right: 0;
 `;
 
 const CodeEditor = ({ noInline, code, scope }) => {


### PR DESCRIPTION
Overlay it on top of the output so you can actually see it when on a
small screen.

Test plan: manual.

![screen shot 2018-12-20 at 3 20 25 pm](https://user-images.githubusercontent.com/177461/50316409-5bd1d200-046b-11e9-8d18-37848e3dfdf3.png)
