### PR TITLE
npm publishing

### DIFF
--- a/packages/@cruise-automation/rpc/package-lock.json
+++ b/packages/@cruise-automation/rpc/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@cruise-automation/rpc",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1
 }

--- a/packages/@cruise-automation/rpc/package-lock.json
+++ b/packages/@cruise-automation/rpc/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@cruise-automation/rpc",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 1
 }

--- a/packages/@cruise-automation/rpc/package.json
+++ b/packages/@cruise-automation/rpc/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "scripts": {
+    "prepublish": "npm run build",
     "build-dev": "BABEL_ENV=$NODE_ENV babel src/index.js --out-dir lib --copy-files --config-file ../../../babel.config.js",
     "build": "NODE_ENV=production npm run build-dev && flow-copy-source -v src lib --ignore '*.test.*'",
     "watch": "NODE_ENV=development npm run build-dev --watch"

--- a/packages/@cruise-automation/rpc/package.json
+++ b/packages/@cruise-automation/rpc/package.json
@@ -5,7 +5,6 @@
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "scripts": {
-    "prepublish": "npm run build",
     "build-dev": "BABEL_ENV=$NODE_ENV babel src/index.js --out-dir lib --copy-files --config-file ../../../babel.config.js",
     "build": "NODE_ENV=production npm run build-dev && flow-copy-source -v src lib --ignore '*.test.*'",
     "watch": "NODE_ENV=development npm run build-dev --watch"

--- a/packages/@cruise-automation/rpc/package.json
+++ b/packages/@cruise-automation/rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruise-automation/rpc",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Add RPC to WebWorkers with transferrable object support",
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@cruise-automation/rpc/package.json
+++ b/packages/@cruise-automation/rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruise-automation/rpc",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Add RPC to WebWorkers with transferrable object support",
   "main": "lib/index.js",
   "license": "Apache-2.0",
@@ -12,5 +12,8 @@
   "keywords": [
     "WebWorker",
     "rpc"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
Needed to add public publish access.  Version bump changed as well because I needed to run `npm run build` from the root directory before publishing.