### PR TITLE
GLTFScene: baseColorFactor & bug fixes

### DIFF
--- a/docs/src/4.12.GLTFScene.mdx
+++ b/docs/src/4.12.GLTFScene.mdx
@@ -11,6 +11,7 @@ import {DuckScene} from './jsx/allLiveEditors';
 | `model` | `string | (() => Promise<Object>)` |                                     | URL of a `.glb` file to load, or an async function resolving to a loaded model. (A `parseGLB` function is also exported if you want custom logic for loading the model.) The file must define a single `scene`. |
 | `pose`  | `Pose`                             | zero position, identity orientation | position and orientation at which to render the scene                                                                                                                                                           |
 | `scale` | `Scale`                            | `{ x: 1, y: 1, z: 1 }`              | scale factor                                                                                                                                                                                                    |
+| `alpha` | `number`                           | 1                                   | global opacity multiplier                                                                                                                                                                                       |
 
 ## Duck.glb
 

--- a/packages/regl-worldview/src/commands/GLTFScene.js
+++ b/packages/regl-worldview/src/commands/GLTFScene.js
@@ -9,9 +9,10 @@
 import { mat4 } from "gl-matrix";
 import React from "react";
 
+import { blend, toRGBA, pointToVec3, orientationToVec4 } from "../utils/commandUtils";
 import parseGLB from "../utils/parseGLB";
 
-import { Command, pointToVec3, orientationToVec4, type Pose, type Scale, WorldviewReactContext } from "..";
+import { Command, type Pose, type Scale, WorldviewReactContext } from "..";
 
 function glConstantToRegl(value: ?number): ?string {
   if (value === undefined) {
@@ -37,8 +38,10 @@ function glConstantToRegl(value: ?number): ?string {
 const drawModel = (regl) => {
   const command = regl({
     primitive: "triangles",
+    blend,
     uniforms: {
       baseColorTexture: regl.prop("baseColorTexture"),
+      baseColorFactor: regl.prop("baseColorFactor"),
       nodeMatrix: regl.prop("nodeMatrix"),
       poseMatrix: regl.context("poseMatrix"),
       "light.direction": [0, 0, -1],
@@ -71,6 +74,7 @@ const drawModel = (regl) => {
     frag: `
   precision mediump float;
   uniform sampler2D baseColorTexture;
+  uniform vec4 baseColorFactor;
   varying mediump vec2 vTexCoord;
   varying mediump vec3 vNormal;
 
@@ -84,11 +88,19 @@ const drawModel = (regl) => {
   uniform DirectionalLight light;
 
   void main() {
-    vec3 baseColor = texture2D(baseColorTexture, vTexCoord).rgb;
+    vec4 baseColor = texture2D(baseColorTexture, vTexCoord) * baseColorFactor;
     float diffuse = light.diffuseIntensity * max(0.0, dot(vNormal, -light.direction));
-    gl_FragColor = vec4((light.ambientIntensity + diffuse) * baseColor, 1);
+    gl_FragColor = vec4((light.ambientIntensity + diffuse) * baseColor.rgb, baseColor.a);
   }
   `,
+  });
+
+  // default values for when baseColorTexture is not specified
+  const singleTexCoord = regl.buffer([0, 0]);
+  const whiteTexture = regl.texture({
+    data: [255, 255, 255, 255],
+    width: 1,
+    height: 1,
   });
 
   // Build the draw calls needed to draw the model. This only needs to happen once, since they
@@ -100,19 +112,23 @@ const drawModel = (regl) => {
     }
 
     // upload textures to the GPU
-    const textures = model.json.textures.map((textureInfo) => {
-      const sampler = model.json.samplers[textureInfo.sampler];
-      const bitmap: ImageBitmap = model.images[textureInfo.source];
-      const texture = regl.texture({
-        data: bitmap,
-        min: glConstantToRegl(sampler.minFilter),
-        mag: glConstantToRegl(sampler.magFilter),
-        wrapS: glConstantToRegl(sampler.wrapS),
-        wrapT: glConstantToRegl(sampler.wrapT),
+    const textures =
+      model.json.textures &&
+      model.json.textures.map((textureInfo) => {
+        const sampler = model.json.samplers[textureInfo.sampler];
+        const bitmap: ImageBitmap = model.images[textureInfo.source];
+        const texture = regl.texture({
+          data: bitmap,
+          min: glConstantToRegl(sampler.minFilter),
+          mag: glConstantToRegl(sampler.magFilter),
+          wrapS: glConstantToRegl(sampler.wrapS),
+          wrapT: glConstantToRegl(sampler.wrapT),
+        });
+        return texture;
       });
-      bitmap.close();
-      return texture;
-    });
+    if (model.images) {
+      model.images.forEach((bitmap: ImageBitmap) => bitmap.close());
+    }
     drawCalls = [];
 
     // helper to draw the primitives comprising a mesh
@@ -124,8 +140,11 @@ const drawModel = (regl) => {
           indices: model.accessors[primitive.indices],
           positions: model.accessors[primitive.attributes.POSITION],
           normals: model.accessors[primitive.attributes.NORMAL],
-          texCoords: model.accessors[primitive.attributes[`TEXCOORD_${texInfo.texCoord || 0}`]],
-          baseColorTexture: textures[texInfo.index],
+          texCoords: texInfo
+            ? model.accessors[primitive.attributes[`TEXCOORD_${texInfo.texCoord || 0}`]]
+            : { divisor: 1, buffer: singleTexCoord },
+          baseColorTexture: texInfo ? textures[texInfo.index] : whiteTexture,
+          baseColorFactor: material.pbrMetallicRoughness.baseColorFactor || [1, 1, 1, 1],
           nodeMatrix,
         });
       }

--- a/packages/regl-worldview/src/commands/GLTFScene.js
+++ b/packages/regl-worldview/src/commands/GLTFScene.js
@@ -9,7 +9,7 @@
 import { mat4 } from "gl-matrix";
 import React from "react";
 
-import { blend, toRGBA, pointToVec3, orientationToVec4 } from "../utils/commandUtils";
+import { blend, pointToVec3, orientationToVec4 } from "../utils/commandUtils";
 import parseGLB from "../utils/parseGLB";
 
 import { Command, type Pose, type Scale, WorldviewReactContext } from "..";


### PR DESCRIPTION
- Add support for [`baseColorFactor`](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#pbrmetallicroughness).
- Make `baseColorTexture` optional (it's assumed to be white by default).
- Add a prop to set `alpha` globally, since the baseColor stuff comes from the model itself which isn't expected to change dynamically.
- Enable `blend` to allow alpha values to take effect.
- Fix an issue where `bitmap.close()` was called multiple times if the same image texture was used for multiple samplers, and fix some issues with models that don't have any images.
- Fix calculation of `length` for typed arrays when the accessor is offset from the start of the bufferView.