### PR TITLE
Fix text disappearing after code update in CodeSandbox

### DIFF
--- a/docs/src/jsx/allLiveEditors.js
+++ b/docs/src/jsx/allLiveEditors.js
@@ -10,7 +10,7 @@ import React from "react";
 
 import WorldviewCodeEditor from "./utils/WorldviewCodeEditor";
 
-function makeCodeComponent(raw, componentName, { isRowView, shouldInsertCodeSandboxStyleFix } = {}) {
+function makeCodeComponent(raw, componentName, { isRowView, insertCodeSandboxStyle } = {}) {
   const code = raw
     .split("// #BEGIN EXAMPLE")[1]
     .split("// #END EXAMPLE")[0]
@@ -27,7 +27,7 @@ function makeCodeComponent(raw, componentName, { isRowView, shouldInsertCodeSand
       nonEditableCode={code[0].trim()}
       componentName={componentName}
       isRowView={isRowView}
-      shouldInsertCodeSandboxStyleFix={shouldInsertCodeSandboxStyleFix}
+      insertCodeSandboxStyle={insertCodeSandboxStyle}
     />
   );
 }
@@ -89,7 +89,7 @@ export const SpheresInstancedColor = makeCodeComponent(
 export const SpheresSingle = makeCodeComponent(require("!!raw-loader!./commands/SpheresSingle"), "SpheresSingle");
 
 export const Text = makeCodeComponent(require("!!raw-loader!./commands/Text"), "Text", {
-  shouldInsertCodeSandboxStyleFix: true,
+  insertCodeSandboxStyle: true,
 });
 
 export const Triangles = makeCodeComponent(require("!!raw-loader!./commands/Triangles"), "Triangles");

--- a/docs/src/jsx/allLiveEditors.js
+++ b/docs/src/jsx/allLiveEditors.js
@@ -10,7 +10,7 @@ import React from "react";
 
 import WorldviewCodeEditor from "./utils/WorldviewCodeEditor";
 
-function makeCodeComponent(raw, componentName, isRowView) {
+function makeCodeComponent(raw, componentName, { isRowView, shouldInsertCodeSandboxStyleFix } = {}) {
   const code = raw
     .split("// #BEGIN EXAMPLE")[1]
     .split("// #END EXAMPLE")[0]
@@ -27,6 +27,7 @@ function makeCodeComponent(raw, componentName, isRowView) {
       nonEditableCode={code[0].trim()}
       componentName={componentName}
       isRowView={isRowView}
+      shouldInsertCodeSandboxStyleFix={shouldInsertCodeSandboxStyleFix}
     />
   );
 }
@@ -41,7 +42,9 @@ export const CameraStateUncontrolled = makeCodeComponent(
   "CameraStateUncontrolled"
 );
 
-export const MouseEvents = makeCodeComponent(require("!!raw-loader!./api/MouseEvents"), "MouseEvents", true);
+export const MouseEvents = makeCodeComponent(require("!!raw-loader!./api/MouseEvents"), "MouseEvents", {
+  isRowView: true,
+});
 
 export const MouseEventsInstanced = makeCodeComponent(
   require("!!raw-loader!./api/MouseEventsInstanced"),
@@ -85,7 +88,9 @@ export const SpheresInstancedColor = makeCodeComponent(
 
 export const SpheresSingle = makeCodeComponent(require("!!raw-loader!./commands/SpheresSingle"), "SpheresSingle");
 
-export const Text = makeCodeComponent(require("!!raw-loader!./commands/Text"), "Text");
+export const Text = makeCodeComponent(require("!!raw-loader!./commands/Text"), "Text", {
+  shouldInsertCodeSandboxStyleFix: true,
+});
 
 export const Triangles = makeCodeComponent(require("!!raw-loader!./commands/Triangles"), "Triangles");
 

--- a/docs/src/jsx/examples/Hitmap.js
+++ b/docs/src/jsx/examples/Hitmap.js
@@ -177,6 +177,8 @@ function Example() {
                 position: "absolute",
                 background: "rgba(0, 0, 0, 0.8)",
                 color: "white",
+                top: 0,
+                left: 0,
                 maxWidth: 250,
                 willChange: "transform",
                 fontSize: 12,

--- a/docs/src/jsx/utils/WorldviewCodeEditor.js
+++ b/docs/src/jsx/utils/WorldviewCodeEditor.js
@@ -56,6 +56,9 @@ const CODE_SANDBOX_CONFIG = {
     "styled-components": "latest",
   },
   files: {
+    "utils/codeSandboxStyleFix.css": {
+      content: require("!!raw-loader!./codeSandboxStyleFix.css"),
+    },
     "utils/CameraStateInfo.js": {
       content: require("!!raw-loader!./CameraStateInfo.js"),
     },
@@ -135,6 +138,7 @@ export default function WorldviewCodeEditor({
   componentName,
   code,
   nonEditableCode = "",
+  shouldInsertCodeSandboxStyleFix,
   ...rest
 }) {
   const hashUrl = getHashUrlByComponentName(componentName);
@@ -149,6 +153,7 @@ ${code}
 // regl-worldview example: ${componentName}
 // docs: ${docUrl}
 
+${shouldInsertCodeSandboxStyleFix ? 'import "./utils/codeSandboxStyleFix.css"; // #CODE_SANDBOX_ONLY' : ""}
 import ReactDOM from "react-dom";
 ${copyCode}
 

--- a/docs/src/jsx/utils/WorldviewCodeEditor.js
+++ b/docs/src/jsx/utils/WorldviewCodeEditor.js
@@ -138,7 +138,7 @@ export default function WorldviewCodeEditor({
   componentName,
   code,
   nonEditableCode = "",
-  shouldInsertCodeSandboxStyleFix,
+  insertCodeSandboxStyle,
   ...rest
 }) {
   const hashUrl = getHashUrlByComponentName(componentName);
@@ -153,7 +153,7 @@ ${code}
 // regl-worldview example: ${componentName}
 // docs: ${docUrl}
 
-${shouldInsertCodeSandboxStyleFix ? 'import "./utils/codeSandboxStyleFix.css"; // #CODE_SANDBOX_ONLY' : ""}
+${insertCodeSandboxStyle ? 'import "./utils/codeSandboxStyleFix.css"; // #CODE_SANDBOX_ONLY' : ""}
 import ReactDOM from "react-dom";
 ${copyCode}
 

--- a/docs/src/jsx/utils/codeSandboxStyleFix.css
+++ b/docs/src/jsx/utils/codeSandboxStyleFix.css
@@ -1,0 +1,16 @@
+/* The file is not needed if you are using Text command outside of CodeSandbox.  */
+.regl-worldview-text-wrapper {
+  position: absolute;
+  white-space: nowrap;
+  z-index: 100;
+  pointer-events: none;
+  top: 0;
+  left: 0;
+  will-change: transform;
+}
+.regl-worldview-text-inner {
+  position: relative;
+  left: -50%;
+  top: -0.5em;
+  white-space: pre-line;
+}


### PR DESCRIPTION
## Summary
As shown below, the text disappears after editing the code. We did some [perf improvement](https://github.com/cruise-automation/webviz/blob/master/packages/regl-worldview/src/commands/Text.js#L33)  by dynamically creating shared global styles for Text. However, the CodeSandbox is not persisting the style between renders.   

![problem](https://user-images.githubusercontent.com/10999093/55184067-7c868380-514e-11e9-9fbe-5444fe808437.gif)

Fixed by adding the needed styles to CodeSandbox examples, which can be configured through `makeCodeComponent`'s options. 



## Test plan
Manually test that changing the code won't cause the text to disappear. 
![demo](https://user-images.githubusercontent.com/10999093/55184543-a7bda280-514f-11e9-8835-54c6491bc151.gif)


## Versioning impact
No impact.