### PR TITLE
Increase the editor height on the Worldview homepage a bit

### DIFF
--- a/docs/src/Demo.js
+++ b/docs/src/Demo.js
@@ -82,7 +82,7 @@ const HelloWorldview = () => {
         </div>
       </Container>
       <WorldviewCodeEditor
-        height={700}
+        height={750}
         code={`function HelloWorldview() {
   const n = ${spheresPerAxis};
   const points = [], colors = [];


### PR DESCRIPTION
So that there isn’t any scrolling in the editor there, which is
annoying, especially on mobile devices.

Test plan: verified manually.