### PR TITLE
Add documentation for pose

### DIFF
--- a/docs/src/3.7.Glossary.mdx
+++ b/docs/src/3.7.Glossary.mdx
@@ -2,7 +2,7 @@
 
 ## Pose
 
-In computer vision and robotics, the **POSE** determines the _position_ and _orientation_ of the specific object in the 3D space. It describes how to bring the target object from a reference pose to the observed pose through translation and rotation. e.g. the pose of A with position `{ x: 1, y: 1, z: 1 }` and orientation `{ x: 0, y: 0, z: 0, w: 1 }` is given by the translation from origin to A's position, and the rotation of A's orientation. The data format follows ROS's [Pose Message](http://docs.ros.org/lunar/api/geometry_msgs/html/msg/Pose.html) definition where position is a point with xyz coordinates and orientation is a [quaternion](https://en.wikipedia.org/wiki/Quaternion).
+In computer vision and robotics, the **Pose** determines the _position_ and _orientation_ of the specific object in the 3D space ([wiki](<https://en.wikipedia.org/wiki/Pose_(computer_vision)>)). It describes how to bring the target object from a reference pose to the observed pose through translation and rotation. e.g. the pose of A with position `{ x: 1, y: 1, z: 1 }` and orientation `{ x: 0, y: 0, z: 0, w: 1 }` is given by the translation from origin to A's position, and the rotation of A's orientation. The data format follows ROS's [Pose Message](http://docs.ros.org/lunar/api/geometry_msgs/html/msg/Pose.html) definition where position is a point with xyz coordinates and orientation is a [quaternion](https://en.wikipedia.org/wiki/Quaternion).
 
 ```js
 type pose = {

--- a/docs/src/3.7.Glossary.mdx
+++ b/docs/src/3.7.Glossary.mdx
@@ -1,0 +1,12 @@
+# Glossary
+
+## Pose
+
+In computer vision and robotics, the **POSE** determines the _position_ and _orientation_ of the specific object in the 3D space. It describes how to bring the target object from a reference pose to the observed pose through translation and rotation. e.g. the pose of A with position `{ x: 1, y: 1, z: 1 }` and orientation `{ x: 0, y: 0, z: 0, w: 1 }` is given by the translation from origin to A's position, and the rotation of A's orientation. The data format follows ROS's [Pose Message](http://docs.ros.org/lunar/api/geometry_msgs/html/msg/Pose.html) definition where position is a point with xyz coordinates and orientation is a [quaternion](https://en.wikipedia.org/wiki/Quaternion).
+
+```js
+type pose = {
+  position: { x: number, y: number, z: number },
+  orientation: { x: number, y: number, z: number, w: number }, // quaternion
+};
+```

--- a/docs/src/routes.js
+++ b/docs/src/routes.js
@@ -15,6 +15,7 @@ import Command from "./3.3.Command.mdx";
 import MouseEvents from "./3.4.MouseEvents.mdx";
 import Flow from "./3.5.FlowTypes.mdx";
 import BrowserSupport from "./3.6.BrowserSupport.mdx";
+import Glossary from "./3.7.Glossary.mdx";
 import Arrows from "./4.1.Arrows.mdx";
 import Text from "./4.10.Text.mdx";
 import Triangles from "./4.11.Triangles.mdx";
@@ -52,6 +53,7 @@ export const componentList = {
   Flow,
   GLTFScene,
   BrowserSupport,
+  Glossary,
 };
 
 const ROUTE_CONFIG = [
@@ -62,7 +64,7 @@ const ROUTE_CONFIG = [
   },
   {
     name: "API",
-    subRouteNames: ["Worldview", "Camera", "Command", "Mouse Events", "Flow", "Browser Support"],
+    subRouteNames: ["Worldview", "Camera", "Command", "Mouse Events", "Flow", "Browser Support", "Glossary"],
   },
   {
     name: "Commands",


### PR DESCRIPTION
## Problem 
There was some confusion around how to handle `pose`. It's unclear that the translation happens before the rotation. 

## Fix
- Add a Glossary section to document different terms
- Add documentation for pose
