### PR TITLE
Prevent clicking through the Overlay in Interactivity example

### DIFF
--- a/docs/src/jsx/Hitmap.js
+++ b/docs/src/jsx/Hitmap.js
@@ -167,7 +167,7 @@ function Example() {
           return (
             <div
               onClick={(ev) => {
-                // prevent from clicking the objects underneath
+                // prevents clicking on the objects underneath
                 ev.stopPropagation();
               }}
               key={item.id}

--- a/docs/src/jsx/Hitmap.js
+++ b/docs/src/jsx/Hitmap.js
@@ -163,8 +163,13 @@ function Example() {
             text,
             info: { color, title },
           } = item;
+
           return (
             <div
+              onClick={(ev) => {
+                // prevent from clicking the objects underneath
+                ev.stopPropagation();
+              }}
               key={item.id}
               style={{
                 transform: `translate(${left.toFixed()}px,${top.toFixed()}px)`,
@@ -173,7 +178,6 @@ function Example() {
                 background: "rgba(0, 0, 0, 0.8)",
                 color: "white",
                 maxWidth: 250,
-                pointerEvents: "none",
                 willChange: "transform",
                 fontSize: 12,
                 padding: 8,

--- a/docs/src/jsx/Overlay.js
+++ b/docs/src/jsx/Overlay.js
@@ -69,7 +69,7 @@ function Example() {
                   background: "rgba(0, 0, 0, 0.8)",
                   color: "white",
                   maxWidth: 250,
-                  pointerEvents: "none",
+                  pointerEvents: "none", // enable clicking the objects underneath
                   willChange: "transform",
                   fontSize: 12,
                   padding: 8,


### PR DESCRIPTION
Before: clicking the Overlay will cause the objects underneath to be clicked and make the current Overlay disappear 
![problem](https://user-images.githubusercontent.com/10999093/54711479-3eaead00-4b07-11e9-91f5-b35ecab6c0b2.gif)

Fixed: click the Overlay and the Overlay doesn't change
![demo](https://user-images.githubusercontent.com/10999093/54711474-3c4c5300-4b07-11e9-8a59-547fbe815201.gif)



