### PR TITLE
Amend FilledPolygon types

### DIFF
--- a/docs/src/4.5.FilledPolygons.mdx
+++ b/docs/src/4.5.FilledPolygons.mdx
@@ -28,8 +28,8 @@ type FilledPolygon = {
     g: number, // between 0 and 1
     b: number, // between 0 and 1
     a: number, // between 0 and 1
-  },
-  points:[{ x: number, y: number, z: number }],
+  } | [number, number, number, number],
+  points: [{ x: number, y: number, z: number } | [number, number, number]],
   id: number,
 }
 ```

--- a/docs/src/jsx/FilledPolygons.js
+++ b/docs/src/jsx/FilledPolygons.js
@@ -23,7 +23,7 @@ function Example() {
   const polygons = [
     {
       points: vertices,
-      color: [1 - range * 0.5, range, 1, 1 - range * 0.3],
+      color: { r: 1 - range * 0.5, g: range, b: 1, a: 1 - range * 0.3 },
       id: 1,
     },
   ];

--- a/packages/regl-worldview/src/commands/FilledPolygons.js
+++ b/packages/regl-worldview/src/commands/FilledPolygons.js
@@ -9,7 +9,8 @@
 import earcut from "earcut";
 import React from "react";
 
-import type { Vec3, Point, PolygonType, TriangleList } from "../types";
+import type { Vec3, PolygonType, TriangleList } from "../types";
+import { shouldConvert, pointToVec3 } from "../utils/commandUtils";
 import Triangles from "./Triangles";
 
 const NO_POSE = {
@@ -50,15 +51,13 @@ type Props = {
 export default function FilledPolygons({ children: polygons = [], getHitmapId, ...props }: Props) {
   const triangles = [];
   for (const poly of polygons) {
-    const { points, color, ...restOfMarker } = poly;
+    const points = shouldConvert(poly.points) ? poly.points.map(pointToVec3) : poly.points;
     const pose = poly.pose ? poly.pose : NO_POSE;
-    const earcutPoints: Vec3[] = getEarcutPoints(points.map(({ x, y, z }) => [x, y, z]));
-    const polyPoints: Point[] = earcutPoints.map(([x, y, z]) => ({ x, y, z }));
+    const earcutPoints: Vec3[] = getEarcutPoints(points);
     triangles.push({
-      ...restOfMarker,
-      points: polyPoints,
+      ...poly,
+      points: earcutPoints,
       pose,
-      color,
       scale: DEFAULT_SCALE,
     });
   }

--- a/packages/regl-worldview/src/commands/FilledPolygons.js
+++ b/packages/regl-worldview/src/commands/FilledPolygons.js
@@ -51,7 +51,8 @@ type Props = {
 export default function FilledPolygons({ children: polygons = [], getHitmapId, ...props }: Props) {
   const triangles = [];
   for (const poly of polygons) {
-    const points = shouldConvert(poly.points) ? poly.points.map(pointToVec3) : poly.points;
+    // $FlowFixMe flow doesn't know how shouldConvert works
+    const points: Vec3[] = shouldConvert(poly.points) ? poly.points.map(pointToVec3) : poly.points;
     const pose = poly.pose ? poly.pose : NO_POSE;
     const earcutPoints: Vec3[] = getEarcutPoints(points);
     triangles.push({

--- a/packages/regl-worldview/src/commands/FilledPolygons.js
+++ b/packages/regl-worldview/src/commands/FilledPolygons.js
@@ -58,7 +58,7 @@ export default function FilledPolygons({ children: polygons = [], getHitmapId, .
       ...restOfMarker,
       points: polyPoints,
       pose,
-      color: { r: color[0], g: color[1], b: color[2], a: color[3] },
+      color,
       scale: DEFAULT_SCALE,
     });
   }

--- a/packages/regl-worldview/src/types/index.js
+++ b/packages/regl-worldview/src/types/index.js
@@ -188,7 +188,7 @@ export type TriangleList = BaseShape & {
 
 export type PolygonType = BaseShape & {
   points: Point[],
-  color: Color,
+  color: Color | Vec4,
   id: number,
 };
 

--- a/packages/regl-worldview/src/types/index.js
+++ b/packages/regl-worldview/src/types/index.js
@@ -187,7 +187,7 @@ export type TriangleList = BaseShape & {
 };
 
 export type PolygonType = BaseShape & {
-  points: Point[],
+  points: (Point | Vec3)[],
   color: Color | Vec4,
   id: number,
 };

--- a/packages/regl-worldview/src/types/index.js
+++ b/packages/regl-worldview/src/types/index.js
@@ -188,6 +188,7 @@ export type TriangleList = BaseShape & {
 
 export type PolygonType = BaseShape & {
   points: Point[],
+  color: Color,
   id: number,
 };
 


### PR DESCRIPTION
This continues @troygibb's work from https://github.com/cruise-automation/webviz/pull/91. 

After some discussion we realized that the FilledPolygon component should be able to support both formats for both color and points, the former of which already works.