### PR TITLE
Bind raycast

### DIFF
--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -182,7 +182,7 @@ export class WorldviewContext {
     this.dimension = dimension;
   }
 
-  raycast(canvasX: number, canvasY: number) {
+  raycast = (canvasX: number, canvasY: number) => {
     if (!this.initializedData) {
       return undefined;
     }
@@ -194,7 +194,7 @@ export class WorldviewContext {
       width,
       height,
     });
-  }
+  };
 
   paint() {
     const start = Date.now();


### PR DESCRIPTION
encountered a bug where calling `raycast` from [react-dnd](https://github.com/react-dnd/react-dnd) had `this` as undefined.

wonder if it's a good idea to bind this to all of these class functions or if we're comfortable with just doing it for `raycast` for now.