### PR TITLE
Update eslint and support reading .bag files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
     "prettier/flowtype",
     "prettier/react",
   ],
-  plugins: ["jest", "import-order-alphabetical"],
+  plugins: ["jest", "import-order-alphabetical", "react-hooks"],
   parser: "babel-eslint",
   settings: { "import/resolver": { webpack: { config: `${__dirname}/webpack.config.js` } } },
   globals: {
@@ -46,5 +46,6 @@ module.exports = {
     ],
     // TODO(JP): Fix this instead of disabling it:
     "import/no-named-as-default": "off",
+    "prefer-arrow-callback": ["error", { allowNamedFunctions: true }],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7468,6 +7468,12 @@
         "prop-types": "^15.6.2"
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-0.0.0.tgz",
+      "integrity": "sha512-SXyU7C3E8AJbXKMdb10P/zHazcxzfuWR5OFwAVZKXVU7P/H56NLszVG6WdQBo9Pt80FfnPXtUGGbWhs3/98N4w==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-jest": "^22.0.1",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react-hooks": "0.0.0",
     "flow-bin": "0.80.0",
     "flow-copy-source": "^2.0.2",
     "flow-typed": "2.5.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -130,7 +130,7 @@ module.exports = {
       },
       { test: /\.scss$/, loader: "sass-loader", options: { sourceMap: true } },
       { test: /\.woff2?$/, loader: "url-loader" },
-      { test: /\.glb$/, loader: "file-loader" },
+      { test: /\.(glb|bag)$/, loader: "file-loader" },
     ],
   },
   optimization: {


### PR DESCRIPTION
- Add eslint plugin for react hooks as it'll be used in webviz-core 
- Use webpack `file-loader` to load `.bag` files (this will be used for loading ROS bag file in storybook)

