### PR TITLE
Allow text markers to specify background and foreground colors

### DIFF
--- a/docs/src/4.10.Text.mdx
+++ b/docs/src/4.10.Text.mdx
@@ -6,13 +6,22 @@ import {Text} from './jsx/allLiveEditors'
 
 ## Props
 
-| Name       | Type     | Default | Description                     |
-| ---------- | -------- | ------- | ------------------------------- |
-| `children` | `Text[]` | `[]`    | array of Text markers to render |
+| Name            | optional | Type      | Default | Description                            |
+| --------------- | -------- | --------- | ------- |
+| `children`      |          | `Text[]`  | `[]`    | array of Text markers to render        |
+| `enableBgColor` | yes      | `boolean` |         | show solid background color if enabled |
+
 
 ### Text
 
 ```js
+type Color = {
+  r: number, // between 0 and 1
+  g: number, // between 0 and 1
+  b: number, // between 0 and 1
+  a: number, // between 0 and 1
+}
+
 type Text = {
   pose: {
     position: { x: number, y: number, z: number },
@@ -23,15 +32,18 @@ type Text = {
     y: number,
     z: number
   },
-  color: {
-    r: number, // between 0 and 1
-    g: number, // between 0 and 1
-    b: number, // between 0 and 1
-    a: number, // between 0 and 1
-  },
+  color: Color,
+  colors?: [
+  // text color, only applied when colors.length >= 2
+  Color,
+  // background color, only applied when colors.length >= 2
+  Color
+ ],
   name?: string,
   text: string,
 }
 ```
 
 <Text />
+
+

--- a/docs/src/4.10.Text.mdx
+++ b/docs/src/4.10.Text.mdx
@@ -51,11 +51,11 @@ type Text = {
   },
   color: Color,
   colors?: [
-  // text color, only applied when colors.length >= 2
-  Color,
-  // background color, only applied when colors.length >= 2
-  Color
- ],
+    // text color, only applied when colors.length >= 2
+    Color,
+    // background color, only applied when colors.length >= 2
+    Color
+  ],
   name?: string,
   text: string,
 }

--- a/docs/src/4.10.Text.mdx
+++ b/docs/src/4.10.Text.mdx
@@ -16,7 +16,7 @@ import {Text} from './jsx/allLiveEditors'
 There are three ways to control the text and background colors:
 
 - Text without background color: set `color` field
-- Text with automatically background color: set `color` field and set `autoBackgroundColor` to `true`
+- Text with automatically-chosen background color: set `color` field and set `autoBackgroundColor` to `true`
 - Custom text and background colors: set `colors` field where `colors[0]` is the text color and `colors[1]` is the background color
 
 Examples:

--- a/docs/src/4.10.Text.mdx
+++ b/docs/src/4.10.Text.mdx
@@ -1,4 +1,4 @@
-import {Text} from './jsx/allLiveEditors'
+import { Text } from './jsx/allLiveEditors'
 
 # Text
 

--- a/docs/src/4.10.Text.mdx
+++ b/docs/src/4.10.Text.mdx
@@ -6,11 +6,28 @@ import {Text} from './jsx/allLiveEditors'
 
 ## Props
 
-| Name            | optional | Type      | Default | Description                            |
-| --------------- | -------- | --------- | ------- |
-| `children`      |          | `Text[]`  | `[]`    | array of Text markers to render        |
-| `enableBgColor` | yes      | `boolean` |         | show solid background color if enabled |
+| Name                  | optional | Type      | Default | Description                                                       |
+| --------------------- | -------- | --------- | ------- |
+| `children`            |          | `Text[]`  | `[]`    | array of Text markers to render                                   |
+| `autoBackgroundColor` | yes      | `boolean` |         | automatically add solid background color with contrast if enabled |
 
+### Text and background colors
+
+There are three ways to control the text and background colors:
+
+- Text without background color: set `color` field
+- Text with automatically background color: set `color` field and set `autoBackgroundColor` to `true`
+- Custom text and background colors: set `colors` field where `colors[0]` is the text color and `colors[1]` is the background color
+
+Examples:
+
+| `colors`         | `color` | `autoBackgroundColor` | Text Color | Background Color                      | Note                            |
+| ---------------- | ------- | --------------------- | ---------- | ------------------------------------- | ------------------------------- |
+|                  | `blue`  | `false`               | `blue`     | none                                  |                                 |
+|                  | `blue`  | `true`                | `blue`     | `#1f1e27` (dark) or `#ffffff` (light) | depending on color's luma value |
+| [`red`]          | `blue`  | `false`               | `blue`     | none                                  | `colors` field is ignored       |
+| [`red`]          | `blue`  | `true`                | `blue`     | `#1f1e27` (dark) or `#ffffff` (light) | `colors` field is ignored       |
+| [`red`, `green`] |         |                       | `red`      | `green`                               | `color` field is ignored        |
 
 ### Text
 

--- a/docs/src/4.10.Text.mdx
+++ b/docs/src/4.10.Text.mdx
@@ -7,7 +7,7 @@ import {Text} from './jsx/allLiveEditors'
 ## Props
 
 | Name                  | optional | Type      | Default | Description                                                       |
-| --------------------- | -------- | --------- | ------- |
+| --------------------- | -------- | --------- | ------- | ----------------------------------------------------------------- |
 | `children`            |          | `Text[]`  | `[]`    | array of Text markers to render                                   |
 | `autoBackgroundColor` | yes      | `boolean` |         | automatically add solid background color with contrast if enabled |
 
@@ -49,7 +49,8 @@ type Text = {
     y: number,
     z: number
   },
-  color: Color,
+  // text color, applied when colors.length < 2
+  color?: Color,
   colors?: [
     // text color, only applied when colors.length >= 2
     Color,
@@ -62,5 +63,3 @@ type Text = {
 ```
 
 <Text />
-
-

--- a/docs/src/jsx/Text.js
+++ b/docs/src/jsx/Text.js
@@ -20,11 +20,25 @@ function Example() {
       position: { x: 10, y: 10, z: 1 },
     },
     scale: { x: 1, y: 1, z: 1 },
+    colors: [
+      {
+        r: 1,
+        g: 1,
+        b: 1,
+        a: 1,
+      },
+      {
+        r: 1,
+        g: 0,
+        b: 0,
+        a: 0.8,
+      },
+    ],
   };
 
   return (
     <Worldview>
-      <Text>{[labelMarker]}</Text>
+      <Text enableBgColor>{[labelMarker]}</Text>
       <Axes />
     </Worldview>
   );

--- a/docs/src/jsx/Text.js
+++ b/docs/src/jsx/Text.js
@@ -20,25 +20,13 @@ function Example() {
       position: { x: 10, y: 10, z: 1 },
     },
     scale: { x: 1, y: 1, z: 1 },
-    colors: [
-      {
-        r: 1,
-        g: 1,
-        b: 1,
-        a: 1,
-      },
-      {
-        r: 1,
-        g: 0,
-        b: 0,
-        a: 0.8,
-      },
-    ],
+    // uncomment colors and remove autoBackgroundColor prop to set text and background colors
+    // colors: [{ r: 1, g: 1, b: 1, a: 1 }, { r: 1, g: 0, b: 0, a: 0.8 }],
   };
 
   return (
     <Worldview>
-      <Text enableBgColor>{[labelMarker]}</Text>
+      <Text autoBackgroundColor>{[labelMarker]}</Text>
       <Axes />
     </Worldview>
   );

--- a/packages/regl-worldview/src/commands/Text.js
+++ b/packages/regl-worldview/src/commands/Text.js
@@ -96,7 +96,6 @@ class TextElement {
     }
 
     if (autoBackgroundColor && !isColorEqual(textColor, this._prevBgColor)) {
-      // set the bgColor if it's not already set or if it's different from the current textColor
       this._prevBgColor = textColor;
       const isTextColorDark = isColorDark(textColor);
       const hexBgColor = isTextColorDark ? BG_COLOR_DARK : BG_COLOR_LIGHT;

--- a/packages/regl-worldview/src/commands/Text.js
+++ b/packages/regl-worldview/src/commands/Text.js
@@ -13,12 +13,19 @@ import { getCSSColor } from "../utils/commandUtils";
 import { type WorldviewContextType } from "../WorldviewContext";
 import WorldviewReactContext from "../WorldviewReactContext";
 
+const BG_COLOR_LIGHT = "#ffffff";
+const BG_COLOR_DARK = "#1f1e27";
+const BRIGHTNESS_THRESHOLD = 123;
+const DEFAULT_TEXT_COLOR = { r: 1, g: 1, b: 1, a: 1 };
+const DEFAULT_BG_COLOR = { r: 0, g: 0, b: 0, a: 0 };
+
 type TextMarker = {
   name?: string,
   pose: Pose,
   scale: Scale,
   color: Color,
   text: string,
+  colors?: Color[],
 };
 
 let cssHasBeenInserted = false;
@@ -50,11 +57,20 @@ function insertGlobalCss() {
   cssHasBeenInserted = true;
 }
 
+function getIsColorDark({ r, g, b }: Color): boolean {
+  // ITU-R BT.709 https://en.wikipedia.org/wiki/Rec._709
+  // 0.2126 * 255 * r + 0.7152 * 255 * g + 0.0722 * 255 * b
+  const luma = 54.213 * r + 182.376 * g + 18.411 * b;
+  return luma > BRIGHTNESS_THRESHOLD;
+}
+
 class TextElement {
   wrapper = document.createElement("span");
   _inner = document.createElement("span");
   _text = document.createTextNode("");
-  _color = "";
+  // store prev colors to improve perf
+  _prevTextColor: Color = DEFAULT_TEXT_COLOR;
+  _prevBgColor: Color = DEFAULT_BG_COLOR;
 
   constructor() {
     insertGlobalCss();
@@ -64,14 +80,30 @@ class TextElement {
     this._inner.appendChild(this._text);
   }
 
-  update(marker: TextMarker, left: number, top: number) {
+  update(marker: TextMarker, left: number, top: number, enableBgColor?: boolean) {
     this.wrapper.style.transform = `translate(${left.toFixed()}px,${top.toFixed()}px)`;
-    const newColor = getCSSColor(marker.color);
+    const { color, colors = [] } = marker;
+    const hasBgColor = colors.length >= 2;
+    const textColor = hasBgColor ? colors[0] : color;
 
-    if (this._color !== newColor) {
-      this._color = newColor;
-      this.wrapper.style.color = newColor;
+    if (this._prevTextColor !== textColor) {
+      this._prevTextColor = textColor;
+      this.wrapper.style.color = getCSSColor(textColor);
     }
+
+    if (enableBgColor) {
+      // set the bgColor if it's not already set or if it's different from the current textColor
+      if (!hasBgColor && this._prevBgColor !== textColor) {
+        this._prevBgColor = textColor;
+        const isTextColorDark = getIsColorDark(textColor);
+        const hexBgColor = isTextColorDark ? BG_COLOR_DARK : BG_COLOR_LIGHT;
+        this._inner.style.background = hexBgColor;
+      } else if (hasBgColor && this._prevBgColor !== colors[1]) {
+        this._prevBgColor = colors[1];
+        this._inner.style.background = getCSSColor(colors[1]);
+      }
+    }
+
     if (this._text.textContent !== marker.text) {
       this._text.textContent = marker.text || "";
     }
@@ -80,6 +112,7 @@ class TextElement {
 
 type Props = {
   children: TextMarker[],
+  enableBgColor?: boolean,
 };
 
 // Render text on a scene using DOM nodes, similar to the Overlay command.
@@ -108,7 +141,7 @@ export default class Text extends React.Component<Props> {
   paint = () => {
     const context = this._context;
     const textComponents = this._textComponents;
-    const { children: markers } = this.props;
+    const { children: markers, enableBgColor } = this.props;
     const { current: textContainer } = this._textContainerRef;
     const initializedData = context && context.initializedData;
 
@@ -145,7 +178,7 @@ export default class Text extends React.Component<Props> {
         textContainer.appendChild(el.wrapper);
       }
 
-      el.update(marker, left, top);
+      el.update(marker, left, top, enableBgColor);
     }
 
     for (const key of componentsToRemove) {

--- a/packages/regl-worldview/src/commands/Text.js
+++ b/packages/regl-worldview/src/commands/Text.js
@@ -23,9 +23,9 @@ type TextMarker = {
   name?: string,
   pose: Pose,
   scale: Scale,
-  color: Color,
-  text: string,
+  color?: Color,
   colors?: Color[],
+  text: string,
 };
 
 let cssHasBeenInserted = false;
@@ -89,20 +89,21 @@ class TextElement {
     const { color, colors = [] } = marker;
     const hasBgColor = colors.length >= 2;
     const textColor = hasBgColor ? colors[0] : color;
+    if (textColor) {
+      if (!isColorEqual(this._prevTextColor, textColor)) {
+        this._prevTextColor = textColor;
+        this.wrapper.style.color = getCSSColor(textColor);
+      }
 
-    if (!isColorEqual(this._prevTextColor, textColor)) {
-      this._prevTextColor = textColor;
-      this.wrapper.style.color = getCSSColor(textColor);
-    }
-
-    if (autoBackgroundColor && !isColorEqual(textColor, this._prevBgColor)) {
-      this._prevBgColor = textColor;
-      const isTextColorDark = isColorDark(textColor);
-      const hexBgColor = isTextColorDark ? BG_COLOR_DARK : BG_COLOR_LIGHT;
-      this._inner.style.background = hexBgColor;
-    } else if (hasBgColor && !isColorEqual(colors[1], this._prevBgColor)) {
-      this._prevBgColor = colors[1];
-      this._inner.style.background = getCSSColor(colors[1]);
+      if (autoBackgroundColor && !isColorEqual(textColor, this._prevBgColor)) {
+        this._prevBgColor = textColor;
+        const isTextColorDark = isColorDark(textColor);
+        const hexBgColor = isTextColorDark ? BG_COLOR_DARK : BG_COLOR_LIGHT;
+        this._inner.style.background = hexBgColor;
+      } else if (hasBgColor && !isColorEqual(colors[1], this._prevBgColor)) {
+        this._prevBgColor = colors[1];
+        this._inner.style.background = getCSSColor(colors[1]);
+      }
     }
 
     if (this._text.textContent !== marker.text) {


### PR DESCRIPTION
- Allow text markers to specify background and text colors with `colors` field so that the text can be more readable. 
- Add `autoBackgroundColor` prop to `Text` in order to automatically add high-contrast background color
 
![bag](https://user-images.githubusercontent.com/10999093/52684011-9307b100-2ef9-11e9-92c6-d6cc75fab8f8.gif)

