### PR TITLE
Fix Overlay so it doesn't flow outside of Worldview by default 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,8 @@
   "javascript.validate.enable": false,
   "files.associations": {
     "*.mdx": "markdown"
+  },
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": false
   }
 }

--- a/docs/src/3.1.Worldview.mdx
+++ b/docs/src/3.1.Worldview.mdx
@@ -2,21 +2,22 @@
 
 ## Props
 
-| Name                  | Type                    | Default                | Description                                                                                             |
-| --------------------- | ----------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------- |
-| `cameraState`         | `$Shape<CameraState>`   |                        | control the [cameraState](#/docs/api/camera), must use with `onCameraStateChange`                       |
-| `onCameraStateChange` | `(CameraState) => void` |                        | callback whenever the camera state changes                                                              |
-| `defaultCameraState`  | `$Shape<CameraState>`   | `DEFAULT_CAMERA_STATE` | pass in this prop to turn Worldview to an uncontrolled component. `onCameraStateChange` will be ignored |
-| `keyMap`              | `CameraKeyMap`          | {}                     | override default Worldview hotkeys                                                                      |
-| `backgroundColor`     | `Vec4`                  | `[0,0,0,1]`            | change the scene background color                                                                       |
-| `hitmapOnMouseMove`   | `boolean`               |                        | if enabled, the clicked objectId will be returned from the mouse event handler                          |
-| `children`            | `React.Node`            |                        | regl components to render inside the Worldview                                                          |
-| `showDebug`           | `boolean`               |                        | show debug information                                                                                  |
-| `onDoubleClick`       | `MouseHandler`          |                        |                                                                                                         |
-| `onMouseDown`         | `MouseHandler`          |                        |                                                                                                         |
-| `onMouseUp`           | `MouseHandler`          |                        |                                                                                                         |
-| `onMouseMove`         | `MouseHandler`          |                        |                                                                                                         |
-| `onClick`             | `MouseHandler`          |                        |                                                                                                         |
+| Name                  | Type                                            | Default                | Description                                                                                             |
+| --------------------- | ----------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| `cameraState`         | `$Shape<CameraState>`                           |                        | control the [cameraState](#/docs/api/camera), must use with `onCameraStateChange`                       |
+| `onCameraStateChange` | `(CameraState) => void`                         |                        | callback whenever the camera state changes                                                              |
+| `defaultCameraState`  | `$Shape<CameraState>`                           | `DEFAULT_CAMERA_STATE` | pass in this prop to turn Worldview to an uncontrolled component. `onCameraStateChange` will be ignored |
+| `keyMap`              | `CameraKeyMap`                                  | {}                     | override default Worldview hotkeys                                                                      |
+| `backgroundColor`     | `Vec4`                                          | `[0,0,0,1]`            | change the scene background color                                                                       |
+| `hitmapOnMouseMove`   | `boolean`                                       |                        | if enabled, the clicked objectId will be returned from the mouse event handler                          |
+| `children`            | `React.Node`                                    |                        | regl components to render inside the Worldview                                                          |
+| `style`               | `{ [styleAttribute: string]: number | string }` | {}                     | html style object for the Worldview root element                                                        |
+| `showDebug`           | `boolean`                                       |                        | show debug information                                                                                  |
+| `onDoubleClick`       | `MouseHandler`                                  |                        |                                                                                                         |
+| `onMouseDown`         | `MouseHandler`                                  |                        |                                                                                                         |
+| `onMouseUp`           | `MouseHandler`                                  |                        |                                                                                                         |
+| `onMouseMove`         | `MouseHandler`                                  |                        |                                                                                                         |
+| `onClick`             | `MouseHandler`                                  |                        |                                                                                                         |
 
 _All props are optional._
 

--- a/docs/src/jsx/Hitmap.js
+++ b/docs/src/jsx/Hitmap.js
@@ -7,7 +7,7 @@
 // #BEGIN EXAMPLE
 import React, { useState } from "react";
 
-import Worldview, { Axes, Cubes, DEFAULT_CAMERA_STATE, getCSSColor, Overlay, Spheres } from "regl-worldview";
+import Worldview, { Axes, Cubes, DEFAULT_CAMERA_STATE, Overlay, Spheres, getCSSColor } from "regl-worldview";
 
 // #BEGIN EDITABLE
 function Example() {
@@ -135,62 +135,59 @@ function Example() {
   }
 
   return (
-    <div style={{ width: 400, height: 300, backgroundColor: "gray", padding: 16 }}>
-      <div style={{ width: 300, height: 40, background: "red" }} />
-      <Worldview
-        cameraState={cameraState}
-        onCameraStateChange={(cameraState) => {
-          setCameraState(cameraState);
-        }}
-        onClick={(e, arg) => {
-          if (clickedId === arg.objectId) {
-            setClickedId(undefined);
-          } else {
-            setClickedId(arg.objectId);
+    <Worldview
+      cameraState={cameraState}
+      onCameraStateChange={(cameraState) => {
+        setCameraState(cameraState);
+      }}
+      onClick={(e, arg) => {
+        if (clickedId === arg.objectId) {
+          setClickedId(undefined);
+        } else {
+          setClickedId(arg.objectId);
+        }
+      }}>
+      <Cubes getHitmapId={getHitmapId}>{cubes}</Cubes>
+      <Spheres getHitmapId={getHitmapId}>{spheres}</Spheres>
+      <Overlay
+        renderItem={({ item, coordinates, dimension: { width, height } }) => {
+          if (!coordinates) {
+            return null;
           }
-        }}>
-        <Cubes getHitmapId={getHitmapId}>{cubes}</Cubes>
-        <Spheres getHitmapId={getHitmapId}>{spheres}</Spheres>
-        <Overlay
-          renderItem={({ item, coordinates, dimension: { width, height } }) => {
-            if (!coordinates) {
-              return null;
-            }
-            const [left, top] = coordinates;
-            if (left < -10 || top < -10 || left > width + 10 || top > height + 10) {
-              return null; // Don't render anything that's too far outside of the canvas
-            }
+          const [left, top] = coordinates;
+          if (left < -10 || top < -10 || left > width + 10 || top > height + 10) {
+            return null; // Don't render anything that's too far outside of the canvas
+          }
 
-            const {
-              text,
-              info: { color, title },
-            } = item;
-            return (
-              <div
-                key={item.id}
-                style={{
-                  transform: `translate(${left.toFixed()}px,${top.toFixed()}px)`,
-                  flexDirection: "column",
-                  position: "absolute",
-                  background: "rgba(0, 0, 0, 0.8)",
-                  color: "white",
-                  maxWidth: 250,
-                  pointerEvents: "none",
-                  willChange: "transform",
-                  fontSize: 12,
-                  padding: 8,
-                  whiteSpace: "pre-line",
-                }}>
-                <div style={{ color: getCSSColor(color) }}>{title}</div>
-                <div>{text}</div>
-              </div>
-            );
-          }}>
-          {textMarkers}
-        </Overlay>
-        <Axes />
-      </Worldview>
-    </div>
+          const {
+            text,
+            info: { color, title },
+          } = item;
+          return (
+            <div
+              key={item.id}
+              style={{
+                transform: `translate(${left.toFixed()}px,${top.toFixed()}px)`,
+                flexDirection: "column",
+                position: "absolute",
+                background: "rgba(0, 0, 0, 0.8)",
+                color: "white",
+                maxWidth: 250,
+                pointerEvents: "none",
+                willChange: "transform",
+                fontSize: 12,
+                padding: 8,
+                whiteSpace: "pre-line",
+              }}>
+              <div style={{ color: getCSSColor(color) }}>{title}</div>
+              <div>{text}</div>
+            </div>
+          );
+        }}>
+        {textMarkers}
+      </Overlay>
+      <Axes />
+    </Worldview>
   );
 }
 // #END EXAMPLE

--- a/docs/src/jsx/Hitmap.js
+++ b/docs/src/jsx/Hitmap.js
@@ -7,7 +7,7 @@
 // #BEGIN EXAMPLE
 import React, { useState } from "react";
 
-import Worldview, { Axes, Cubes, DEFAULT_CAMERA_STATE, Overlay, Spheres, getCSSColor } from "regl-worldview";
+import Worldview, { Axes, Cubes, DEFAULT_CAMERA_STATE, getCSSColor, Overlay, Spheres } from "regl-worldview";
 
 // #BEGIN EDITABLE
 function Example() {
@@ -135,59 +135,62 @@ function Example() {
   }
 
   return (
-    <Worldview
-      cameraState={cameraState}
-      onCameraStateChange={(cameraState) => {
-        setCameraState(cameraState);
-      }}
-      onClick={(e, arg) => {
-        if (clickedId === arg.objectId) {
-          setClickedId(undefined);
-        } else {
-          setClickedId(arg.objectId);
-        }
-      }}>
-      <Cubes getHitmapId={getHitmapId}>{cubes}</Cubes>
-      <Spheres getHitmapId={getHitmapId}>{spheres}</Spheres>
-      <Overlay
-        renderItem={({ item, coordinates, dimension: { width, height } }) => {
-          if (!coordinates) {
-            return null;
+    <div style={{ width: 400, height: 300, backgroundColor: "gray", padding: 16 }}>
+      <div style={{ width: 300, height: 40, background: "red" }} />
+      <Worldview
+        cameraState={cameraState}
+        onCameraStateChange={(cameraState) => {
+          setCameraState(cameraState);
+        }}
+        onClick={(e, arg) => {
+          if (clickedId === arg.objectId) {
+            setClickedId(undefined);
+          } else {
+            setClickedId(arg.objectId);
           }
-          const [left, top] = coordinates;
-          if (left < -10 || top < -10 || left > width + 10 || top > height + 10) {
-            return null; // Don't render anything that's too far outside of the canvas
-          }
-
-          const {
-            text,
-            info: { color, title },
-          } = item;
-          return (
-            <div
-              key={item.id}
-              style={{
-                transform: `translate(${left.toFixed()}px,${top.toFixed()}px)`,
-                flexDirection: "column",
-                position: "absolute",
-                background: "rgba(0, 0, 0, 0.8)",
-                color: "white",
-                maxWidth: 250,
-                pointerEvents: "none",
-                willChange: "transform",
-                fontSize: 12,
-                padding: 8,
-                whiteSpace: "pre-line",
-              }}>
-              <div style={{ color: getCSSColor(color) }}>{title}</div>
-              <div>{text}</div>
-            </div>
-          );
         }}>
-        {textMarkers}
-      </Overlay>
-      <Axes />
-    </Worldview>
+        <Cubes getHitmapId={getHitmapId}>{cubes}</Cubes>
+        <Spheres getHitmapId={getHitmapId}>{spheres}</Spheres>
+        <Overlay
+          renderItem={({ item, coordinates, dimension: { width, height } }) => {
+            if (!coordinates) {
+              return null;
+            }
+            const [left, top] = coordinates;
+            if (left < -10 || top < -10 || left > width + 10 || top > height + 10) {
+              return null; // Don't render anything that's too far outside of the canvas
+            }
+
+            const {
+              text,
+              info: { color, title },
+            } = item;
+            return (
+              <div
+                key={item.id}
+                style={{
+                  transform: `translate(${left.toFixed()}px,${top.toFixed()}px)`,
+                  flexDirection: "column",
+                  position: "absolute",
+                  background: "rgba(0, 0, 0, 0.8)",
+                  color: "white",
+                  maxWidth: 250,
+                  pointerEvents: "none",
+                  willChange: "transform",
+                  fontSize: 12,
+                  padding: 8,
+                  whiteSpace: "pre-line",
+                }}>
+                <div style={{ color: getCSSColor(color) }}>{title}</div>
+                <div>{text}</div>
+              </div>
+            );
+          }}>
+          {textMarkers}
+        </Overlay>
+        <Axes />
+      </Worldview>
+    </div>
   );
 }
 // #END EXAMPLE

--- a/docs/src/jsx/Overlay.js
+++ b/docs/src/jsx/Overlay.js
@@ -42,7 +42,7 @@ function Example() {
   return (
     <div style={{ width: 400, height: 400, margin: 20, background: "#1e1e27", display: "block", position: "relative" }}>
       <button style={{ position: "absolute", zIndex: 10001 }} onClick={() => setOverflowVisible(!overflowVisible)}>
-        {overflowVisible ? "Clip overflow" : "Show overflow"}
+        {overflowVisible ? "Overflow visible" : "Overflow clipped"}
       </button>
       <Worldview style={{ width: 360, height: 320, overflow: overflowVisible ? "visible" : "hidden" }}>
         <Spheres>{sphereMarkers}</Spheres>

--- a/docs/src/jsx/Overlay.js
+++ b/docs/src/jsx/Overlay.js
@@ -5,14 +5,15 @@
 //  You may not use this file except in compliance with the License.
 
 // #BEGIN EXAMPLE
-import React from "react";
+import React, { useState } from "react";
 
 import useRange from "./utils/useRange";
-import Worldview, { Overlay, Spheres, Axes } from "regl-worldview";
+import Worldview, { Axes, Overlay, Spheres } from "regl-worldview";
 
 // #BEGIN EDITABLE
 function Example() {
   const range = useRange();
+  const [overflowVisible, setOverflowVisible] = useState(false);
   const marker = {
     pose: {
       orientation: { x: 0, y: 0, z: 0, w: 1 },
@@ -39,56 +40,61 @@ function Example() {
   }));
 
   return (
-    <Worldview>
-      <Spheres>{sphereMarkers}</Spheres>
-      <Overlay
-        renderItem={({ item, coordinates, index, dimension: { width, height } }) => {
-          if (!coordinates) {
-            return null;
-          }
-          const [left, top] = coordinates;
-          if (left < -10 || top < -10 || left > width + 10 || top > height + 10) {
-            return null; // Don't render anything that's too far outside of the canvas
-          }
-          const {
-            text,
-            info: { title },
-          } = item;
-          return (
-            <div
-              key={index}
-              style={{
-                transform: `translate(${left.toFixed()}px,${top.toFixed()}px)`,
-                flexDirection: "column",
-                position: "absolute",
-                background: "rgba(0, 0, 0, 0.8)",
-                color: "white",
-                maxWidth: 250,
-                pointerEvents: "none",
-                willChange: "transform",
-                fontSize: 12,
-                padding: 8,
-                whiteSpace: "pre-line",
-                top: 0,
-                left: 0,
-              }}>
-              <div>{title}</div>
-              <div>{text}</div>
-              <a
-                style={{ pointerEvents: "visible" }}
-                href="http://www.getcruise.com"
-                target="_blank"
-                rel="noopener noreferrer">
-                custom link
-              </a>
-              <div>range: {range.toFixed(2)}</div>
-            </div>
-          );
-        }}>
-        {textMarkers}
-      </Overlay>
-      <Axes />
-    </Worldview>
+    <div style={{ width: 400, height: 400, margin: 20, background: "#1e1e27", display: "block", position: "relative" }}>
+      <button style={{ position: "absolute", zIndex: 10001 }} onClick={() => setOverflowVisible(!overflowVisible)}>
+        {overflowVisible ? "Clip overflow" : "Show overflow"}
+      </button>
+      <Worldview style={{ width: 360, height: 320, overflow: overflowVisible ? "visible" : "hidden" }}>
+        <Spheres>{sphereMarkers}</Spheres>
+        <Overlay
+          renderItem={({ item, coordinates, index, dimension: { width, height } }) => {
+            if (!coordinates) {
+              return null;
+            }
+            const [left, top] = coordinates;
+            if (left < -10 || top < -10 || left > width + 10 || top > height + 10) {
+              return null; // Don't render anything that's too far outside of the canvas
+            }
+            const {
+              text,
+              info: { title },
+            } = item;
+            return (
+              <div
+                key={index}
+                style={{
+                  transform: `translate(${left.toFixed()}px,${top.toFixed()}px)`,
+                  flexDirection: "column",
+                  position: "absolute",
+                  background: "rgba(0, 0, 0, 0.8)",
+                  color: "white",
+                  maxWidth: 250,
+                  pointerEvents: "none",
+                  willChange: "transform",
+                  fontSize: 12,
+                  padding: 8,
+                  whiteSpace: "pre-line",
+                  top: 0,
+                  left: 0,
+                }}>
+                <div>{title}</div>
+                <div>{text}</div>
+                <a
+                  style={{ pointerEvents: "visible" }}
+                  href="http://www.getcruise.com"
+                  target="_blank"
+                  rel="noopener noreferrer">
+                  custom link
+                </a>
+                <div>range: {range.toFixed(2)}</div>
+              </div>
+            );
+          }}>
+          {textMarkers}
+        </Overlay>
+        <Axes />
+      </Worldview>
+    </div>
   );
 }
 // #END EXAMPLE

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -27,6 +27,7 @@ export type BaseProps = {|
   hitmapOnMouseMove?: boolean,
   showDebug?: boolean,
   children?: React.Node,
+  style: { [styleAttribute: string]: number | string },
 
   cameraState?: CameraState,
   onCameraStateChange?: (CameraState) => void,
@@ -71,6 +72,7 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
 
   static defaultProps = {
     backgroundColor: DEFAULT_BACKGROUND_COLOR,
+    style: {},
   };
 
   constructor(props: BaseProps) {
@@ -249,15 +251,14 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
   }
 
   render() {
-    const { width, height, showDebug, keyMap } = this.props;
+    const { width, height, showDebug, keyMap, style } = this.props;
     const { worldviewContext } = this.state;
-    const style = { width, height };
 
     return (
-      <React.Fragment>
+      <div style={{ position: "relative", overflow: "visible", ...style }}>
         <CameraListener cameraStore={worldviewContext.cameraStore} keyMap={keyMap}>
           <canvas
-            style={style}
+            style={{ width, height }}
             width={width}
             height={height}
             ref={this._canvas}
@@ -274,7 +275,7 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
             {this.props.children}
           </WorldviewReactContext.Provider>
         )}
-      </React.Fragment>
+      </div>
     );
   }
 }

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -255,10 +255,10 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     const { worldviewContext } = this.state;
 
     return (
-      <div style={{ position: "relative", overflow: "visible", ...style }}>
+      <div style={{ position: "relative", overflow: "hidden", ...style }}>
         <CameraListener cameraStore={worldviewContext.cameraStore} keyMap={keyMap}>
           <canvas
-            style={{ width, height }}
+            style={{ width, height, maxWidth: "100%", maxHeight: "100%" }}
             width={width}
             height={height}
             ref={this._canvas}

--- a/packages/regl-worldview/src/commands/GLTFScene.js
+++ b/packages/regl-worldview/src/commands/GLTFScene.js
@@ -9,10 +9,11 @@
 import { mat4 } from "gl-matrix";
 import React from "react";
 
-import { blend, pointToVec3, orientationToVec4 } from "../utils/commandUtils";
+import type { Pose, Scale } from "../types";
+import { blend, orientationToVec4, pointToVec3 } from "../utils/commandUtils";
 import parseGLB from "../utils/parseGLB";
-
-import { Command, type Pose, type Scale, WorldviewReactContext } from "..";
+import WorldviewReactContext from "../WorldviewReactContext";
+import Command from "./Command";
 
 function glConstantToRegl(value: ?number): ?string {
   if (value === undefined) {


### PR DESCRIPTION
## The Problem
The Overlay sometimes go over the Worldview main container which is not the expected behavior: [Codesandbox](https://codesandbox.io/s/nwzr8o3wll?fontsize=14)
![image](https://user-images.githubusercontent.com/10999093/53308104-515cfb80-3853-11e9-9c9f-abae4a05df58.png)

The main cause is that we are using `React.Fragment` as the root container for Worldview, and it doesn't have any styling. When the Overlay gets rendered, it'll be at the same level as Worldview. 

## The Fix 
Use `div` instead of `React.Fragment` for Worldview root container and add default `relative` positioning so the Overlay will be positioned correctly relative it's parent. I also add `style` prop to allow consumer to add more custom styling to the root container. 

![screen shot 2019-02-24 at 4 17 04 pm](https://user-images.githubusercontent.com/10999093/53308240-625a3c80-3854-11e9-99c2-d135a5c3aa54.png)

## Test 
Manually test the Hitmap and Overlay examples to make sure the content doesn't overflow the container. 