### PR TITLE
Auto generate links for h1, h2 and h3 links in markdown

### DIFF
--- a/docs/src/2.3.RenderingObjects.mdx
+++ b/docs/src/2.3.RenderingObjects.mdx
@@ -86,7 +86,7 @@ Check your browser to see the results – you have successfully created a Hello
 
 <HelloWorld />
 
-You can interact with Worldview by left-clicking and dragging to move the scene, or right-clicking and dragging to rotate. Learn more about [controlling the camera with your keyboard](#/docs/api/worldview).
+You can interact with Worldview by left-clicking and dragging to move the scene, or right-clicking and dragging to rotate. Learn more about [controlling the camera with your keyboard](#/docs/api/worldview/keyboard-controls).
 
 ## Controlling Objects' Position, Size, and Color
 

--- a/docs/src/2.4.ManagingTheCamera.mdx
+++ b/docs/src/2.4.ManagingTheCamera.mdx
@@ -28,7 +28,7 @@ import duckModel from "../utils/Duck.glb";
     },
     scale: { x: 3, y: 3, z: 3 },
   }}
-</GLTFScene>
+</GLTFScene>;
 ```
 
 To move the camera, we will need to store some state that changes over time. Let's add a [React Hook](https://reactjs.org/docs/hooks-intro.html) that accepts a callback which will be called at each timestep. We'll use [window.requestAnimationFrame](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame) to keep our state updates in sync with the display refresh rate.
@@ -81,7 +81,7 @@ First, let's remove the camera setting for `thetaOffset` and `phi`, so that we d
 
 Voilà! By adding the `target` position to `cameraState`, the camera now follows the duck around!
 
-## Bonus Point: Following the Object Orientattion
+## Bonus Point: Following the Object Orientation
 
 The duck is moving, but not very realistically: it doesn't lean forward or backward when it goes up or down the knob curves. In this step, we'll refine the following behavior by computing the duck's orientation based on it's location on the knot, and use it as `targetOrientation` input for `cameraState`.
 

--- a/docs/src/App.js
+++ b/docs/src/App.js
@@ -7,7 +7,8 @@
 import { MDXProvider } from "@mdx-js/tag";
 import createHashHistory from "history/createHashHistory";
 import React from "react";
-import { Router, Route, Redirect, Switch } from "react-router-dom";
+import { withRouter } from "react-router";
+import { Router, Route, Redirect, Switch, Link } from "react-router-dom";
 
 import Docs from "./Docs";
 import Landing from "./Landing";
@@ -15,9 +16,53 @@ import Landing from "./Landing";
 const history = createHashHistory();
 history.listen(() => window.scrollTo(0, 0));
 
+// A wrapper for generating scrollTo behavior when children text is matched with url path's last part.
+function ScrollTo({ component: Tag = "div", location, children, match, disableAnchorLink, ...rest }) {
+  const wrapperRef = React.useRef();
+  const lastPathPartials = location.pathname.split("/").pop();
+  let hasLink = false;
+  let linkStr;
+  if (typeof children === "string") {
+    linkStr = children
+      .replace(/[\W_]+/g, " ") // only keep letters, numbers and spaces
+      .toLowerCase()
+      .split(" ")
+      .join("-");
+    hasLink = linkStr === lastPathPartials;
+  }
+
+  React.useEffect(
+    () => {
+      if (hasLink) {
+        window.scrollTo({ top: wrapperRef.current.offsetTop, behavior: "smooth" });
+      }
+    },
+    [lastPathPartials]
+  );
+  return (
+    <div ref={wrapperRef}>
+      {linkStr ? (
+        <Link style={{ textDecoration: "none" }} to={disableAnchorLink ? match.path : `${match.path}/${linkStr}`}>
+          <Tag>{children}</Tag>
+        </Link>
+      ) : (
+        <Tag>{children}</Tag>
+      )}
+    </div>
+  );
+}
+
+const ScrollToWithRouter = withRouter(ScrollTo);
+
+const components = {
+  // auto generate links for h2 and h3 and scroll to the element if the url path is matched with the heading text
+  h2: (props) => <ScrollToWithRouter component="h2" {...props} />, // eslint-disable-line react/display-name
+  h3: (props) => <ScrollToWithRouter component="h3" {...props} />, // eslint-disable-line react/display-name
+  h1: (props) => <ScrollToWithRouter component="h1" disableAnchorLink {...props} />, // eslint-disable-line react/display-name
+};
 export default function App() {
   return (
-    <MDXProvider components={{}}>
+    <MDXProvider components={components}>
       <Router history={history}>
         <Switch>
           <Route path="/docs" component={Docs} />

--- a/docs/src/routes.js
+++ b/docs/src/routes.js
@@ -133,7 +133,6 @@ export default ROUTE_CONFIG.map(({ name, subRouteNames }) => {
     subRoutes: subRouteNames.map((subRouteName, idx) => {
       const subComponentName = getComponentName(subRouteName);
       return {
-        exact: idx !== 0,
         path: `/${getSubRoutePath(subRouteName)}`,
         name: subRouteName,
         main: subComponentName,


### PR DESCRIPTION
## Summary
For long pages such as Worldview and the tutorials, it's a little inconvenient to not be able to link to a specific section. 

This PR addresses this issue:
- Auto generate links for all h1, h2 and h3 tags in the markdown docs 
- Auto scroll to the heading when the URL path's last part is matched with the heading's text content

## Test plan
Manual test:
![after](https://user-images.githubusercontent.com/10999093/55265708-bdf25e00-5236-11e9-8b4a-49b6cc6e99bd.gif)


## Versioning impact

No impact. 
