### PR TITLE
Don't trigger onClick if mouse moved beyond distance

### DIFF
--- a/docs/src/3.1.Worldview.mdx
+++ b/docs/src/3.1.Worldview.mdx
@@ -2,23 +2,23 @@
 
 ## Props
 
-| Name                  | Type                                            | Default                | Description                                                                                                            |
-| --------------------- | ----------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `cameraState`         | `$Shape<CameraState>`                           |                        | control the [cameraState](#/docs/api/camera), must use with `onCameraStateChange`                                      |
-| `onCameraStateChange` | `(CameraState) => void`                         |                        | callback whenever the camera state changes                                                                             |
-| `defaultCameraState`  | `$Shape<CameraState>`                           | `DEFAULT_CAMERA_STATE` | pass in this prop to turn Worldview to an uncontrolled component. `onCameraStateChange` will be ignored                |
-| `keyMap`              | `CameraKeyMap`                                  | {}                     | override default Worldview hotkeys                                                                                     |
-| `backgroundColor`     | `Vec4`                                          | `[0,0,0,1]`            | change the scene background color                                                                                      |
-| `hitmapOnMouseMove`   | `boolean`                                       |                        | if enabled, the clicked objectId will be returned from the mouse event handler                                         |
-| `children`            | `React.Node`                                    |                        | regl components to render inside the Worldview                                                                         |
-| `style`               | `{ [styleAttribute: string]: number | string }` | {}                     | html style object for the Worldview root element                                                                       |
-| `showDebug`           | `boolean`                                       |                        | show debug information                                                                                                 |
-| `mouseClickRadius`    | `number`                                        | 3                      | if the mouse has moved distance beyond the mouseClickRadius limit, the click event handler isn't going to be triggered |
-| `onDoubleClick`       | `MouseHandler`                                  |                        |                                                                                                                        |
-| `onMouseDown`         | `MouseHandler`                                  |                        |                                                                                                                        |
-| `onMouseUp`           | `MouseHandler`                                  |                        |                                                                                                                        |
-| `onMouseMove`         | `MouseHandler`                                  |                        |                                                                                                                        |
-| `onClick`             | `MouseHandler`                                  |                        |                                                                                                                        |
+| Name                  | Type                                            | Default                | Description                                                                                                                                           |
+| --------------------- | ----------------------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cameraState`         | `$Shape<CameraState>`                           |                        | control the [cameraState](#/docs/api/camera), must use with `onCameraStateChange`                                                                     |
+| `onCameraStateChange` | `(CameraState) => void`                         |                        | callback whenever the camera state changes                                                                                                            |
+| `defaultCameraState`  | `$Shape<CameraState>`                           | `DEFAULT_CAMERA_STATE` | pass in this prop to turn Worldview to an uncontrolled component. `onCameraStateChange` will be ignored                                               |
+| `keyMap`              | `CameraKeyMap`                                  | {}                     | override default Worldview hotkeys                                                                                                                    |
+| `backgroundColor`     | `Vec4`                                          | `[0,0,0,1]`            | change the scene background color                                                                                                                     |
+| `hitmapOnMouseMove`   | `boolean`                                       |                        | if enabled, the clicked objectId will be returned from the mouse event handler                                                                        |
+| `children`            | `React.Node`                                    |                        | regl components to render inside the Worldview                                                                                                        |
+| `style`               | `{ [styleAttribute: string]: number | string }` | {}                     | html style object for the Worldview root element                                                                                                      |
+| `showDebug`           | `boolean`                                       |                        | show debug information                                                                                                                                |
+| `mouseClickRadius`    | `number`                                        | 3                      | if the mouse has moved a distance (pixels in the screen space) beyond the mouseClickRadius limit, the click event handler isn't going to be triggered |
+| `onDoubleClick`       | `MouseHandler`                                  |                        |                                                                                                                                                       |
+| `onMouseDown`         | `MouseHandler`                                  |                        |                                                                                                                                                       |
+| `onMouseUp`           | `MouseHandler`                                  |                        |                                                                                                                                                       |
+| `onMouseMove`         | `MouseHandler`                                  |                        |                                                                                                                                                       |
+| `onClick`             | `MouseHandler`                                  |                        |                                                                                                                                                       |
 
 _All props are optional._
 

--- a/docs/src/3.1.Worldview.mdx
+++ b/docs/src/3.1.Worldview.mdx
@@ -2,22 +2,23 @@
 
 ## Props
 
-| Name                  | Type                                            | Default                | Description                                                                                             |
-| --------------------- | ----------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------- |
-| `cameraState`         | `$Shape<CameraState>`                           |                        | control the [cameraState](#/docs/api/camera), must use with `onCameraStateChange`                       |
-| `onCameraStateChange` | `(CameraState) => void`                         |                        | callback whenever the camera state changes                                                              |
-| `defaultCameraState`  | `$Shape<CameraState>`                           | `DEFAULT_CAMERA_STATE` | pass in this prop to turn Worldview to an uncontrolled component. `onCameraStateChange` will be ignored |
-| `keyMap`              | `CameraKeyMap`                                  | {}                     | override default Worldview hotkeys                                                                      |
-| `backgroundColor`     | `Vec4`                                          | `[0,0,0,1]`            | change the scene background color                                                                       |
-| `hitmapOnMouseMove`   | `boolean`                                       |                        | if enabled, the clicked objectId will be returned from the mouse event handler                          |
-| `children`            | `React.Node`                                    |                        | regl components to render inside the Worldview                                                          |
-| `style`               | `{ [styleAttribute: string]: number | string }` | {}                     | html style object for the Worldview root element                                                        |
-| `showDebug`           | `boolean`                                       |                        | show debug information                                                                                  |
-| `onDoubleClick`       | `MouseHandler`                                  |                        |                                                                                                         |
-| `onMouseDown`         | `MouseHandler`                                  |                        |                                                                                                         |
-| `onMouseUp`           | `MouseHandler`                                  |                        |                                                                                                         |
-| `onMouseMove`         | `MouseHandler`                                  |                        |                                                                                                         |
-| `onClick`             | `MouseHandler`                                  |                        |                                                                                                         |
+| Name                  | Type                                            | Default                | Description                                                                                                            |
+| --------------------- | ----------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `cameraState`         | `$Shape<CameraState>`                           |                        | control the [cameraState](#/docs/api/camera), must use with `onCameraStateChange`                                      |
+| `onCameraStateChange` | `(CameraState) => void`                         |                        | callback whenever the camera state changes                                                                             |
+| `defaultCameraState`  | `$Shape<CameraState>`                           | `DEFAULT_CAMERA_STATE` | pass in this prop to turn Worldview to an uncontrolled component. `onCameraStateChange` will be ignored                |
+| `keyMap`              | `CameraKeyMap`                                  | {}                     | override default Worldview hotkeys                                                                                     |
+| `backgroundColor`     | `Vec4`                                          | `[0,0,0,1]`            | change the scene background color                                                                                      |
+| `hitmapOnMouseMove`   | `boolean`                                       |                        | if enabled, the clicked objectId will be returned from the mouse event handler                                         |
+| `children`            | `React.Node`                                    |                        | regl components to render inside the Worldview                                                                         |
+| `style`               | `{ [styleAttribute: string]: number | string }` | {}                     | html style object for the Worldview root element                                                                       |
+| `showDebug`           | `boolean`                                       |                        | show debug information                                                                                                 |
+| `mouseClickRadius`    | `number`                                        | 3                      | if the mouse has moved distance beyond the mouseClickRadius limit, the click event handler isn't going to be triggered |
+| `onDoubleClick`       | `MouseHandler`                                  |                        |                                                                                                                        |
+| `onMouseDown`         | `MouseHandler`                                  |                        |                                                                                                                        |
+| `onMouseUp`           | `MouseHandler`                                  |                        |                                                                                                                        |
+| `onMouseMove`         | `MouseHandler`                                  |                        |                                                                                                                        |
+| `onClick`             | `MouseHandler`                                  |                        |                                                                                                                        |
 
 _All props are optional._
 

--- a/docs/src/3.1.Worldview.mdx
+++ b/docs/src/3.1.Worldview.mdx
@@ -2,23 +2,22 @@
 
 ## Props
 
-| Name                  | Type                                            | Default                | Description                                                                                                                                           |
-| --------------------- | ----------------------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cameraState`         | `$Shape<CameraState>`                           |                        | control the [cameraState](#/docs/api/camera), must use with `onCameraStateChange`                                                                     |
-| `onCameraStateChange` | `(CameraState) => void`                         |                        | callback whenever the camera state changes                                                                                                            |
-| `defaultCameraState`  | `$Shape<CameraState>`                           | `DEFAULT_CAMERA_STATE` | pass in this prop to turn Worldview to an uncontrolled component. `onCameraStateChange` will be ignored                                               |
-| `keyMap`              | `CameraKeyMap`                                  | {}                     | override default Worldview hotkeys                                                                                                                    |
-| `backgroundColor`     | `Vec4`                                          | `[0,0,0,1]`            | change the scene background color                                                                                                                     |
-| `hitmapOnMouseMove`   | `boolean`                                       |                        | if enabled, the clicked objectId will be returned from the mouse event handler                                                                        |
-| `children`            | `React.Node`                                    |                        | regl components to render inside the Worldview                                                                                                        |
-| `style`               | `{ [styleAttribute: string]: number | string }` | {}                     | html style object for the Worldview root element                                                                                                      |
-| `showDebug`           | `boolean`                                       |                        | show debug information                                                                                                                                |
-| `mouseClickRadius`    | `number`                                        | 3                      | if the mouse has moved a distance (pixels in the screen space) beyond the mouseClickRadius limit, the click event handler isn't going to be triggered |
-| `onDoubleClick`       | `MouseHandler`                                  |                        |                                                                                                                                                       |
-| `onMouseDown`         | `MouseHandler`                                  |                        |                                                                                                                                                       |
-| `onMouseUp`           | `MouseHandler`                                  |                        |                                                                                                                                                       |
-| `onMouseMove`         | `MouseHandler`                                  |                        |                                                                                                                                                       |
-| `onClick`             | `MouseHandler`                                  |                        |                                                                                                                                                       |
+| Name                  | Type                                            | Default                | Description                                                                                             |
+| --------------------- | ----------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| `cameraState`         | `$Shape<CameraState>`                           |                        | control the [cameraState](#/docs/api/camera), must use with `onCameraStateChange`                       |
+| `onCameraStateChange` | `(CameraState) => void`                         |                        | callback whenever the camera state changes                                                              |
+| `defaultCameraState`  | `$Shape<CameraState>`                           | `DEFAULT_CAMERA_STATE` | pass in this prop to turn Worldview to an uncontrolled component. `onCameraStateChange` will be ignored |
+| `keyMap`              | `CameraKeyMap`                                  | {}                     | override default Worldview hotkeys                                                                      |
+| `backgroundColor`     | `Vec4`                                          | `[0,0,0,1]`            | change the scene background color                                                                       |
+| `hitmapOnMouseMove`   | `boolean`                                       |                        | if enabled, the clicked objectId will be returned from the mouse event handler                          |
+| `children`            | `React.Node`                                    |                        | regl components to render inside the Worldview                                                          |
+| `style`               | `{ [styleAttribute: string]: number | string }` | {}                     | html style object for the Worldview root element                                                        |
+| `showDebug`           | `boolean`                                       |                        | show debug information                                                                                  |
+| `onDoubleClick`       | `MouseHandler`                                  |                        |                                                                                                         |
+| `onMouseDown`         | `MouseHandler`                                  |                        |                                                                                                         |
+| `onMouseUp`           | `MouseHandler`                                  |                        |                                                                                                         |
+| `onMouseMove`         | `MouseHandler`                                  |                        |                                                                                                         |
+| `onClick`             | `MouseHandler`                                  |                        |                                                                                                         |
 
 _All props are optional._
 

--- a/docs/src/3.4.MouseEvents.mdx
+++ b/docs/src/3.4.MouseEvents.mdx
@@ -75,3 +75,7 @@ Check out below example for automatic/custom hitmap mapping, and regular/instanc
 ## Full Example
 
 <MouseEvents />
+
+## Other
+
+We use `mouseClickRadius` prop to determine if mouseClick event is going to be triggered, specificially if the mouse has moved beyond the `mouseClickRadius` limit, the `onClick` event handler will be canceled, and `onMouseUp` will still get triggered if present.

--- a/docs/src/3.4.MouseEvents.mdx
+++ b/docs/src/3.4.MouseEvents.mdx
@@ -78,4 +78,4 @@ Check out below example for automatic/custom hitmap mapping, and regular/instanc
 
 ## Other
 
-We use `mouseClickRadius` prop to determine if mouseClick event is going to be triggered, specificially if the mouse has moved beyond the `mouseClickRadius` limit, the `onClick` event handler will be canceled, and `onMouseUp` will still get triggered if present.
+We use `mouseClickRadius` prop to determine if mouseClick event is going to be triggered, specificially if the mouse has moved beyond the `mouseClickRadius` limit, the `onClick` event handler will be canceled, and `onMouseUp` will still get triggered if present.This helps implement certain behaviors such as panning around worldview without firing `onClick` event.

--- a/docs/src/3.4.MouseEvents.mdx
+++ b/docs/src/3.4.MouseEvents.mdx
@@ -78,4 +78,4 @@ Check out below example for automatic/custom hitmap mapping, and regular/instanc
 
 ## Other
 
-We use `mouseClickRadius` prop to determine if mouseClick event is going to be triggered, specificially if the mouse has moved beyond the `mouseClickRadius` limit, the `onClick` event handler will be canceled, and `onMouseUp` will still get triggered if present.This helps implement certain behaviors such as panning around worldview without firing `onClick` event.
+`onClick` events don't fire if the user moves their cursor for more than 3 screen pixels between mouse down and mouse up. This helps implement certain behaviors such as panning around worldview without firing `onClick` event.

--- a/docs/src/jsx/utils/WorldviewCodeEditor.js
+++ b/docs/src/jsx/utils/WorldviewCodeEditor.js
@@ -40,6 +40,7 @@ import Worldview, {
   getCSSColor,
   intToRGB,
   cameraStateSelectors,
+  getRayFromClick,
 } from "regl-worldview";
 
 // Add required packages and files for all examples to run
@@ -113,7 +114,7 @@ export const scope = {
   Text,
   GLTFScene,
   withPose,
-
+  getRayFromClick,
   duckModel,
 };
 

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -19,7 +19,7 @@ import { WorldviewContext } from "./WorldviewContext";
 import WorldviewReactContext from "./WorldviewReactContext";
 
 const DEFAULT_BACKGROUND_COLOR = [0, 0, 0, 1];
-const DEFAULT_MOUSE_CLICK_RADIUS = 3;
+export const DEFAULT_MOUSE_CLICK_RADIUS = 3;
 
 export type BaseProps = {|
   keyMap?: CameraKeyMap,
@@ -33,7 +33,6 @@ export type BaseProps = {|
   cameraState?: CameraState,
   onCameraStateChange?: (CameraState) => void,
   defaultCameraState?: CameraState,
-  mouseClickRadius: number,
   // interactions
   onDoubleClick?: MouseHandler,
   onMouseDown?: MouseHandler,
@@ -76,7 +75,6 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
   static defaultProps = {
     backgroundColor: DEFAULT_BACKGROUND_COLOR,
     style: {},
-    mouseClickRadius: DEFAULT_MOUSE_CLICK_RADIUS,
   };
 
   constructor(props: BaseProps) {
@@ -171,7 +169,7 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
       const deltaX = e.clientX - _dragStartPos.x;
       const deltaY = e.clientY - _dragStartPos.y;
       const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
-      if (distance < this.props.mouseClickRadius) {
+      if (distance < DEFAULT_MOUSE_CLICK_RADIUS) {
         this._onMouseInteraction(e, "onClick");
       }
       this._dragStartPos = null;

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -277,7 +277,6 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
             onMouseDown={this._onMouseDown}
             onDoubleClick={this._onDoubleClick}
             onMouseMove={this._onMouseMove}
-            onClick={this._onClick}
           />
           {showDebug ? this._renderDebug() : null}
         </CameraListener>


### PR DESCRIPTION
## Problem 
The Worldview `onClick` handler is being fired even when user is panning around because currently `onClicked` is always fired after `onMouseUp`. 

## Fix 
Track the movement, only fire `onClick` if the mouse has moved a distance within 3 screen pixels. 

## Test
Manually test: press and pan around for long distance, the information display should not change. Will add a drag object demo later in a separate PR. 

![demo](https://user-images.githubusercontent.com/10999093/54247527-8f664a80-44f6-11e9-9278-7ba95a156edd.gif)
