### PR TITLE
Component-based mouse interactions

### DIFF
--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -162,10 +162,6 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     const { worldviewContext } = this.state;
     const worldviewHandler = this.props[mouseEventName];
 
-    if (!worldviewHandler) {
-      return;
-    }
-
     if (!(e.target instanceof window.HTMLElement) || e.button !== 0) {
       return;
     }

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -141,38 +141,34 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
   }
 
   _onClick = (e: MouseEvent) => {
-    const handlerName = "onClick";
-    this._onMouseInteraction(e, handlerName);
+    this._onMouseInteraction(e, "onClick");
   };
 
   _onDoubleClick = (e: MouseEvent) => {
-    const handlerName = "onDoubleClick";
-    this._onMouseInteraction(e, handlerName);
+    this._onMouseInteraction(e, "onDoubleClick");
   };
 
   _onMouseDown = (e: MouseEvent) => {
-    const handlerName = "onMouseDown";
-    this._onMouseInteraction(e, handlerName);
+    this._onMouseInteraction(e, "onMouseDown");
   };
 
   _onMouseMove = (e: MouseEvent) => {
-    const handlerName = "onMouseMove";
-    this._onMouseInteraction(e, handlerName, this.props.hitmapOnMouseMove);
+    this._onMouseInteraction(e, "onMouseMove", this.props.hitmapOnMouseMove);
   };
 
   _onMouseUp = (e: MouseEvent) => {
-    const handlerName = "onMouseUp";
-    this._onMouseInteraction(e, handlerName);
+    this._onMouseInteraction(e, "onMouseUp");
   };
 
   _anyComponentHandlerExists = (handlerName: string) =>
     size(this.state.worldviewContext.mouseHandlers[handlerName]) > 0;
 
   _onMouseInteraction = (e: MouseEvent, handlerName: string, readHitmap: boolean = true) => {
+    const { worldviewContext } = this.state;
     const worldviewHandler = this.props[handlerName];
-    const anyComponentHandlerExists = this._anyComponentHandlerExists(handlerName);
+    const componentHandlers = this.state.worldviewContext.mouseHandlers[handlerName];
 
-    if (!worldviewHandler && !anyComponentHandlerExists) {
+    if (!worldviewHandler && size(componentHandlers) === 0) {
       return;
     }
 
@@ -181,7 +177,6 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     }
 
     const { top: clientTop, left: clientLeft } = e.target.getBoundingClientRect();
-    const { worldviewContext } = this.state;
     const { clientX, clientY } = e;
 
     const canvasX = clientX - clientLeft;

--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -273,8 +273,8 @@ export class WorldviewContext {
 
   callComponentHandlers = (objectId: number, ray: Ray, e: MouseEvent, mouseEventName: MouseEventEnum) => {
     this._hitmapCalls.forEach((_, component) => {
-      if (component.fireRelevantMouseHandler) {
-        component.fireRelevantMouseHandler(objectId, e, ray, mouseEventName);
+      if (component.handleMouseEvent) {
+        component.handleMouseEvent(objectId, e, ray, mouseEventName);
       }
     });
   };

--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -273,7 +273,9 @@ export class WorldviewContext {
 
   callComponentHandlers = (objectId: number, ray: Ray, e: MouseEvent, mouseEventName: MouseEventEnum) => {
     this._hitmapCalls.forEach((_, component) => {
-      component.fireRelevantMouseHandler(objectId, e, ray, mouseEventName);
+      if (component.fireRelevantMouseHandler) {
+        component.fireRelevantMouseHandler(objectId, e, ray, mouseEventName);
+      }
     });
   };
 

--- a/packages/regl-worldview/src/commands/Command.js
+++ b/packages/regl-worldview/src/commands/Command.js
@@ -82,17 +82,17 @@ export default class Command<T> extends React.Component<Props<T>> {
     }
   }
 
-  getDrawPropFromHitmapId(id: number) {
-    const { hitmapProps } = this.props;
-    for (const drawProp of hitmapProps) {
-      if (drawProp.color) {
-        const drawPropId = getIdFromColor(drawProp.color.map((color) => color * 255));
-        if (drawPropId === id) {
-          return drawProp;
+  getHitmapPropFromHitmapId(id: number) {
+    const { hitmapProps = [] } = this.props;
+    return hitmapProps.find((hitmapProp) => {
+      // TODO handle objects with 'colors' prop
+      if (hitmapProp.color) {
+        const hitmapPropId = getIdFromColor(hitmapProp.color.map((color) => color * 255));
+        if (hitmapPropId === id) {
+          return true;
         }
       }
-    }
-    return null;
+    });
   }
 
   fireRelevantMouseHandler(id: number, e: any, ray: any, mouseEventName: MouseEventEnum) {
@@ -101,15 +101,14 @@ export default class Command<T> extends React.Component<Props<T>> {
       return;
     }
 
-    const drawProp = this.getDrawPropFromHitmapId(id);
-    if (!drawProp) {
+    const hitmapProp = this.getHitmapPropFromHitmapId(id);
+    if (!hitmapProp) {
       return;
     }
 
     mouseHandler(e, {
       ray,
-      interactedObject: drawProp,
-      component: this,
+      interactedObject: hitmapProp,
     });
   }
 

--- a/packages/regl-worldview/src/commands/Command.js
+++ b/packages/regl-worldview/src/commands/Command.js
@@ -121,7 +121,7 @@ export function makeCommand<T>(name: string, command: RawCommand<T>): React.Stat
     const hitmapProps = props.getHitmapProps
       ? props.getHitmapProps()
       : getHitmapProps(props.getHitmapId, props.children);
-    return <Command reglCommand={command} drawProps={props.children} hitmapProps={hitmapProps} />;
+    return <Command {...props} reglCommand={command} drawProps={props.children} hitmapProps={hitmapProps} />;
   };
   cmd.displayName = name;
   cmd.reglCommand = command;

--- a/packages/regl-worldview/src/commands/Command.js
+++ b/packages/regl-worldview/src/commands/Command.js
@@ -82,26 +82,27 @@ export default class Command<T> extends React.Component<Props<T>> {
     }
   }
 
-  getHitmapPropFromHitmapId(id: number) {
+  _getHitmapPropFromHitmapId(objectId: number) {
     const { hitmapProps = [] } = this.props;
     return hitmapProps.find((hitmapProp) => {
-      // TODO handle objects with 'colors' prop
+      // TODO handle objects with 'colors' property
       if (hitmapProp.color) {
         const hitmapPropId = getIdFromColor(hitmapProp.color.map((color) => color * 255));
-        if (hitmapPropId === id) {
+        if (hitmapPropId === objectId) {
           return true;
         }
       }
+      return false;
     });
   }
 
-  fireRelevantMouseHandler(id: number, e: any, ray: any, mouseEventName: MouseEventEnum) {
+  handleMouseEvent(objectId: number, e: any, ray: any, mouseEventName: MouseEventEnum) {
     const mouseHandler = this.props[mouseEventName];
     if (!mouseHandler) {
       return;
     }
 
-    const hitmapProp = this.getHitmapPropFromHitmapId(id);
+    const hitmapProp = this._getHitmapPropFromHitmapId(objectId);
     if (!hitmapProp) {
       return;
     }

--- a/packages/regl-worldview/src/stories/Cubes.stories.js
+++ b/packages/regl-worldview/src/stories/Cubes.stories.js
@@ -5,6 +5,7 @@ import React from "react";
 
 import { intToRGB } from "../utils/commandUtils";
 import Container from "./Container";
+import PerComponentHitmapStory from "./PerComponentHitmapStory";
 import { cube, p, UNIT_QUATERNION, buildMatrix, rng } from "./util";
 import withRange from "./withRange";
 
@@ -108,6 +109,7 @@ storiesOf("Worldview", module)
       return <DynamicCubes range={range} />;
     })
   )
+  .add("<Cubes> - per-component interaction", () => <PerComponentHitmapStory />)
   .add(
     "<Cubes> - instanced",
     withRange((range) => {

--- a/packages/regl-worldview/src/stories/PerComponentHitmapStory.js
+++ b/packages/regl-worldview/src/stories/PerComponentHitmapStory.js
@@ -47,15 +47,15 @@ class PerCubeInteractions extends React.Component<any, any> {
     }
   };
 
-  onCubeClick = (id, ray, event, clickedObject) => this.setState({ cubeDetails: clickedObject });
+  onCubeClick = (e, { interactedObject }) => this.setState({ cubeDetails: interactedObject });
 
-  onCubeDoubleClick = (id, ray, event, clickedObject) => {
+  onCubeDoubleClick = (id, { interactedObject }) => {
     const newCubes = [...this.state.cubes];
-    remove(newCubes, (cube) => cube.id === clickedObject.id);
+    remove(newCubes, (cube) => cube.id === interactedObject.id);
     this.setState({ cubes: newCubes });
   };
 
-  onCubeHover = (id, ray, event, hoveredObject) => this.setState({ cursor: hoveredObject.mouseCursor });
+  onCubeHover = (e, { interactedObject }) => this.setState({ cursor: interactedObject.mouseCursor });
 
   createCube = (i) => {
     const marker = cube(0, i + 1);

--- a/packages/regl-worldview/src/stories/PerComponentHitmapStory.js
+++ b/packages/regl-worldview/src/stories/PerComponentHitmapStory.js
@@ -44,28 +44,32 @@ function PerCubeInteractions() {
   const [cubeDetails, setCubeDetails] = useState({});
   const [cursor, setCursor] = useState("auto");
 
-  const onContainerClick = (e, args) => {
+  function onContainerClick(e, args) {
     if (!args.clickedObjectId) {
       setCubeDetails({});
     }
-  };
+  }
 
-  const onContainerMouseMove = (e, args) => {
+  function onContainerMouseMove(e, args) {
     if (!args.clickedObjectId) {
       setCursor("auto");
     }
-  };
+  }
 
-  const onCubeClick = (e, { interactedObject }) => setCubeDetails(interactedObject);
+  function onCubeClick(e, { interactedObject }) {
+    setCubeDetails(interactedObject);
+  }
 
-  const onCubeDoubleClick = (id, { interactedObject }) => {
+  function onCubeDoubleClick(id, { interactedObject }) {
     const newCubes = [...cubes];
     remove(newCubes, (cube) => cube.id === interactedObject.id);
 
     setCubes(newCubes);
-  };
+  }
 
-  const onCubeHover = (e, { interactedObject }) => setCursor(interactedObject.mouseCursor);
+  function onCubeHover(e, { interactedObject }) {
+    setCursor(interactedObject.mouseCursor);
+  }
 
   return (
     <div style={{ cursor, width: "100%", height: "100%" }}>
@@ -89,7 +93,9 @@ function PerCubeInteractions() {
           <div style={{ margin: "5px 0" }}>
             you clicked on cube: <pre style={{ whiteSpace: "pre-wrap" }}>{JSON.stringify(cubeDetails, null, 2)}</pre>{" "}
           </div>
-          <button onClick={() => setCubes([...cubes, createCube(last(cubes).index + 1)])}>Add Cube</button>
+          <button onClick={() => setCubes([...cubes, createCube(last(cubes) ? last(cubes).index + 1 : 0)])}>
+            Add Cube
+          </button>
         </div>
         <Cubes
           onMouseMove={onCubeHover}

--- a/packages/regl-worldview/src/stories/PerComponentHitmapStory.js
+++ b/packages/regl-worldview/src/stories/PerComponentHitmapStory.js
@@ -1,0 +1,116 @@
+import last from "lodash/last";
+import remove from "lodash/remove";
+import sample from "lodash/sample";
+import React from "react";
+
+import Container from "./Container";
+import { cube, p, rng } from "./util";
+
+import { Cubes, DEFAULT_CAMERA_STATE } from "..";
+
+const randomCubeFacts = [
+  "A cube is a three dimensional shape",
+  "A cube has 6 square faces.",
+  "A cube has the largest volume of all cuboids with a certain surface area",
+  "All the matter that makes up the human race could fit in a sugar cube",
+  "There are 43,252,003,274,489,856,000 possible permutations of the Rubik's Cube",
+  "Ice Cube was the only member of NWA not born in Compton",
+  "Wombats have cube-shaped poop",
+];
+
+const randomMouseCursors = ["progress", "wait", "crosshair", "text", "move", "grab", "ew-resize", "ns-resize"];
+
+const getCube = (marker, position, color) => ({
+  ...marker,
+  color,
+  pose: {
+    orientation: { x: 0, y: 0, z: 0, w: 1 },
+    position,
+  },
+});
+
+class PerCubeInteractions extends React.Component<any, any> {
+  constructor() {
+    super();
+    this.state = { cubes: [this.createCube(0)], cubeDetails: {}, cursor: "auto" };
+  }
+
+  onContainerClick = (e, args) => {
+    if (!args.clickedObjectId) {
+      this.setState({ cubeDetails: {} });
+    }
+  };
+
+  onContainerMouseMove = (e, args) => {
+    if (!args.clickedObjectId) {
+      this.setState({ cursor: "auto" });
+    }
+  };
+
+  onCubeClick = (id, ray, event, clickedObject) => this.setState({ cubeDetails: clickedObject });
+
+  onCubeDoubleClick = (id, ray, event, clickedObject) => {
+    const newCubes = [...this.state.cubes];
+    remove(newCubes, (cube) => cube.id === clickedObject.id);
+    this.setState({ cubes: newCubes });
+  };
+
+  onCubeHover = (id, ray, event, hoveredObject) => this.setState({ cursor: hoveredObject.mouseCursor });
+
+  createCube = (i) => {
+    const marker = cube(0, i + 1);
+    const { position: posePosition } = marker.pose;
+    const color = [rng(), rng(), rng(), 1];
+    const { x, y, z } = posePosition;
+    const position = { x: x + i * 5, y: y + i * 5, z: z + i * 5 };
+    return {
+      ...getCube(marker, position, color),
+      cubeFact: sample(randomCubeFacts),
+      mouseCursor: sample(randomMouseCursors),
+      index: i,
+    };
+  };
+
+  render() {
+    const { cubes, cubeDetails, cursor } = this.state;
+
+    return (
+      <div style={{ cursor, width: "100%", height: "100%" }}>
+        <Container
+          hitmapOnMouseMove
+          cameraState={DEFAULT_CAMERA_STATE}
+          onClick={this.onContainerClick}
+          onMouseMove={this.onContainerMouseMove}>
+          <div
+            style={{
+              position: "absolute",
+              padding: "5px",
+              top: 30,
+              left: 30,
+              width: "400px",
+              backgroundColor: "rgba(165, 94, 255, 0.1)",
+            }}>
+            <div>click on a cube to see its details</div>
+            <div>double click on a cube to remove it</div>
+            <br />
+            <div style={{ margin: "5px 0" }}>
+              you clicked on cube: <pre style={{ whiteSpace: "pre-wrap" }}>{JSON.stringify(cubeDetails, null, 2)}</pre>{" "}
+            </div>
+            <button onClick={() => this.setState({ cubes: [...cubes, this.createCube(last(cubes).index + 1)] })}>
+              Add Cube
+            </button>
+          </div>
+          <Cubes
+            onMouseMove={this.onCubeHover}
+            onClick={this.onCubeClick}
+            onDoubleClick={this.onCubeDoubleClick}
+            getHitmapId={(marker) => marker.id}>
+            {cubes}
+          </Cubes>
+        </Container>
+      </div>
+    );
+  }
+}
+
+export default PerCubeInteractions;

--- a/packages/regl-worldview/src/stories/PerComponentHitmapStory.js
+++ b/packages/regl-worldview/src/stories/PerComponentHitmapStory.js
@@ -4,7 +4,7 @@ import sample from "lodash/sample";
 import React from "react";
 
 import Container from "./Container";
-import { cube, p, rng } from "./util";
+import { cube, rng } from "./util";
 
 import { Cubes, DEFAULT_CAMERA_STATE } from "..";
 

--- a/packages/regl-worldview/src/types/index.js
+++ b/packages/regl-worldview/src/types/index.js
@@ -5,8 +5,10 @@
 //  This source code is licensed under the Apache License, Version 2.0,
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
+import * as React from "react";
 
 import type { CameraState } from "../camera/CameraStore";
+import CommandComponent from "../commands/Command";
 import { Ray } from "../utils/Raycast";
 import type { BaseProps, Props } from "../Worldview";
 
@@ -100,7 +102,15 @@ export type ReglClickInfo = {
   clickedObjectId?: number,
 };
 
+export type ComponentReglClickInfo = {
+  ray: Ray,
+  interactedObject: Object,
+  component: CommandComponent,
+};
+
 export type MouseHandler = (MouseEvent, ?ReglClickInfo) => void;
+
+export type ComponentMouseHandler = (MouseEvent, ComponentReglClickInfo) => void;
 
 export type ReglComponentProps = {
   commandId: string,
@@ -184,6 +194,8 @@ export type PolygonType = BaseShape & {
   points: Vec3[],
   id: number,
 };
+
+export type MouseEventEnum = "onClick" | "onMouseUp" | "onMouseMove" | "onMouseDown" | "onDoubleClick";
 
 // Camera
 export type CameraAction =

--- a/packages/regl-worldview/src/types/index.js
+++ b/packages/regl-worldview/src/types/index.js
@@ -6,7 +6,6 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 import type { CameraState } from "../camera/CameraStore";
-import CommandComponent from "../commands/Command";
 import { Ray } from "../utils/Raycast";
 import type { BaseProps, Props } from "../Worldview";
 
@@ -103,7 +102,6 @@ export type ReglClickInfo = {
 export type ComponentReglClickInfo = {
   ray: Ray,
   interactedObject: Object,
-  component: CommandComponent,
 };
 
 export type MouseHandler = (MouseEvent, ?ReglClickInfo) => void;


### PR DESCRIPTION
This PR adds component-based mouse interactions so that consumers can add `onClick` or `onMouseMove` etc. to a command component.

The story added showcases 3 interactions, clicking for details, double clicking for removal, and hovering for changing the mouse cursor.
![out](https://user-images.githubusercontent.com/5697723/52304141-d46eee00-2946-11e9-8d21-a7c3b0ee0774.gif)

This takes a similar approach from a previous PR, without a lot of the extra overhead.