### PR TITLE
Fix camera docs page

### DIFF
--- a/docs/src/jsx/utils/Scrubber.js
+++ b/docs/src/jsx/utils/Scrubber.js
@@ -35,13 +35,25 @@ export default function Scrubber({ value, onChange, speed = 1, vertical = false 
     position: { clientX: NaN, clientY: NaN },
   });
 
-  useEventListener(window, "mousemove", dragging, (event: MouseEvent) => {
-    const delta = vertical ? start.position.clientY - event.clientY : event.clientX - start.position.clientX;
-    onChange(start.value + delta * speed);
-  });
-  useEventListener(window, "mouseup", dragging, (event: MouseEvent) => {
-    setDragging(false);
-  });
+  useEventListener(
+    window,
+    "mousemove",
+    dragging,
+    (event: MouseEvent) => {
+      const delta = vertical ? start.position.clientY - event.clientY : event.clientX - start.position.clientX;
+      onChange(start.value + delta * speed);
+    },
+    []
+  );
+  useEventListener(
+    window,
+    "mouseup",
+    dragging,
+    (event: MouseEvent) => {
+      setDragging(false);
+    },
+    []
+  );
 
   return (
     <StyledNumber


### PR DESCRIPTION
## Summary

The [camera](https://cruise-automation.github.io/webviz/worldview/#/docs/api/camera) page is broken. This PR fixes it.

## Test plan
The page should load locally. I also tested all other pages. 

## Versioning impact
No impact.