### PR TITLE
Docs: add optional column and use code style for names and defaults

### DIFF
--- a/docs/src/3.1.Worldview.mdx
+++ b/docs/src/3.1.Worldview.mdx
@@ -2,20 +2,20 @@
 
 ## Props
 
-| Name                | Optional | Type                     | Default              | Description                                                                                             |
-| ------------------- | -------- | ------------------------ | -------------------- | ------------------------------------------------------------------------------------------------------- |
-| cameraState         | yes      | `$Shape<CameraState>`    |                      | control the [cameraState](/api/camera), must use with `onCameraStateChange`                             |
-| onCameraStateChange | yes      | `?(CameraState) => void` |                      | callback whenever the camera state changes                                                              |
-| defaultCameraState  |          | `$Shape<CameraState>`    | DEFAULT_CAMERA_STATE | pass in this prop to turn Worldview to an uncontrolled component. `onCameraStateChange` will be ignored |
-| backgroundColor     |          | `Vec4`                   | [0,0,0,1]            | change the scene background color                                                                       |
-| hitmapOnMouseMove   |          | `boolean`                | false                | if enabled, the clicked objectId will be returned from the mouse event handler                          |
-| children            | yes      | `React.Node`             |                      | regl components to render inside the Worldview                                                          |
-| showDebug           | yes      | `?boolean`               |                      | show debug information                                                                                  |
-| onDoubleClick       | yes      | `MouseHandler`           |                      |                                                                                                         |
-| onMouseDown         | yes      | `MouseHandler`           |                      |                                                                                                         |
-| onMouseUp           | yes      | `MouseHandler`           |                      |                                                                                                         |
-| onMouseMove         | yes      | `MouseHandler`           |                      |                                                                                                         |
-| onClick             | yes      | `MouseHandler`           |                      |                                                                                                         |
+| Name                  | Optional | Type                     | Default                | Description                                                                                             |
+| --------------------- | -------- | ------------------------ | ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| `cameraState`         | yes      | `$Shape<CameraState>`    |                        | control the [cameraState](/api/camera), must use with `onCameraStateChange`                             |
+| `onCameraStateChange` | yes      | `?(CameraState) => void` |                        | callback whenever the camera state changes                                                              |
+| `defaultCameraState`  |          | `$Shape<CameraState>`    | `DEFAULT_CAMERA_STATE` | pass in this prop to turn Worldview to an uncontrolled component. `onCameraStateChange` will be ignored |
+| `backgroundColor`     |          | `Vec4`                   | `[0,0,0,1]`            | change the scene background color                                                                       |
+| `hitmapOnMouseMove`   |          | `boolean`                | `false`                | if enabled, the clicked objectId will be returned from the mouse event handler                          |
+| `children`            | yes      | `React.Node`             |                        | regl components to render inside the Worldview                                                          |
+| `showDebug`           | yes      | `?boolean`               |                        | show debug information                                                                                  |
+| `onDoubleClick`       | yes      | `MouseHandler`           |                        |                                                                                                         |
+| `onMouseDown`         | yes      | `MouseHandler`           |                        |                                                                                                         |
+| `onMouseUp`           | yes      | `MouseHandler`           |                        |                                                                                                         |
+| `onMouseMove`         | yes      | `MouseHandler`           |                        |                                                                                                         |
+| `onClick`             | yes      | `MouseHandler`           |                        |                                                                                                         |
 
 ## Event Handlers
 

--- a/docs/src/3.1.Worldview.mdx
+++ b/docs/src/3.1.Worldview.mdx
@@ -2,20 +2,20 @@
 
 ## Props
 
-| Name                 | Type                              | Default              | Description                                                                                             |
-| -------------------- | --------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------- |
-| cameraState?         | `$Shape<CameraState>`             |                      | control the [cameraState](/api/camera), must use with `onCameraStateChange`                             |
-| onCameraStateChange? | `?(CameraState) => void`          |                      | callback whenever the camera state changes                                                              |
-| defaultCameraState   | `$Shape<CameraState>`             | DEFAULT_CAMERA_STATE | pass in this prop to turn Worldview to an uncontrolled component. `onCameraStateChange` will be ignored |
-| backgroundColor      | `Vec4`                            | [0,0,0,1]            | change the scene background color                                                                       |
-| hitmapOnMouseMove    | `boolean`                         | false                | if enabled, the clicked objectId will be returned from the mouse event handler                          |
-| children?            | `React.Node`                      |                      | regl components to render inside the Worldview                                                          |
-| showDebug?           | `?boolean`                        |                      | show debug information                                                                                  |
-| onDoubleClick?       | `MouseHandler`                    |                      |                                                                                                         |
-| onMouseDown?         | `MouseHandler`                    |                      |                                                                                                         |
-| onMouseUp?           | `MouseHandler`                    |                      |                                                                                                         |
-| onMouseMove?         | `MouseHandler`                    |                      |                                                                                                         |
-| onClick?             | `MouseHandler`                    |                      |                                                                                                         |
+| Name                | Optional | Type                     | Default              | Description                                                                                             |
+| ------------------- | -------- | ------------------------ | -------------------- | ------------------------------------------------------------------------------------------------------- |
+| cameraState         | yes      | `$Shape<CameraState>`    |                      | control the [cameraState](/api/camera), must use with `onCameraStateChange`                             |
+| onCameraStateChange | yes      | `?(CameraState) => void` |                      | callback whenever the camera state changes                                                              |
+| defaultCameraState  |          | `$Shape<CameraState>`    | DEFAULT_CAMERA_STATE | pass in this prop to turn Worldview to an uncontrolled component. `onCameraStateChange` will be ignored |
+| backgroundColor     |          | `Vec4`                   | [0,0,0,1]            | change the scene background color                                                                       |
+| hitmapOnMouseMove   |          | `boolean`                | false                | if enabled, the clicked objectId will be returned from the mouse event handler                          |
+| children            | yes      | `React.Node`             |                      | regl components to render inside the Worldview                                                          |
+| showDebug           | yes      | `?boolean`               |                      | show debug information                                                                                  |
+| onDoubleClick       | yes      | `MouseHandler`           |                      |                                                                                                         |
+| onMouseDown         | yes      | `MouseHandler`           |                      |                                                                                                         |
+| onMouseUp           | yes      | `MouseHandler`           |                      |                                                                                                         |
+| onMouseMove         | yes      | `MouseHandler`           |                      |                                                                                                         |
+| onClick             | yes      | `MouseHandler`           |                      |                                                                                                         |
 
 ## Event Handlers
 

--- a/docs/src/3.1.Worldview.mdx
+++ b/docs/src/3.1.Worldview.mdx
@@ -2,20 +2,22 @@
 
 ## Props
 
-| Name                  | Optional | Type                     | Default                | Description                                                                                             |
-| --------------------- | -------- | ------------------------ | ---------------------- | ------------------------------------------------------------------------------------------------------- |
-| `cameraState`         | yes      | `$Shape<CameraState>`    |                        | control the [cameraState](/api/camera), must use with `onCameraStateChange`                             |
-| `onCameraStateChange` | yes      | `?(CameraState) => void` |                        | callback whenever the camera state changes                                                              |
-| `defaultCameraState`  |          | `$Shape<CameraState>`    | `DEFAULT_CAMERA_STATE` | pass in this prop to turn Worldview to an uncontrolled component. `onCameraStateChange` will be ignored |
-| `backgroundColor`     |          | `Vec4`                   | `[0,0,0,1]`            | change the scene background color                                                                       |
-| `hitmapOnMouseMove`   |          | `boolean`                | `false`                | if enabled, the clicked objectId will be returned from the mouse event handler                          |
-| `children`            | yes      | `React.Node`             |                        | regl components to render inside the Worldview                                                          |
-| `showDebug`           | yes      | `?boolean`               |                        | show debug information                                                                                  |
-| `onDoubleClick`       | yes      | `MouseHandler`           |                        |                                                                                                         |
-| `onMouseDown`         | yes      | `MouseHandler`           |                        |                                                                                                         |
-| `onMouseUp`           | yes      | `MouseHandler`           |                        |                                                                                                         |
-| `onMouseMove`         | yes      | `MouseHandler`           |                        |                                                                                                         |
-| `onClick`             | yes      | `MouseHandler`           |                        |                                                                                                         |
+| Name                  | Type                    | Default                | Description                                                                                             |
+| --------------------- | ----------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| `cameraState`         | `$Shape<CameraState>`   |                        | control the [cameraState](/api/camera), must use with `onCameraStateChange`                             |
+| `onCameraStateChange` | `(CameraState) => void` |                        | callback whenever the camera state changes                                                              |
+| `defaultCameraState`  | `$Shape<CameraState>`   | `DEFAULT_CAMERA_STATE` | pass in this prop to turn Worldview to an uncontrolled component. `onCameraStateChange` will be ignored |
+| `backgroundColor`     | `Vec4`                  | `[0,0,0,1]`            | change the scene background color                                                                       |
+| `hitmapOnMouseMove`   | `boolean`               |                        | if enabled, the clicked objectId will be returned from the mouse event handler                          |
+| `children`            | `React.Node`            |                        | regl components to render inside the Worldview                                                          |
+| `showDebug`           | `boolean`               |                        | show debug information                                                                                  |
+| `onDoubleClick`       | `MouseHandler`          |                        |                                                                                                         |
+| `onMouseDown`         | `MouseHandler`          |                        |                                                                                                         |
+| `onMouseUp`           | `MouseHandler`          |                        |                                                                                                         |
+| `onMouseMove`         | `MouseHandler`          |                        |                                                                                                         |
+| `onClick`             | `MouseHandler`          |                        |                                                                                                         |
+
+*All props are optional.*
 
 ## Event Handlers
 

--- a/docs/src/3.10.Lines.mdx
+++ b/docs/src/3.10.Lines.mdx
@@ -29,7 +29,7 @@ type Line = {
     b: number, // between 0 and 1
     a: number, // between 0 and 1
   },
-  points: [{ x: number, y: number, z: number }]
+  points: [{ x: number, y: number, z: number } | [ number, number, number ]]
 }
 ```
 

--- a/docs/src/3.10.Lines.mdx
+++ b/docs/src/3.10.Lines.mdx
@@ -6,9 +6,9 @@ import { LinesDemo, LinesWireframe } from "./jsx/allLiveEditors";
 
 ## Props
 
-| Name     | Type     | Default | Description                     |
-| -------- | -------- | ------- | ------------------------------- |
-| children | `Line[]` | []      | array of Line markers to render |
+| Name       | Type     | Default | Description                     |
+| ---------- | -------- | ------- | ------------------------------- |
+| `children` | `Line[]` | `[]`    | array of Line markers to render |
 
 ### Line
 

--- a/docs/src/3.11.Overlay.mdx
+++ b/docs/src/3.11.Overlay.mdx
@@ -6,10 +6,10 @@ import { Overlay } from './jsx/allLiveEditors'
 
 ## Props
 
-| Name       | Type                                 | Default | Description                            |
-| ---------- | ------------------------------------ | ------- | -------------------------------------- |
-| children   | `T[]`                                | []      | array of Overlay markers to render     |
-| renderItem | `(RenderItemInput<T>) => React.Node` |         | custom renderer to render each overlay |
+| Name         | Type                                 | Default | Description                            |
+| ------------ | ------------------------------------ | ------- | -------------------------------------- |
+| `children`   | `T[]`                                | `[]`    | array of Overlay markers to render     |
+| `renderItem` | `(RenderItemInput<T>) => React.Node` |         | custom renderer to render each overlay |
 
 ### Example
 

--- a/docs/src/3.12.Points.mdx
+++ b/docs/src/3.12.Points.mdx
@@ -29,7 +29,7 @@ type Point = {
     b: number, // between 0 and 1
     a: number, // between 0 and 1
   },
-  points: [{ x: number, y: number, z: number }],
+  points: [{ x: number, y: number, z: number } | [ number, number, number ]] ,
 }
 ```
 

--- a/docs/src/3.12.Points.mdx
+++ b/docs/src/3.12.Points.mdx
@@ -6,9 +6,9 @@ import { Points } from './jsx/allLiveEditors'
 
 ## Props
 
-| Name     | Type      | Default | Description                      |
-| -------- | --------- | ------- | -------------------------------- |
-| children | `Point[]` | []      | array of Point markers to render |
+| Name       | Type      | Default | Description                      |
+| ---------- | --------- | ------- | -------------------------------- |
+| `children` | `Point[]` | `[]`    | array of Point markers to render |
 
 ### Point
 

--- a/docs/src/3.13.Spheres.mdx
+++ b/docs/src/3.13.Spheres.mdx
@@ -6,9 +6,9 @@ import {SpheresSingle, SpheresInstanced, SpheresInstancedColor} from './jsx/allL
 
 ## Props
 
-| Name     | Type       | Default | Description                       |
-| -------- | ---------- | ------- | --------------------------------- |
-| children | `Sphere[]` | []      | array of Sphere markers to render |
+| Name       | Type       | Default | Description                       |
+| ---------- | ---------- | ------- | --------------------------------- |
+| `children` | `Sphere[]` | `[]`    | array of Sphere markers to render |
 
 ### Sphere
 

--- a/docs/src/3.14.Text.mdx
+++ b/docs/src/3.14.Text.mdx
@@ -6,9 +6,9 @@ import {Text} from './jsx/allLiveEditors'
 
 ## Props
 
-| Name     | Type     | Default | Description                     |
-| -------- | -------- | ------- | ------------------------------- |
-| children | `Text[]` | []      | array of Text markers to render |
+| Name       | Type     | Default | Description                     |
+| ---------- | -------- | ------- | ------------------------------- |
+| `children` | `Text[]` | `[]`    | array of Text markers to render |
 
 ### Text
 

--- a/docs/src/3.15.Triangles.mdx
+++ b/docs/src/3.15.Triangles.mdx
@@ -6,9 +6,9 @@ import {Triangles} from './jsx/allLiveEditors'
 
 ## Props
 
-| Name     | Type         | Default | Description                         |
-| -------- | ------------ | ------- | ----------------------------------- |
-| children | `Triangle[]` | []      | array of Triangle markers to render |
+| Name       | Type         | Default | Description                         |
+| ---------- | ------------ | ------- | ----------------------------------- |
+| `children` | `Triangle[]` | `[]`    | array of Triangle markers to render |
 
 ### Triangle
 

--- a/docs/src/3.2.Camera.mdx
+++ b/docs/src/3.2.Camera.mdx
@@ -13,15 +13,15 @@ CameraStore holds the camera state and offers methods to handle camera rotation,
 
 ## cameraState
 
-| Name              | Type      | Default      | Description                                                                                     |
-| ----------------- | --------- | ------------ | ----------------------------------------------------------------------------------------------- |
-| perspective       | `boolean` | true         | type of the camera, default to orthographic (2D), pass in `true` to enable perspective (3D)     |
-| target            | `vec3`    | [0, 0, 0]    | position of the target                                                                          |
-| targetOrientation | `quat`    | [0, 0, 0, 1] | orientation of the target (only yaw angle is used to determine camera placement)                |
-| targetOffset      | `vec3`    | [0, 0, 0]    | additional offset for the camera, specified in the `target`/`targetOrientation` reference frame |
-| distance          | `number`  | 75           | distance between the camera and target                                                          |
-| phi               | `number`  | Math.PI/4    | angle in radians from +z pole to -z pole, range: [0, π]. Ignored when `perspective` is false    |
-| thetaOffset       | `number`  | 0            | offset azimuth angle in radians, +θ corresponds to +x→+y, range: [0, 2π]                        |
+| Name                | Type      | Default        | Description                                                                                     |
+| ------------------- | --------- | -------------- | ----------------------------------------------------------------------------------------------- |
+| `perspective`       | `boolean` | `true`         | type of the camera, default to orthographic (2D), pass in `true` to enable perspective (3D)     |
+| `target`            | `vec3`    | `[0, 0, 0]`    | position of the target                                                                          |
+| `targetOrientation` | `quat`    | `[0, 0, 0, 1]` | orientation of the target (only yaw angle is used to determine camera placement)                |
+| `targetOffset`      | `vec3`    | `[0, 0, 0]`    | additional offset for the camera, specified in the `target`/`targetOrientation` reference frame |
+| `distance`          | `number`  | `75`           | distance between the camera and target                                                          |
+| `phi`               | `number`  | `Math.PI/4`    | angle in radians from +z pole to -z pole, range: [0, π]. Ignored when `perspective` is false    |
+| `thetaOffset`       | `number`  | `0`            | offset azimuth angle in radians, +θ corresponds to +x→+y, range: [0, 2π]                        |
 
 <CameraState />
 
@@ -52,10 +52,10 @@ const targetHeading = cameraStateSelectors.targetHeading(cameraState);
 const theta = cameraStateSelectors.theta(cameraState);
 ```
 
-| Name          | Type     | Description                                                          |
-| ------------- | -------- | -------------------------------------------------------------------- |
-| orientation   | `quat`   | orientation of the camera                                            |
-| position      | `vec3`   | position of the camera                                               |
-| targetHeading | `quat`   | heading direction of the target                                      |
-| theta         | `number` | azimuth angle in radians, +θ corresponds to +x→+y, range: [0, 2π]    |
-| view          | `mat4`   | field of view, control the behavior of the projection transformation |
+| Name            | Type     | Description                                                          |
+| --------------- | -------- | -------------------------------------------------------------------- |
+| `orientation`   | `quat`   | orientation of the camera                                            |
+| `position`      | `vec3`   | position of the camera                                               |
+| `targetHeading` | `quat`   | heading direction of the target                                      |
+| `theta`         | `number` | azimuth angle in radians, +θ corresponds to +x→+y, range: [0, 2π]    |
+| `view`          | `mat4`   | field of view, control the behavior of the projection transformation |

--- a/docs/src/3.3.Command.mdx
+++ b/docs/src/3.3.Command.mdx
@@ -5,9 +5,9 @@ import CommandDemo from './jsx/Command.js';
 Command is the base class for all regl-based drawing commands. Subclasses should override getDrawProps and (and optionally getHitmapProps). Note: getHitmapProps is not implemented in this base class.
 Checkout [Writing A Custom Command Component](/guides/writing-a-custom-command-component) for more.
 
-| Name       | type    | Default | Description                                                                       |
-| ---------- | ------- | ------- | --------------------------------------------------------------------------------- |
-| layerIndex | ?number |         | defines the draw order of each command, e.g. -1 will put the shape in lower layer |
+| Name       | optional | type    | Default | Description                                                                       |
+| ---------- | -------- | ------- | ------- |
+| layerIndex | yes      | ?number |         | defines the draw order of each command, e.g. -1 will put the shape in lower layer |
 
 
 Sample usage:

--- a/docs/src/3.3.Command.mdx
+++ b/docs/src/3.3.Command.mdx
@@ -5,9 +5,9 @@ import CommandDemo from './jsx/Command.js';
 Command is the base class for all regl-based drawing commands. Subclasses should override getDrawProps and (and optionally getHitmapProps). Note: getHitmapProps is not implemented in this base class.
 Checkout [Writing A Custom Command Component](/guides/writing-a-custom-command-component) for more.
 
-| Name         | optional | type      | Default | Description                                                                       |
-| ------------ | -------- | --------- | ------- |
-| `layerIndex` | yes      | `?number` |         | defines the draw order of each command, e.g. -1 will put the shape in lower layer |
+| Name         | optional | type     | Default | Description                                                                       |
+| ------------ | -------- | -------- | ------- |
+| `layerIndex` | yes      | `number` |         | defines the draw order of each command, e.g. -1 will put the shape in lower layer |
 
 
 Sample usage:

--- a/docs/src/3.3.Command.mdx
+++ b/docs/src/3.3.Command.mdx
@@ -5,9 +5,9 @@ import CommandDemo from './jsx/Command.js';
 Command is the base class for all regl-based drawing commands. Subclasses should override getDrawProps and (and optionally getHitmapProps). Note: getHitmapProps is not implemented in this base class.
 Checkout [Writing A Custom Command Component](/guides/writing-a-custom-command-component) for more.
 
-| Name       | optional | type    | Default | Description                                                                       |
-| ---------- | -------- | ------- | ------- |
-| layerIndex | yes      | ?number |         | defines the draw order of each command, e.g. -1 will put the shape in lower layer |
+| Name         | optional | type      | Default | Description                                                                       |
+| ------------ | -------- | --------- | ------- |
+| `layerIndex` | yes      | `?number` |         | defines the draw order of each command, e.g. -1 will put the shape in lower layer |
 
 
 Sample usage:

--- a/docs/src/3.4.Arrows.mdx
+++ b/docs/src/3.4.Arrows.mdx
@@ -6,9 +6,9 @@ import { Arrows } from './jsx/allLiveEditors'
 
 ## Props
 
-| Name     | Type                         | Default | Description                      |
-| -------- | ---------------------------- | ------- | -------------------------------- |
-| children | `(PoseArrow | PointArrow)[]` | []      | array of Arrow markers to render |
+| Name       | Type                         | Default | Description                      |
+| ---------- | ---------------------------- | ------- | -------------------------------- |
+| `children` | `(PoseArrow | PointArrow)[]` | `[]`    | array of Arrow markers to render |
 
 ### PoseArrow
 

--- a/docs/src/3.5.Cones.mdx
+++ b/docs/src/3.5.Cones.mdx
@@ -6,9 +6,9 @@ import { Cones } from './jsx/allLiveEditors'
 
 ## Props
 
-| Name     | Type     | Default | Description                     |
-| -------- | -------- | ------- | ------------------------------- |
-| children | `Cone[]` | []      | array of Cone markers to render |
+| Name       | Type     | Default | Description                     |
+| ---------- | -------- | ------- | ------------------------------- |
+| `children` | `Cone[]` | `[]`    | array of Cone markers to render |
 
 ### Cone
 

--- a/docs/src/3.6.Cubes.mdx
+++ b/docs/src/3.6.Cubes.mdx
@@ -6,9 +6,9 @@ import { Cubes } from './jsx/allLiveEditors'
 
 ## Props
 
-| Name     | Type     | Default | Description                     |
-| -------- | -------- | ------- | ------------------------------- |
-| children | `Cube[]` | []      | array of cube markers to render |
+| Name       | Type     | Default | Description                     |
+| ---------- | -------- | ------- | ------------------------------- |
+| `children` | `Cube[]` | `[]`    | array of cube markers to render |
 
 ### Cone
 

--- a/docs/src/3.7.Cylinders.mdx
+++ b/docs/src/3.7.Cylinders.mdx
@@ -6,9 +6,9 @@ import { Cylinders } from './jsx/allLiveEditors'
 
 ## Props
 
-| Name     | Type         | Default | Description                         |
-| -------- | ------------ | ------- | ----------------------------------- |
-| children | `Cylinder[]` | []      | array of Cylinder markers to render |
+| Name       | Type         | Default | Description                         |
+| ---------- | ------------ | ------- | ----------------------------------- |
+| `children` | `Cylinder[]` | `[]`    | array of Cylinder markers to render |
 
 ### Cylinder
 

--- a/docs/src/3.8.FilledPolygons.mdx
+++ b/docs/src/3.8.FilledPolygons.mdx
@@ -6,9 +6,9 @@ import { FilledPolygons } from './jsx/allLiveEditors'
 
 ## Props
 
-| Name     | Type              | Default | Description                              |
-| -------- | ----------------- | ------- | ---------------------------------------- |
-| children | `FilledPolygon[]` | []      | array of FilledPolygon markers to render |
+| Name       | Type              | Default | Description                              |
+| ---------- | ----------------- | ------- | ---------------------------------------- |
+| `children` | `FilledPolygon[]` | `[]`    | array of FilledPolygon markers to render |
 
 ### FilledPolygon
 

--- a/docs/src/jsx/CodeEditor.js
+++ b/docs/src/jsx/CodeEditor.js
@@ -13,6 +13,7 @@ import CopyIcon from "../utils/icons/Copy";
 import DoneIcon from "../utils/icons/Done";
 
 const SUCCESS_COLOR = "#2bb622";
+
 const StyledProvider = styled(LiveProvider)`
   overflow: hidden;
   margin-bottom: 60px;

--- a/docs/src/jsx/CodeEditor.js
+++ b/docs/src/jsx/CodeEditor.js
@@ -111,7 +111,7 @@ function CodeEditor({ noInline, code, nonEditableCode, scope }) {
         <StyledEditor onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
           {hovered && (
             <StyledActions>
-              <CopyToClipboard text={[nonEditableCode, '\n',  code].join('\n')} onCopy={() => setCopied(true)}>
+              <CopyToClipboard text={[nonEditableCode, "\n", code].join("\n")} onCopy={() => setCopied(true)}>
                 <StyledActionBtn onMouseLeave={() => setCopied(false)}>
                   {copied ? <DoneIcon color={SUCCESS_COLOR} /> : <CopyIcon />}
                 </StyledActionBtn>

--- a/docs/src/jsx/CodeEditor.js
+++ b/docs/src/jsx/CodeEditor.js
@@ -111,7 +111,7 @@ function CodeEditor({ noInline, code, nonEditableCode, scope }) {
         <StyledEditor onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
           {hovered && (
             <StyledActions>
-              <CopyToClipboard text={code} onCopy={() => setCopied(true)}>
+              <CopyToClipboard text={[nonEditableCode, '\n',  code].join('\n')} onCopy={() => setCopied(true)}>
                 <StyledActionBtn onMouseLeave={() => setCopied(false)}>
                   {copied ? <DoneIcon color={SUCCESS_COLOR} /> : <CopyIcon />}
                 </StyledActionBtn>

--- a/docs/src/jsx/allLiveEditors.js
+++ b/docs/src/jsx/allLiveEditors.js
@@ -17,7 +17,7 @@ function makeCodeComponent(raw) {
     .split("// #BEGIN EDITABLE");
 
   if (code.length !== 2) {
-    throw new Error("Check demo code!");
+    throw new Error("Demo code must contain `// #BEGIN EXAMPLE`,  `// #BEGIN EDITABLE`, and `// #END EXAMPLE`");
   }
 
   // eslint-disable-next-line react/display-name

--- a/docs/src/utils/icons/Done.js
+++ b/docs/src/utils/icons/Done.js
@@ -4,7 +4,7 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 
-// Icon from https://material.io/tools/icons/?icon=file_copy&style=outline
+// Icon from https://material.io/tools/icons/?icon=done&style=baseline
 import React from "react";
 
 export default function Done({ size = 24, color = "#fff" }) {

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -21,6 +21,7 @@ const DEFAULT_BACKGROUND_COLOR = [0, 0, 0, 1];
 
 export type BaseProps = {|
   backgroundColor?: Vec4,
+  // rendering the hitmap on mouse move is expensive, so disable it by default
   hitmapOnMouseMove?: boolean,
   showDebug?: boolean,
   children?: React.Node,
@@ -60,8 +61,6 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
   _tick: AnimationFrameID | void;
 
   static defaultProps = {
-    // rendering the hitmap on mouse move is expensive, so disable it by default
-    hitmapOnMouseMove: false,
     backgroundColor: DEFAULT_BACKGROUND_COLOR,
   };
 

--- a/packages/regl-worldview/src/commands/Command.js
+++ b/packages/regl-worldview/src/commands/Command.js
@@ -16,12 +16,12 @@ import WorldviewReactContext from "../WorldviewReactContext";
 
 export type Props<T> = {
   children?: T[],
-  getHitmapId?: ?(T) => ?number,
-  layerIndex?: ?number,
+  getHitmapId?: (T) => ?number,
+  layerIndex?: number,
 };
 
 type CommandProps = {
-  layerIndex?: ?number,
+  layerIndex?: number,
 };
 
 // The base class for all regl-based drawing commands.


### PR DESCRIPTION
- Add `optional` column to some props tables
- Use code style for names and defaults in props tables
- Minor left-over work from prev PR #49. Somehow I forgot to push up yesterday 