### PR TITLE
Fix eslint import order for internal packages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
     "react/prop-types": "off", // We use Flow instead.
     "no-useless-computed-key": "off", // https://github.com/facebook/flow/issues/380#issuecomment-224380551
     yoda: "off", // https://github.com/RyanZim/eslint-config-problems/pull/1 and https://github.com/eslint/eslint/issues/10591
+    "import/external-module-folders": ["node_modules", "packages"],
     // Some good ones that people really should be adding to import/recommended:
     "import/first": "error",
     "import/no-self-import": "error",

--- a/packages/webviz-core/src/components/Modal.js
+++ b/packages/webviz-core/src/components/Modal.js
@@ -6,14 +6,11 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 
-// Need to import separately because disparity in import order between
-// proprietary and open source repos.
-import KeyListener from "react-key-listener"; // eslint-disable-line
-
 import CloseIcon from "@mdi/svg/svg/close.svg";
 import * as React from "react";
 import styled from "styled-components";
 
+import KeyListener from "react-key-listener";
 import Icon from "webviz-core/src/components/Icon";
 import colors from "webviz-core/src/styles/colors.module.scss";
 

--- a/packages/webviz-core/src/components/Panel.js
+++ b/packages/webviz-core/src/components/Panel.js
@@ -6,9 +6,6 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 
-// Need to import separately because disparity in import order between
-// proprietary and open source repos.
-import KeyListener from "react-key-listener"; // eslint-disable-line
 
 import CloseIcon from "@mdi/svg/svg/close.svg";
 import FullscreenIcon from "@mdi/svg/svg/fullscreen.svg";
@@ -20,6 +17,7 @@ import { getNodeAtPath } from "react-mosaic-component";
 import { connect } from "react-redux";
 
 import styles from "./Panel.module.scss";
+import KeyListener from "react-key-listener";
 import ErrorBoundary from "webviz-core/src/components/ErrorBoundary";
 import Flex from "webviz-core/src/components/Flex";
 import { MessagePipelineConsumer, type MessagePipelineContext } from "webviz-core/src/components/MessagePipeline";

--- a/packages/webviz-core/src/components/Panel.js
+++ b/packages/webviz-core/src/components/Panel.js
@@ -6,7 +6,6 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 
-
 import CloseIcon from "@mdi/svg/svg/close.svg";
 import FullscreenIcon from "@mdi/svg/svg/fullscreen.svg";
 import cx from "classnames";

--- a/packages/webviz-core/src/components/PlaybackControls/index.js
+++ b/packages/webviz-core/src/components/PlaybackControls/index.js
@@ -6,9 +6,6 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 
-// Need to import separately because disparity in import order between
-// proprietary and open source repos.
-import KeyListener from "react-key-listener"; // eslint-disable-line
 
 import Tooltip from "@cruise-automation/tooltip";
 import CancelIcon from "@mdi/svg/svg/cancel.svg";
@@ -20,6 +17,7 @@ import type { Time } from "rosbag";
 import styled from "styled-components";
 
 import styles from "./index.module.scss";
+import KeyListener from "react-key-listener";
 import Dropdown from "webviz-core/src/components/Dropdown";
 import EmptyState from "webviz-core/src/components/EmptyState";
 import Flex from "webviz-core/src/components/Flex";

--- a/packages/webviz-core/src/components/PlaybackControls/index.js
+++ b/packages/webviz-core/src/components/PlaybackControls/index.js
@@ -6,7 +6,6 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 
-
 import Tooltip from "@cruise-automation/tooltip";
 import CancelIcon from "@mdi/svg/svg/cancel.svg";
 import PauseIcon from "@mdi/svg/svg/pause.svg";


### PR DESCRIPTION
## Summary

Add eslint rule for import/external-module-folders to remove the eslint disable and keep internal and external repos linting in sync. 

## Test plan
CI shouldn't fail.

## Versioning impact

No impact.