### PR TITLE
Remove flakey test on <Button>

### DIFF
--- a/packages/@cruise-automation/button/src/index.test.js
+++ b/packages/@cruise-automation/button/src/index.test.js
@@ -89,21 +89,6 @@ describe("<Button />", () => {
     expect(clicked).toBe(false);
   });
 
-  it("does not fire click callback if mouse leaves button before delay", (done: any) => {
-    const fail = () => done("Should not have called click callback");
-    const el = mount(
-      <Button delay={1} onClick={fail}>
-        hello
-      </Button>
-    );
-    el.simulate("mouseDown");
-    el.simulate("mouseUp");
-    setTimeout(() => {
-      done();
-      el.unmount();
-    }, 10);
-  });
-
   it("can control mousedown via external calls", (done: any) => {
     const onClick = () => {
       el.unmount(); // eslint-disable-line no-use-before-define


### PR DESCRIPTION
This test didn’t even work properly, since it passed even when removing
the `delay` bit. I couldn’t quite figure out the best way to fix this
test so I just removed it. This test has caused us more trouble than
prevented bugs. It’s not sparking any joy any more.