### PR TITLE
Make Camera State example fast

### DIFF
--- a/docs/src/jsx/CameraState.js
+++ b/docs/src/jsx/CameraState.js
@@ -8,10 +8,12 @@ import { quat, vec3 } from "gl-matrix";
 import React, { useState } from "react";
 
 import CameraStateControls from "./CameraStateControls";
+import useRange from "./useRange";
 import { p, q } from "./utils";
 import Worldview, { Arrows, Spheres, Axes, Grid, cameraStateSelectors } from "regl-worldview";
 
 function CameraState() {
+  const range = useRange();
   const [perspective, setPerspective] = useState(true);
   const [distance, setDistance] = useState(50);
   const [thetaOffset, setThetaOffset] = useState(0.3);
@@ -20,7 +22,7 @@ function CameraState() {
   const [orientationY, setOrientationY] = useState(0);
   const [orientationZ, setOrientationZ] = useState(0);
 
-  const [posX, setPosX] = useState(0);
+  const posX = range * 5;
   const [posY, setPosY] = useState(0);
   const [posZ, setPosZ] = useState(0);
   const [offsetX, setOffsetX] = useState(0);
@@ -111,23 +113,22 @@ function CameraState() {
       }}>
       <CameraStateControls
         perspective={perspective}
-        distance={distance}
-        thetaOffset={thetaOffset}
-        phi={phi}
-        posX={posX}
-        posY={posY}
-        posZ={posZ}
-        offsetX={offsetX}
-        offsetY={offsetY}
-        offsetZ={offsetZ}
-        orientationX={orientationX}
-        orientationY={orientationY}
-        orientationZ={orientationZ}
+        distance={distance.toFixed(3)}
+        thetaOffset={thetaOffset.toFixed(3)}
+        phi={phi.toFixed(3)}
+        posX={posX.toFixed(3)}
+        posY={posY.toFixed(3)}
+        posZ={posZ.toFixed(3)}
+        offsetX={offsetX.toFixed(3)}
+        offsetY={offsetY.toFixed(3)}
+        offsetZ={offsetZ.toFixed(3)}
+        orientationX={orientationX.toFixed(3)}
+        orientationY={orientationY.toFixed(3)}
+        orientationZ={orientationZ.toFixed(3)}
         setPerspective={setPerspective}
         setDistance={setDistance}
         setThetaOffset={setThetaOffset}
         setPhi={setPhi}
-        setPosX={setPosX}
         setPosY={setPosY}
         setPosZ={setPosZ}
         setOffsetX={setOffsetX}
@@ -154,7 +155,6 @@ function CameraState() {
               setDistance(distance);
               setThetaOffset(thetaOffset);
               setPhi(phi);
-              setPosX(target[0]);
               setPosY(target[1]);
               setPosZ(target[2]);
               setOffsetX(targetOffset[0]);

--- a/docs/src/jsx/CameraStateControls.js
+++ b/docs/src/jsx/CameraStateControls.js
@@ -4,7 +4,7 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 
-import React from "react";
+import React, { memo } from "react";
 import styled from "styled-components";
 
 import InputNumber from "./InputNumber";
@@ -28,7 +28,7 @@ const InputGroupWrapper = styled.div`
   }
 `;
 
-export default function CameraStateControls({
+function CameraStateControls({
   perspective,
   distance,
   thetaOffset,
@@ -46,7 +46,6 @@ export default function CameraStateControls({
   setDistance,
   setThetaOffset,
   setPhi,
-  setPosX,
   setPosY,
   setPosZ,
   setOffsetX,
@@ -75,7 +74,7 @@ export default function CameraStateControls({
           <InputNumber label="phi" value={phi} min={0} max={Math.PI} step={0.01} onChange={setPhi} />
         </div>
         <div>
-          <InputNumber label="posX" value={posX} min={0} max={20} step={0.1} onChange={setPosX} />
+          <InputNumber label="posX" value={posX} min={0} max={20} step={0.1} />
           <InputNumber label="posY" value={posY} min={0} max={20} step={0.1} onChange={setPosY} />
           <InputNumber label="posZ" value={posZ} min={0} max={20} step={0.1} onChange={setPosZ} />
         </div>
@@ -114,3 +113,5 @@ export default function CameraStateControls({
     </div>
   );
 }
+
+export default memo(CameraStateControls);


### PR DESCRIPTION
By rounding some values and then memoizing the function.

Plus animate it to demonstrate following the target. I wonder if we
should show something like this on the landing page, too? This is a
core feature of Worldview that I think is worth highlighting.

![camera-state-demo](https://user-images.githubusercontent.com/177461/50320389-fab4f900-0480-11e9-8e29-e121ae742928.gif)
