### PR TITLE
Skip rendering CameraListener if Worldview is fully-controlled

### DIFF
--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -264,22 +264,21 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
   render() {
     const { width, height, showDebug, keyMap, shiftKeys, style, cameraState } = this.props;
     const { worldviewContext } = this.state;
-    const canvasHtml = [
-      <canvas
-        key={0}
-        style={{ width, height, maxWidth: "100%", maxHeight: "100%" }}
-        width={width}
-        height={height}
-        ref={this._canvas}
-        onMouseUp={this._onMouseUp}
-        onMouseDown={this._onMouseDown}
-        onDoubleClick={this._onDoubleClick}
-        onMouseMove={this._onMouseMove}
-      />,
-    ];
-    if (showDebug) {
-      canvasHtml.push(this._renderDebug());
-    }
+    const canvasHtml = (
+      <React.Fragment>
+        <canvas
+          style={{ width, height, maxWidth: "100%", maxHeight: "100%" }}
+          width={width}
+          height={height}
+          ref={this._canvas}
+          onMouseUp={this._onMouseUp}
+          onMouseDown={this._onMouseDown}
+          onDoubleClick={this._onDoubleClick}
+          onMouseMove={this._onMouseMove}
+        />
+        {showDebug && this._renderDebug()}
+      </React.Fragment>
+    );
 
     return (
       <div style={{ position: "relative", overflow: "hidden", ...style }}>

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -262,24 +262,35 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
   }
 
   render() {
-    const { width, height, showDebug, keyMap, shiftKeys, style } = this.props;
+    const { width, height, showDebug, keyMap, shiftKeys, style, cameraState } = this.props;
     const { worldviewContext } = this.state;
+    const canvasHtml = [
+      <canvas
+        key={0}
+        style={{ width, height, maxWidth: "100%", maxHeight: "100%" }}
+        width={width}
+        height={height}
+        ref={this._canvas}
+        onMouseUp={this._onMouseUp}
+        onMouseDown={this._onMouseDown}
+        onDoubleClick={this._onDoubleClick}
+        onMouseMove={this._onMouseMove}
+      />,
+    ];
+    if (showDebug) {
+      canvasHtml.push(this._renderDebug());
+    }
 
     return (
       <div style={{ position: "relative", overflow: "hidden", ...style }}>
-        <CameraListener cameraStore={worldviewContext.cameraStore} keyMap={keyMap} shiftKeys={shiftKeys}>
-          <canvas
-            style={{ width, height, maxWidth: "100%", maxHeight: "100%" }}
-            width={width}
-            height={height}
-            ref={this._canvas}
-            onMouseUp={this._onMouseUp}
-            onMouseDown={this._onMouseDown}
-            onDoubleClick={this._onDoubleClick}
-            onMouseMove={this._onMouseMove}
-          />
-          {showDebug ? this._renderDebug() : null}
-        </CameraListener>
+        {/* skip rendering CameraListener if Worldview is controlled */}
+        {cameraState ? (
+          canvasHtml
+        ) : (
+          <CameraListener cameraStore={worldviewContext.cameraStore} keyMap={keyMap} shiftKeys={shiftKeys}>
+            {canvasHtml}
+          </CameraListener>
+        )}
         {worldviewContext.initializedData && (
           <WorldviewReactContext.Provider value={worldviewContext}>
             {this.props.children}


### PR DESCRIPTION
<!-- Thanks for contributing to Webviz! To help us understand and review your PR, please fill out the following sections: -->

## Summary
Suggested by @jtbandes  [here](https://github.com/cruise-automation/webviz/pull/103/files#r267911290): if the camera if fully controlled, we shouldn't allow the any mouse interactions, because the camera should be managed by the consumer. 

## Test plan
Manually test
**before**: moving the mouse will cause the object to shift a little and snap back right away [demo](https://cruise-automation.github.io/webviz/worldview/#/docs/tutorial/managing-the-camera):
![before](https://user-images.githubusercontent.com/10999093/55192067-e445ca00-5160-11e9-8836-858bbc55a715.gif)
**after**:  moving the mouse doesn't cause any shifting when Worldview is fully controlled. 
![after](https://user-images.githubusercontent.com/10999093/55192569-012ecd00-5162-11e9-94a2-8812234c9e15.gif)


## Versioning impact
No impact if Worldview is correctly used for `controlled` and `uncontrolled` camera state. 
