### PR TITLE
Shift log to debug, add more info

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,7 @@ module.exports = {
   rules: {
     curly: "error",
     "prettier/prettier": "error",
-    "no-console": ["error", { allow: ["warn", "error"] }],
+    "no-console": ["error", { allow: ["warn", "error", "debug"] }],
     "no-unused-vars": ["error", { args: "none", varsIgnorePattern: "^_" }],
     "flowtype/no-unused-expressions": "error",
     "no-underscore-dangle": ["error", { allowAfterThis: true }],

--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -286,7 +286,7 @@ export class WorldviewContext {
     sortedDrawCalls.forEach((drawInput: DrawInput) => {
       const { command, drawProps, instance } = drawInput;
       if (!drawProps) {
-        return console.warn(`${isHitmap ? "hitmap" : ""} draw skipped, props was falsy`);
+        return console.debug(`${isHitmap ? "hitmap" : ""} draw skipped, props was falsy`, drawInput);
       }
       const cmd = this._compiled.get(command);
       if (!cmd) {


### PR DESCRIPTION
We get thousands of these `hitmap draw skipped, props was falsy` log statements as this fires constantly and they're more or less useless without any info.  I think by default this should be set to `debug` or this log should be removed completely as falsy hitmap draw props don't cause issues.