### PR TITLE
Add @babel/runtime as prod dependency

### DIFF
--- a/packages/regl-worldview/package-lock.json
+++ b/packages/regl-worldview/package-lock.json
@@ -4,6 +4,14 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/runtime": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
+			"integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+			"requires": {
+				"regenerator-runtime": "^0.12.0"
+			}
+		},
 		"batch-processor": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
@@ -87,6 +95,11 @@
 				"invariant": "^2.2.2",
 				"prop-types": "^15.5.8"
 			}
+		},
+		"regenerator-runtime": {
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+			"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
 		},
 		"regl": {
 			"version": "1.3.9",

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -25,6 +25,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@babel/runtime": "^7.3.1",
     "earcut": "^2.1.3",
     "gl-matrix": ">=2.6.1",
     "lodash": "^4.17.11",


### PR DESCRIPTION
We use @babel/transform-runtime in the [rollup config](https://github.com/cruise-automation/webviz/blob/master/packages/regl-worldview/rollup.config.js#L22) to reduce the codesize. As specified in the doc [here](https://babeljs.io/docs/en/babel-plugin-transform-runtime), we need to add @babel/runtime as prod dependency. 


Test: 
CodeSandBox only works if this dependency is present. https://codesandbox.io/s/j322yv070v 
Will publish a new package version to test once the PR is merged. 