### PR TITLE
🧬🐛 BaseShape optional id property issue

### DIFF
--- a/packages/regl-worldview/src/types/index.js
+++ b/packages/regl-worldview/src/types/index.js
@@ -160,7 +160,7 @@ export type BaseShape = {
   id?: number,
   pose: Pose,
   scale: Scale,
-  color: Color,
+  color: Color | Vec4,
 };
 
 export type Arrow = BaseShape & {
@@ -192,7 +192,6 @@ export type TriangleList = BaseShape & {
 
 export type PolygonType = BaseShape & {
   points: (Point | Vec3)[],
-  color: Color | Vec4,
 };
 
 export type MouseEventEnum = "onClick" | "onMouseUp" | "onMouseMove" | "onMouseDown" | "onDoubleClick";

--- a/packages/regl-worldview/src/types/index.js
+++ b/packages/regl-worldview/src/types/index.js
@@ -193,7 +193,6 @@ export type TriangleList = BaseShape & {
 export type PolygonType = BaseShape & {
   points: (Point | Vec3)[],
   color: Color | Vec4,
-  id: number,
 };
 
 export type MouseEventEnum = "onClick" | "onMouseUp" | "onMouseMove" | "onMouseDown" | "onDoubleClick";


### PR DESCRIPTION
I am not sure this is the right approach here but it seems like optional subtype property `id` is not a thing flow accept. (https://github.com/facebook/flow/issues/3866)

We ran into problem while updating Worldview.
