### PR TITLE
Fix process undefined in umd build

### DIFF
--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -205,7 +205,7 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     const { worldviewContext } = this.state;
     const initializedData = worldviewContext.initializedData;
 
-    if (process.env.NODE_ENV === "production" || !initializedData) {
+    if ((process && process.env && process.env.NODE_ENV === "production") || !initializedData) {
       return null;
     }
     const { regl } = initializedData;

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -13,6 +13,7 @@ import ContainerDimensions from "react-container-dimensions";
 
 import { CameraListener, DEFAULT_CAMERA_STATE } from "./camera/index";
 import type { MouseHandler, Dimensions, Vec4, CameraState, CameraKeyMap } from "./types";
+import { getNodeEnv } from "./utils/common";
 import { Ray } from "./utils/Raycast";
 import { WorldviewContext } from "./WorldviewContext";
 import WorldviewReactContext from "./WorldviewReactContext";
@@ -205,7 +206,7 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     const { worldviewContext } = this.state;
     const initializedData = worldviewContext.initializedData;
 
-    if ((process && process.env && process.env.NODE_ENV === "production") || !initializedData) {
+    if (getNodeEnv() === "production" || !initializedData) {
       return null;
     }
     const { regl } = initializedData;

--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -13,6 +13,7 @@ import { camera, CameraStore } from "./camera/index";
 import Command from "./commands/Command";
 import type { Dimensions, RawCommand, CompiledReglCommand, CameraCommand, Vec4, CameraState } from "./types";
 import { getIdFromColor } from "./utils/commandUtils";
+import { getNodeEnv } from "./utils/common";
 import { getRayFromClick } from "./utils/Raycast";
 
 type Props = any;
@@ -103,7 +104,7 @@ export class WorldviewContext {
       createREGL({
         canvas,
         extensions: ["angle_instanced_arrays", "oes_texture_float", "oes_element_index_uint"],
-        profile: process && process.env && process.env.NODE_ENV !== "production",
+        profile: getNodeEnv() !== "production",
       })
     );
     // compile any components which mounted before regl is initialized
@@ -294,7 +295,7 @@ export class WorldviewContext {
   };
 
   _instrumentCommands(regl: any) {
-    if (process && process.env && process.env.NODE_ENV === "production") {
+    if (getNodeEnv() === "production") {
       return regl;
     }
     return new Proxy(regl, {

--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -103,7 +103,7 @@ export class WorldviewContext {
       createREGL({
         canvas,
         extensions: ["angle_instanced_arrays", "oes_texture_float", "oes_element_index_uint"],
-        profile: process.env.NODE_ENV !== "production",
+        profile: process && process.env && process.env.NODE_ENV !== "production",
       })
     );
     // compile any components which mounted before regl is initialized
@@ -294,7 +294,7 @@ export class WorldviewContext {
   };
 
   _instrumentCommands(regl: any) {
-    if (process.env.NODE_ENV === "production") {
+    if (process && process.env && process.env.NODE_ENV === "production") {
       return regl;
     }
     return new Proxy(regl, {

--- a/packages/regl-worldview/src/commands/Command.js
+++ b/packages/regl-worldview/src/commands/Command.js
@@ -11,6 +11,7 @@ import * as React from "react";
 
 import type { RawCommand } from "../types";
 import { intToRGB } from "../utils/commandUtils";
+import { getNodeEnv } from "../utils/common";
 import { type WorldviewContextType } from "../WorldviewContext";
 import WorldviewReactContext from "../WorldviewReactContext";
 
@@ -30,7 +31,7 @@ export default class Command<T> extends React.Component<Props<T>> {
     super(props);
     // In development put a check in to make sure the reglCommand prop is not mutated.
     // Similar to how react checks for unsupported or deprecated calls in a development build.
-    if (process && process.env && process.env.NODE_ENV !== "production") {
+    if (getNodeEnv() !== "production") {
       this.shouldComponentUpdate = (nextProps: Props) => {
         if (nextProps.reglCommand !== this.props.reglCommand) {
           console.error("Changing the regl command prop on a <Command /> is not supported.");

--- a/packages/regl-worldview/src/utils/common.js
+++ b/packages/regl-worldview/src/utils/common.js
@@ -1,0 +1,11 @@
+// @flow
+
+//  Copyright (c) 2018-present, GM Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+export function getNodeEnv() {
+  return process && process.env && process.env.NODE_ENV;
+}


### PR DESCRIPTION
The current umd build doesn't work without `const process = {}`  https://codepen.io/vidaaudrey/pen/WPwmqg  

Fix by always checking for `process` and `process.env` before getting NODE_ENV. 