### PR TITLE
add oes_element_index_uint extension

### DIFF
--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -102,7 +102,7 @@ export class WorldviewContext {
     const regl = this._instrumentCommands(
       createREGL({
         canvas,
-        extensions: ["angle_instanced_arrays", "oes_texture_float"],
+        extensions: ["angle_instanced_arrays", "oes_texture_float", "oes_element_index_uint"],
         profile: process.env.NODE_ENV !== "production",
       })
     );


### PR DESCRIPTION
Enable the use of Uint32Array for element index arrays.

Probably we should add a hook to allow customizing the set of extensions, but it doesn't seem like a big deal to just add one more and I doubt we'll need to add them very often :)