### PR TITLE
Deploy docs using NODE_ENV=production

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "screenshot": "NODE_ENV=development storybook-chrome-screenshot -c stories --parallel 8 --inject-files stories/injected.js --browser-timeout 60000",
     "screenshot-ci": "npm run screenshot -- --puppeteer-launch-config '{\"executablePath\": \"/usr/bin/google-chrome\", \"headless\": false, \"args\":[\"--use-gl=swiftshader\", \"--no-sandbox\",\"--disable-setuid-sandbox\", \"--disable-dev-shm-usage\", \"--headless\", \"--mute-audio\"]}'",
     "screenshot-debug": "npm run screenshot -- --parallel 1 --debug --puppeteer-launch-config '{\"headless\": false}'",
-    "ci": "npm run install-ci && npm run build && npm run lint && npm run flow && npm test && npm run screenshot-ci"
+    "ci": "npm run install-ci && NODE_ENV=production npm run build && npm run lint && npm run flow && npm test && NODE_ENV=production npm run screenshot-ci"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
This runs significantly faster.

Test plan: did a manual deploy with NODE_ENV=production and things are
indeed much faster. Will verify again after merging.