### PR TITLE
Use depth by default for triangles

### DIFF
--- a/packages/regl-worldview/src/commands/Triangles.js
+++ b/packages/regl-worldview/src/commands/Triangles.js
@@ -7,7 +7,15 @@
 //  You may not use this file except in compliance with the License.
 
 import type { TriangleList, Regl } from "../types";
-import { blend, getVertexColors, pointToVec3Array, shouldConvert, toRGBA, withPose } from "../utils/commandUtils";
+import {
+  blend,
+  depth,
+  getVertexColors,
+  pointToVec3Array,
+  shouldConvert,
+  toRGBA,
+  withPose,
+} from "../utils/commandUtils";
 import { getHitmapPropsForInstancedCommands, getObjectForInstancedCommands } from "../utils/hitmapDefaults";
 import { makeCommand } from "./Command";
 
@@ -58,9 +66,7 @@ const singleColor = (regl) =>
       },
     },
 
-    // turn off depth to prevent flicker
-    // because multiple items are rendered to the same z plane
-    depth: { enable: true, mask: false },
+    depth,
     blend,
 
     count: (context, props) => props.points.length,

--- a/packages/regl-worldview/src/utils/commandUtils.js
+++ b/packages/regl-worldview/src/utils/commandUtils.js
@@ -98,6 +98,14 @@ export const blend = {
   },
 };
 
+// regl default depth values that can be overridden by props
+export const depth = {
+  enable: (context: Object, props: Object) => (props.depthEnable === false ? false : true),
+  mask: (context: Object, props: Object) => (props.depthMask === false ? false : true),
+  range: (context: Object, props: Object) => props.depthRange || [0, 1],
+  func: (context: Object, props: Object) => props.depthFunc || "less",
+};
+
 // takes a regl command definition object and injects
 // position and rotation from the object pose and also
 // inserts some glsl helpers to apply the pose to points in a fragment shader


### PR DESCRIPTION
Encountered bugs where triangles did not respect depth. I think this `depth` property by default should use the default values that regl uses, and instead can be overridden by the consumer.