### PR TITLE
 Add option to customize blend and depth

### DIFF
--- a/docs/src/jsx/examples/Composition.js
+++ b/docs/src/jsx/examples/Composition.js
@@ -10,6 +10,7 @@ import Worldview, { Axes, Triangles, Text, DEFAULT_CAMERA_STATE } from "regl-wor
 
 // #BEGIN EDITABLE
 function Example() {
+  const depth = { enable: true, mask: true };
   const labelMarker = {
     name: "randomName",
     text: "STOP",
@@ -21,6 +22,7 @@ function Example() {
     scale: { x: 1, y: 1, z: 1 },
   };
   const stopSignWhiteBaseMarker = {
+    depth,
     color: { r: 1, g: 1, b: 1, a: 1 },
     points: [
       { x: 0, y: 0, z: 0 },
@@ -51,11 +53,12 @@ function Example() {
     scale: { x: 1, y: 1, z: 1 },
     pose: {
       orientation: { x: 0, y: 0, z: 0, w: 1 },
-      position: { x: 5, y: 5, z: 0.01 },
+      position: { x: 5, y: 5, z: 0.02 },
     },
   };
 
   const stopSignMarker = {
+    depth,
     color: { r: 1.0, g: 0.2, b: 0.2, a: 1.0 },
     points: [
       { x: 0, y: 0, z: 0 },
@@ -85,7 +88,7 @@ function Example() {
     ],
     pose: {
       orientation: { x: 0, y: 0, z: 0, w: 1 },
-      position: { x: 5, y: 5, z: 0 },
+      position: { x: 5, y: 5, z: 0.03 },
     },
     scale: { x: 1, y: 1, z: 1 },
   };
@@ -99,7 +102,19 @@ function Example() {
         targetOffset: [2, 3, 0],
         thetaOffset: 0.3,
       }}>
-      <Triangles>{[stopSignWhiteBaseMarker, stopSignMarker]}</Triangles>
+      <Triangles>
+        {[
+          {
+            ...stopSignMarker,
+            pose: {
+              orientation: { x: 0, y: 0, z: 0, w: 1 },
+              position: { x: 5, y: 5, z: 0.01 },
+            },
+          },
+          stopSignWhiteBaseMarker,
+          stopSignMarker,
+        ]}
+      </Triangles>
       <Text>{[labelMarker]}</Text>
       <Axes />
     </Worldview>

--- a/docs/src/jsx/utils/Scrubber.js
+++ b/docs/src/jsx/utils/Scrubber.js
@@ -43,7 +43,11 @@ export default function Scrubber({ value, onChange, speed = 1, vertical = false 
       const delta = vertical ? start.position.clientY - event.clientY : event.clientX - start.position.clientX;
       onChange(start.value + delta * speed);
     },
+<<<<<<< HEAD
     []
+=======
+    [dragging]
+>>>>>>> Fix Camera page
   );
   useEventListener(
     window,
@@ -52,7 +56,11 @@ export default function Scrubber({ value, onChange, speed = 1, vertical = false 
     (event: MouseEvent) => {
       setDragging(false);
     },
+<<<<<<< HEAD
     []
+=======
+    [dragging]
+>>>>>>> Fix Camera page
   );
 
   return (

--- a/docs/src/jsx/utils/Scrubber.js
+++ b/docs/src/jsx/utils/Scrubber.js
@@ -43,11 +43,7 @@ export default function Scrubber({ value, onChange, speed = 1, vertical = false 
       const delta = vertical ? start.position.clientY - event.clientY : event.clientX - start.position.clientX;
       onChange(start.value + delta * speed);
     },
-<<<<<<< HEAD
     []
-=======
-    [dragging]
->>>>>>> Fix Camera page
   );
   useEventListener(
     window,
@@ -56,11 +52,7 @@ export default function Scrubber({ value, onChange, speed = 1, vertical = false 
     (event: MouseEvent) => {
       setDragging(false);
     },
-<<<<<<< HEAD
     []
-=======
-    [dragging]
->>>>>>> Fix Camera page
   );
 
   return (

--- a/packages/regl-worldview/src/commands/GLTFScene.js
+++ b/packages/regl-worldview/src/commands/GLTFScene.js
@@ -10,7 +10,7 @@ import { mat4 } from "gl-matrix";
 import React from "react";
 
 import type { Pose, Scale } from "../types";
-import { blend, pointToVec3, orientationToVec4 } from "../utils/commandUtils";
+import { defaultBlend, pointToVec3, orientationToVec4 } from "../utils/commandUtils";
 import parseGLB from "../utils/parseGLB";
 import WorldviewReactContext from "../WorldviewReactContext";
 import Command from "./Command";
@@ -39,7 +39,7 @@ function glConstantToRegl(value: ?number): ?string {
 const drawModel = (regl) => {
   const command = regl({
     primitive: "triangles",
-    blend,
+    blend: (context, props) => props.blend || defaultBlend,
     uniforms: {
       globalAlpha: regl.context("globalAlpha"),
       poseMatrix: regl.context("poseMatrix"),

--- a/packages/regl-worldview/src/commands/Lines.js
+++ b/packages/regl-worldview/src/commands/Lines.js
@@ -7,7 +7,7 @@
 //  You may not use this file except in compliance with the License.
 
 import type { Line } from "../types";
-import { blend, withPose, toRGBA, shouldConvert, pointToVec3 } from "../utils/commandUtils";
+import { defaultBlend, withPose, toRGBA, shouldConvert, pointToVec3 } from "../utils/commandUtils";
 import { makeCommand } from "./Command";
 
 /*
@@ -252,7 +252,7 @@ const lines = (regl: any) => {
     withPose({
       vert,
       frag,
-      blend,
+      blend: (context, props) => props.blend || defaultBlend,
       uniforms: {
         thickness: regl.prop("scale.x"),
         viewportWidth: regl.context("viewportWidth"),

--- a/packages/regl-worldview/src/commands/Triangles.js
+++ b/packages/regl-worldview/src/commands/Triangles.js
@@ -18,7 +18,8 @@ import {
 import { getHitmapPropsForInstancedCommands, getObjectForInstancedCommands } from "../utils/hitmapDefaults";
 import { makeCommand } from "./Command";
 
-const defaultSingleColorDepth = { enable: true, mask: true };
+// TODO(Audrey): default to the actual regl defaults before 1.x release
+const defaultSingleColorDepth = { enable: true, mask: false };
 const defaultVetexColorDepth = {
   enable: true,
   func: "<=",

--- a/packages/regl-worldview/src/commands/Triangles.js
+++ b/packages/regl-worldview/src/commands/Triangles.js
@@ -65,7 +65,7 @@ const singleColor = (regl) =>
         return props.color;
       },
     },
-    // can pass in {enable: true, depth: true } to turn off depth to prevent flicker
+    // can pass in { enable: true, depth: true } to turn off depth to prevent flicker
     // because multiple items are rendered to the same z plane
     depth: (context, props) => props.depth || defaultDepth,
     blend: (context, props) => props.blend || defaultBlend,

--- a/packages/regl-worldview/src/commands/Triangles.js
+++ b/packages/regl-worldview/src/commands/Triangles.js
@@ -9,7 +9,6 @@
 import type { TriangleList, Regl } from "../types";
 import {
   defaultBlend,
-  defaultDepth,
   getVertexColors,
   pointToVec3Array,
   shouldConvert,
@@ -18,6 +17,12 @@ import {
 } from "../utils/commandUtils";
 import { getHitmapPropsForInstancedCommands, getObjectForInstancedCommands } from "../utils/hitmapDefaults";
 import { makeCommand } from "./Command";
+
+const defaultSingleColorDepth = { enable: true, mask: true };
+const defaultVetexColorDepth = {
+  enable: true,
+  func: "<=",
+};
 
 const singleColor = (regl) =>
   withPose({
@@ -65,9 +70,9 @@ const singleColor = (regl) =>
         return props.color;
       },
     },
-    // can pass in { enable: true, depth: true } to turn off depth to prevent flicker
+    // can pass in { enable: true, depth: false } to turn off depth to prevent flicker
     // because multiple items are rendered to the same z plane
-    depth: (context, props) => props.depth || defaultDepth,
+    depth: (context, props) => props.depth || defaultSingleColorDepth,
     blend: (context, props) => props.blend || defaultBlend,
     count: (context, props) => props.points.length,
   });
@@ -116,11 +121,7 @@ const vertexColors = (regl) =>
     },
 
     blend: (context, props) => props.blend || defaultBlend,
-    depth: (context, props) =>
-      props.depth || {
-        enable: true,
-        func: "<=",
-      },
+    depth: (context, props) => props.depth || defaultVetexColorDepth,
 
     count: (context, props) => props.points.length,
   });

--- a/packages/regl-worldview/src/commands/Triangles.js
+++ b/packages/regl-worldview/src/commands/Triangles.js
@@ -7,7 +7,15 @@
 //  You may not use this file except in compliance with the License.
 
 import type { TriangleList, Regl } from "../types";
-import { blend, getVertexColors, pointToVec3Array, shouldConvert, toRGBA, withPose } from "../utils/commandUtils";
+import {
+  defaultBlend,
+  defaultDepth,
+  getVertexColors,
+  pointToVec3Array,
+  shouldConvert,
+  toRGBA,
+  withPose,
+} from "../utils/commandUtils";
 import { getHitmapPropsForInstancedCommands, getObjectForInstancedCommands } from "../utils/hitmapDefaults";
 import { makeCommand } from "./Command";
 
@@ -57,12 +65,10 @@ const singleColor = (regl) =>
         return props.color;
       },
     },
-
-    // turn off depth to prevent flicker
+    // can pass in {enable: true, depth: true } to turn off depth to prevent flicker
     // because multiple items are rendered to the same z plane
-    depth: { enable: true, mask: false },
-    blend,
-
+    depth: (context, props) => props.depth || defaultDepth,
+    blend: (context, props) => props.blend || defaultBlend,
     count: (context, props) => props.points.length,
   });
 
@@ -109,11 +115,12 @@ const vertexColors = (regl) =>
       },
     },
 
-    blend,
-    depth: {
-      enable: true,
-      func: "<=",
-    },
+    blend: (context, props) => props.blend || defaultBlend,
+    depth: (context, props) =>
+      props.depth || {
+        enable: true,
+        func: "<=",
+      },
 
     count: (context, props) => props.points.length,
   });

--- a/packages/regl-worldview/src/utils/commandUtils.js
+++ b/packages/regl-worldview/src/utils/commandUtils.js
@@ -35,6 +35,7 @@ export const orientationToVec4 = ({ x, y, z, w }: Orientation): Vec4 => {
 };
 
 export const vec3ToPoint = ([x, y, z]: Vec3): Point => ({ x, y, z });
+
 export const vec4ToOrientation = ([x, y, z, w]: Vec4): Orientation => ({ x, y, z, w });
 
 export const pointToVec3Array = (points: Point[]) => {

--- a/packages/regl-worldview/src/utils/commandUtils.js
+++ b/packages/regl-worldview/src/utils/commandUtils.js
@@ -83,7 +83,7 @@ const constantRGBAArray = (count: number, { r, g, b, a }: Color): Float32Array =
 };
 
 // default blend func params to be mixed into regl commands
-export const blend = {
+export const defaultBlend = {
   enable: true,
   // this is the same gl.BlendFunc used by three.js by default
   func: {
@@ -97,6 +97,8 @@ export const blend = {
     alpha: "add",
   },
 };
+
+export const defaultDepth = { enable: true, mask: true };
 
 // takes a regl command definition object and injects
 // position and rotation from the object pose and also

--- a/packages/regl-worldview/src/utils/commandUtils.js
+++ b/packages/regl-worldview/src/utils/commandUtils.js
@@ -98,8 +98,6 @@ export const defaultBlend = {
   },
 };
 
-export const defaultDepth = { enable: true, mask: true };
-
 // takes a regl command definition object and injects
 // position and rotation from the object pose and also
 // inserts some glsl helpers to apply the pose to points in a fragment shader

--- a/packages/regl-worldview/src/utils/fromGeometry.js
+++ b/packages/regl-worldview/src/utils/fromGeometry.js
@@ -7,7 +7,7 @@
 //  You may not use this file except in compliance with the License.
 
 import type { ReglCommand, Vec3 } from "../types";
-import { withPose, pointToVec3, blend, shouldConvert, colorBuffer } from "./commandUtils";
+import { withPose, pointToVec3, defaultBlend, shouldConvert, colorBuffer } from "./commandUtils";
 
 // Creates a regl command factory which will render any geometry described by point positions
 // and elements (indexes into the array of positions), and apply the object's pose, scale, and color to it.
@@ -71,7 +71,7 @@ export default (positions: Vec3[], elements: Vec3[]) => (regl: any): ReglCommand
 
     elements: elementsArray,
 
-    blend,
+    blend: (context, props) => props.blend || defaultBlend,
 
     uniforms: {
       scale: (context, props) => (shouldConvert(props.scale) ? pointToVec3(props.scale) : props.scale),


### PR DESCRIPTION
## Summary
We've encountered a few [bugs](https://github.com/cruise-automation/webviz/pull/100) where triangles' depth value was causing weird behaviors demonstrated as below: the stop sign is always behind the axes no matter where we place the camera.
https://codesandbox.io/s/qkv1793yrw 

![before](https://user-images.githubusercontent.com/10999093/55764058-cc066280-5a1e-11e9-8da4-27feb6cc4265.gif)

## Fix 
Update existing commands to take `blend` and `depth` as prop in order to customize per draw call, e.g. 
```
<Triangles>
{[
  depth: { enable: true, mask: false },
  blend: { enable: false },
  pose: {
      position: { x: 0, y: 0, z: 0 },
      orientation: { x: 0, y: 0, z: 0, w: 1 },
    },
    points: ...,
    colors: ...,
]}
</Triangles>
```
## Test plan
With the change, the `blend` and `depth` props are now transparent, the consumer should see the expected behaviors when they pass in the right props.  
Also manually test that the composition example is fixed: the stop sign does show in front of the axes.  
![after](https://user-images.githubusercontent.com/10999093/55764065-d0328000-5a1e-11e9-9d1b-a3634681b737.gif)

## Versioning impact
Will do a minor release since this PR adds 2 new APIs.