### PR TITLE
Fix inconsistent updates in camera rotation

### DIFF
--- a/packages/regl-worldview/src/camera/CameraStore.js
+++ b/packages/regl-worldview/src/camera/CameraStore.js
@@ -56,6 +56,7 @@ export default class CameraStore {
   };
 
   cameraRotate = ([x, y]: Vec2) => {
+    // This can happen in 2D mode, when both e.movementX and e.movementY are evaluated as negative and mouseX move is 0
     if (x === 0 && y === 0) {
       return;
     }
@@ -70,6 +71,7 @@ export default class CameraStore {
 
   // move the camera along x, y axis; do not move up/down
   cameraMove = ([x, y]: Vec2) => {
+    // moveX and moveY both be 0 sometimes
     if (x === 0 && y === 0) {
       return;
     }

--- a/packages/regl-worldview/src/camera/CameraStore.js
+++ b/packages/regl-worldview/src/camera/CameraStore.js
@@ -7,7 +7,6 @@
 //  You may not use this file except in compliance with the License.
 
 import { vec3, quat } from "gl-matrix";
-import isEqual from "lodash/isEqual";
 
 import type { Vec2, Vec3, Vec4 } from "../types";
 import selectors from "./cameraStateSelectors";
@@ -56,47 +55,50 @@ export default class CameraStore {
     this.state = state;
   };
 
-  _setStateAndNotify(cameraState: CameraState) {
-    // we only want to call onChange when cameraState values actually changes, as each
-    // onChange will trigger Worldview to rerender by forceUpdate or onCameraStateChange
-    if (!isEqual(this.state, cameraState)) {
-      this.state = cameraState;
-      this._onChange(this.state);
-    }
-  }
-
   cameraRotate = ([x, y]: Vec2) => {
+    if (x === 0 && y === 0) {
+      return;
+    }
     const { thetaOffset, phi } = this.state;
-
-    this._setStateAndNotify({
+    this.state = {
       ...this.state,
       thetaOffset: thetaOffset - x,
       phi: Math.max(0, Math.min(phi + y, Math.PI)),
-    });
+    };
+    this._onChange(this.state);
   };
 
   // move the camera along x, y axis; do not move up/down
   cameraMove = ([x, y]: Vec2) => {
+    if (x === 0 && y === 0) {
+      return;
+    }
+
     const { targetOffset, thetaOffset } = this.state;
 
     // rotate around z axis so the offset is in the target's reference frame
     const result = [x, y, 0];
     const offset = vec3.transformQuat(result, result, quat.setAxisAngle(TEMP_QUAT, UNIT_Z_VECTOR, -thetaOffset));
 
-    this._setStateAndNotify({
+    this.state = {
       ...this.state,
       targetOffset: vec3.add(offset, targetOffset, offset),
-    });
+    };
+    this._onChange(this.state);
   };
 
   cameraZoom = (zoomPercent: number) => {
     const { distance } = this.state;
     const newDistance: number = distanceAfterZoom(distance, zoomPercent);
-    this._setStateAndNotify({
+    if (distance === newDistance) {
+      return;
+    }
+
+    this.state = {
       ...this.state,
       distance: newDistance,
-    });
+    };
+    this._onChange(this.state);
   };
 }
-
 export { selectors };


### PR DESCRIPTION
Problem: currently we  consolidate `cameraState` updates in `_setStateAndNotify ` and skip updating `cameraState` if the next state is deeply equal to the current state. This approach has two issues:
- potential race condition as `cameraState` can be set elsewhere during the movement (e.g. worldview props)
- not efficient because we only need to compare a few primitives before updating the `cameraState`: `x`, `y`, `distance`. 

Test plan: test the new esm build internally, we should be able to rotate the 3d view when the webviz bag play is paused. 

Note: upon further investigation, we found the root problem is related to object spread in Chrome. Changing `const newState = {...this.state, thetaOffset: newThetaOffset}` to `const newState = Object.assign({}, this.state); newState.thetaOffset = newThetaOffset` work.  Canary and Firefox don't have any issues.  