### PR TITLE
Amend FilledPolygon color type

### DIFF
--- a/docs/src/jsx/FilledPolygons.js
+++ b/docs/src/jsx/FilledPolygons.js
@@ -23,7 +23,7 @@ function Example() {
   const polygons = [
     {
       points: vertices,
-      color: [1 - range * 0.5, range, 1, 1 - range * 0.3],
+      color: { r: 1 - range * 0.5, g: range, b: 1, a: 1 - range * 0.3 },
       id: 1,
     },
   ];

--- a/packages/regl-worldview/src/commands/FilledPolygons.js
+++ b/packages/regl-worldview/src/commands/FilledPolygons.js
@@ -58,7 +58,7 @@ export default function FilledPolygons({ children: polygons = [], getHitmapId, .
       ...restOfMarker,
       points: polyPoints,
       pose,
-      color: { r: color[0], g: color[1], b: color[2], a: color[3] },
+      color,
       scale: DEFAULT_SCALE,
     });
   }

--- a/packages/regl-worldview/src/types/index.js
+++ b/packages/regl-worldview/src/types/index.js
@@ -188,6 +188,7 @@ export type TriangleList = BaseShape & {
 
 export type PolygonType = BaseShape & {
   points: Point[],
+  color: Color,
   id: number,
 };
 


### PR DESCRIPTION
I should have added this update to my [previous PR](https://github.com/cruise-automation/webviz/pull/86) after realizing that `FilledPolygons` should probably use the shared `Color` type that the reset of the markers use. 

@robin-pham we don't have any dependencies on `FilledPolygons` elsewhere do we?