### PR TITLE
Allow custom getHitmapProps() function to be passed to simple commands.

### DIFF
--- a/packages/regl-worldview/src/commands/Command.js
+++ b/packages/regl-worldview/src/commands/Command.js
@@ -118,13 +118,10 @@ function getHitmapProps(getHitmapId, children) {
 // which creates a new regl component. It also handles basic hitmap interactions.
 export function makeCommand<T>(name: string, command: RawCommand<T>): React.StatelessFunctionalComponent<T> {
   const cmd = (props: Props<T>) => {
-    return (
-      <Command
-        reglCommand={command}
-        drawProps={props.children}
-        hitmapProps={getHitmapProps(props.getHitmapId, props.children)}
-      />
-    );
+    const hitmapProps = props.getHitmapProps
+      ? props.getHitmapProps()
+      : getHitmapProps(props.getHitmapId, props.children);
+    return <Command reglCommand={command} drawProps={props.children} hitmapProps={hitmapProps} />;
   };
   cmd.displayName = name;
   return cmd;

--- a/packages/regl-worldview/src/commands/Command.js
+++ b/packages/regl-worldview/src/commands/Command.js
@@ -17,7 +17,7 @@ import WorldviewReactContext from "../WorldviewReactContext";
 export type Props<T> = {
   children?: T[],
   reglCommand: RawCommand<T>,
-  getHitmapId?: (T) => ?number,
+  getHitmapId?: (T) =>?number,
   layerIndex?: number,
 };
 
@@ -124,5 +124,6 @@ export function makeCommand<T>(name: string, command: RawCommand<T>): React.Stat
     return <Command reglCommand={command} drawProps={props.children} hitmapProps={hitmapProps} />;
   };
   cmd.displayName = name;
+  cmd.reglCommand = command;
   return cmd;
 }

--- a/packages/regl-worldview/src/commands/Command.js
+++ b/packages/regl-worldview/src/commands/Command.js
@@ -17,7 +17,7 @@ import WorldviewReactContext from "../WorldviewReactContext";
 export type Props<T> = {
   children?: T[],
   reglCommand: RawCommand<T>,
-  getHitmapId?: (T) =>?number,
+  getHitmapId?: (T) => ?number,
   layerIndex?: number,
 };
 

--- a/packages/regl-worldview/src/commands/Command.test.js
+++ b/packages/regl-worldview/src/commands/Command.test.js
@@ -1,0 +1,11 @@
+// @flow
+import { makeCommand } from "./Command";
+
+describe("makeCommand", () => {
+  it("attaches the regl command to the component constructor", () => {
+    const fakeReglCommand = () => {};
+    const cmd = makeCommand("foo", fakeReglCommand);
+    expect(cmd.displayName).toEqual("foo");
+    expect(cmd.reglCommand).toBe(fakeReglCommand);
+  });
+});

--- a/packages/regl-worldview/src/index.js
+++ b/packages/regl-worldview/src/index.js
@@ -16,6 +16,7 @@ export { default as fromGeometry } from "./utils/fromGeometry";
 export * from "./utils/Raycast";
 export * from "./commands/index";
 export * from "./types/index";
+export { default as WorldviewReactContext } from "./WorldviewReactContext";
 
 export { Worldview };
 export default Worldview;


### PR DESCRIPTION
Also export WorldviewReactContext so non-command components can grab access to the regl instance.