### PR TITLE
Fix CodeSandbox link for landing page

### DIFF
--- a/docs/src/Demo.js
+++ b/docs/src/Demo.js
@@ -83,7 +83,9 @@ const HelloWorldview = () => {
       </Container>
       <WorldviewCodeEditor
         height={750}
-        code={`function HelloWorldview() {
+        componentName="HelloWorld"
+        code={`
+function Example() {
   const n = ${spheresPerAxis};
   const points = [], colors = [];
   for (let x = 0; x < n; x++) {
@@ -120,6 +122,9 @@ const HelloWorldview = () => {
     </Worldview>
   );
 }`}
+        nonEditableCode={`
+import React from 'react';
+import { Worldview, Spheres } from 'regl-worldview'`}
       />
     </React.Fragment>
   );


### PR DESCRIPTION
The CodeSandbox link on the landing page was broken. Fixed by adding the right props.

Before: https://codesandbox.io/s/140519qkjl 
Fixed: https://codesandbox.io/s/yj2308xr5z 