### PR TITLE
 Add mouse interaction to Lines

### DIFF
--- a/docs/src/4.6.Lines.mdx
+++ b/docs/src/4.6.Lines.mdx
@@ -1,4 +1,4 @@
-import { LinesDemo, LinesWireframe } from "./jsx/allLiveEditors";
+import { LinesDemo, LinesWireframe, LinesHitmap } from "./jsx/allLiveEditors";
 
 # Lines
 
@@ -34,6 +34,7 @@ type Line = {
 }
 ```
 
+<LinesHitmap />
 <LinesDemo />
 
 <LinesWireframe />

--- a/docs/src/4.6.Lines.mdx
+++ b/docs/src/4.6.Lines.mdx
@@ -6,12 +6,9 @@ import { LinesDemo, LinesWireframe, LinesHitmap } from "./jsx/allLiveEditors";
 
 ## Props
 
-| Name                      | Type      | Default                      | Description                                                                                                                                     |
-| ------------------------- | --------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `children`                | `Line[]`  | `[]`                         | array of Line markers to render                                                                                                                 |
-| `enableClickableInterior` | `boolean` |                              | when enabled, a polygon will be drawn using the line `points`, and the user will get the original line object after clicking inside the polygon |
-| `fillColor`               | `Color`   | `{ r: 0, g: 0, b: 0, a: 0 }` | the fill color for the polygon                                                                                                                  |
-| `showBorder`              | `boolean` |                              | draw the lines around the polygon                                                                                                               |
+| Name       | Type     | Default | Description                     |
+| ---------- | -------- | ------- | ------------------------------- |
+| `children` | `Line[]` | `[]`    | array of Line markers to render |
 
 ### Line
 

--- a/docs/src/4.6.Lines.mdx
+++ b/docs/src/4.6.Lines.mdx
@@ -6,15 +6,21 @@ import { LinesDemo, LinesWireframe, LinesHitmap } from "./jsx/allLiveEditors";
 
 ## Props
 
-| Name       | Type     | Default | Description                     |
-| ---------- | -------- | ------- | ------------------------------- |
-| `children` | `Line[]` | `[]`    | array of Line markers to render |
+| Name                      | Type      | Default                      | Description                                                                                                                                     |
+| ------------------------- | --------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `children`                | `Line[]`  | `[]`                         | array of Line markers to render                                                                                                                 |
+| `enableClickableInterior` | `boolean` |                              | when enabled, a polygon will be drawn using the line `points`, and the user will get the original line object after clicking inside the polygon |
+| `fillColor`               | `Color`   | `{ r: 0, g: 0, b: 0, a: 0 }` | the fill color for the polygon                                                                                                                  |
+| `showBorder`              | `boolean` |                              | draw the lines around the polygon                                                                                                               |
 
 ### Line
 
 ```js
 type Line = {
   id?: number, // positive integer
+  primitive:  "line strip" | "lines",
+  closed: boolean,
+  scaleInvariant: boolean,
   pose: {
     position: { x: number, y: number, z: number },
     orientation: { x: number, y: number, z: number, w: number }
@@ -34,7 +40,14 @@ type Line = {
 }
 ```
 
-<LinesHitmap />
+## Props Example
+
 <LinesDemo />
 
+## Wireframe Example
+
 <LinesWireframe />
+
+## Mouse Interaction
+
+<LinesHitmap />

--- a/docs/src/App.js
+++ b/docs/src/App.js
@@ -33,7 +33,14 @@ function ScrollTo({ component: Tag = "div", location, children, match, disableAn
 
   React.useEffect(
     () => {
-      if (hasLink) {
+      let disableScroll = false;
+      const urlPartials = window.location.href.split("?");
+      if (urlPartials.length > 1) {
+        const queryStr = urlPartials[1];
+        const search = new URLSearchParams(queryStr);
+        disableScroll = search.get("disableScroll");
+      }
+      if (!disableScroll && hasLink) {
         window.scrollTo({ top: wrapperRef.current.offsetTop, behavior: "smooth" });
       }
     },

--- a/docs/src/jsx/allLiveEditors.js
+++ b/docs/src/jsx/allLiveEditors.js
@@ -70,6 +70,8 @@ export const FilledPolygonsHitmap = makeCodeComponent(
 
 export const LinesDemo = makeCodeComponent(require("!!raw-loader!./commands/LinesDemo"), "LinesDemo");
 
+export const LinesHitmap = makeCodeComponent(require("!!raw-loader!./commands/LinesHitmap"), "LinesHitmap");
+
 export const LinesWireframe = makeCodeComponent(require("!!raw-loader!./commands/LinesWireframe"), "LinesWireframe");
 
 export const Overlay = makeCodeComponent(require("!!raw-loader!./commands/Overlay"), "Overlay");

--- a/docs/src/jsx/commands/LinesHitmap.js
+++ b/docs/src/jsx/commands/LinesHitmap.js
@@ -1,0 +1,83 @@
+//  Copyright (c) 2018-present, GM Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+// #BEGIN EXAMPLE
+import React, { useState } from "react";
+import Worldview, { Lines, DEFAULT_CAMERA_STATE } from "regl-worldview";
+
+// #BEGIN EDITABLE
+function Example() {
+  const [clickedObj, setClickedObj] = useState(null);
+  const [clickedObjId, setClickedObjId] = useState(null);
+  // map a number/index to a specific color
+  function numberToColor(number, max, a = 1) {
+    const i = (number * 255) / max;
+    const r = Math.round(Math.sin(0.024 * i + 0) * 127 + 128) / 255;
+    const g = Math.round(Math.sin(0.024 * i + 2) * 127 + 128) / 255;
+    const b = Math.round(Math.sin(0.024 * i + 4) * 127 + 128) / 255;
+    return { r, g, b, a };
+  }
+  const points = [
+    { x: 0, y: 0, z: 1 },
+    { x: 0, y: 3, z: 1 },
+    { x: 3, y: 3, z: 1 },
+    { x: 3, y: 0, z: 1 },
+
+    // { x: 0, y: -3, z: 1 },
+    // { x: 0, y: -3, z: 0 },
+
+    // { x: 1, y: -2, z: 1 },
+    // { x: 1, y: -2, z: 0 },
+  ];
+  const lines = [
+    {
+      id: 191,
+      closed: true,
+      primitive: "line strip",
+      pose: {
+        position: { x: 0, y: 0, z: 0 },
+        orientation: { x: 0, y: 0, z: 0, w: 0 },
+      },
+      scale: { x: 0.1, y: 0.1, z: 0.1 },
+      color: { r: 0, g: 1, b: 0, a: 1 },
+      points,
+      colors: points.map((x, idx) => numberToColor(idx, points.length)),
+    },
+  ];
+
+  return (
+    <Worldview
+      onClick={(ev, { objectId }) => {
+        setClickedObjId(objectId);
+        if (!objectId) {
+          setClickedObj(null);
+        }
+      }}
+      defaultCameraState={{ ...DEFAULT_CAMERA_STATE, distance: 10 }}>
+      <Lines
+        onClick={(ev, { object, objectId }) => {
+          setClickedObj(object);
+        }}>
+        {lines}
+      </Lines>
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          top: 0,
+          width: 320,
+          maxWidth: "100%",
+          color: "white",
+          backgroundColor: "rgba(0, 0, 0, 0.5)",
+        }}>
+        {clickedObj ? <span>Clicked line point id: {clickedObjId} </span> : <span>Click on any lines</span>}
+      </div>
+    </Worldview>
+  );
+}
+// #END EXAMPLE
+
+export default Example;

--- a/docs/src/jsx/commands/LinesHitmap.js
+++ b/docs/src/jsx/commands/LinesHitmap.js
@@ -10,28 +10,10 @@ import Worldview, { Lines, DEFAULT_CAMERA_STATE } from "regl-worldview";
 
 // #BEGIN EDITABLE
 function Example() {
-  const [clickedObj, setClickedObj] = useState(null);
-  const [clickedObjId, setClickedObjId] = useState(null);
-  // map a number/index to a specific color
-  function numberToColor(number, max, a = 1) {
-    const i = (number * 255) / max;
-    const r = Math.round(Math.sin(0.024 * i + 0) * 127 + 128) / 255;
-    const g = Math.round(Math.sin(0.024 * i + 2) * 127 + 128) / 255;
-    const b = Math.round(Math.sin(0.024 * i + 4) * 127 + 128) / 255;
-    return { r, g, b, a };
-  }
-  const points = [
-    { x: 0, y: 0, z: 1 },
-    { x: 0, y: 3, z: 1 },
-    { x: 3, y: 3, z: 1 },
-    { x: 3, y: 0, z: 1 },
+  const defaultMsg = "Click on top of the green lines or inside the red area.";
+  const [msg, setMsg] = useState(defaultMsg);
 
-    // { x: 0, y: -3, z: 1 },
-    // { x: 0, y: -3, z: 0 },
-
-    // { x: 1, y: -2, z: 1 },
-    // { x: 1, y: -2, z: 0 },
-  ];
+  const points = [{ x: 0, y: 0, z: 2 }, { x: 0, y: 3, z: 2 }, { x: 3, y: 3, z: 2 }, { x: 3, y: 0, z: 2 }];
   const lines = [
     {
       id: 191,
@@ -44,36 +26,53 @@ function Example() {
       scale: { x: 0.1, y: 0.1, z: 0.1 },
       color: { r: 0, g: 1, b: 0, a: 1 },
       points,
-      colors: points.map((x, idx) => numberToColor(idx, points.length)),
     },
   ];
 
   return (
     <Worldview
       onClick={(ev, { objectId }) => {
-        setClickedObjId(objectId);
         if (!objectId) {
-          setClickedObj(null);
+          setMsg(defaultMsg);
         }
       }}
       defaultCameraState={{ ...DEFAULT_CAMERA_STATE, distance: 10 }}>
       <Lines
         onClick={(ev, { object, objectId }) => {
-          setClickedObj(object);
+          setMsg(`Clicked on the lines. objectId: ${objectId}`);
         }}>
         {lines}
+      </Lines>
+      <Lines
+        onClick={(ev, { object, objectId }) => {
+          setMsg(`Clicked on the interior of the lines. objectId: ${objectId}`);
+        }}
+        enableClickableInterior
+        showBorder
+        fillColor={{ r: 1, g: 0, b: 0, a: 0.2 }}>
+        {[
+          {
+            ...lines[0],
+            id: 200,
+            color: { r: 1, g: 0, b: 0, a: 1 },
+            points: points.map(({ x, y, z }) => ({ x: x - 1, y: y - 1, z: z - 1 })),
+          },
+        ]}
       </Lines>
       <div
         style={{
           position: "absolute",
+          display: "flex",
+          flexDirection: "column",
+          padding: 8,
           left: 0,
           top: 0,
-          width: 320,
+          right: 0,
           maxWidth: "100%",
           color: "white",
           backgroundColor: "rgba(0, 0, 0, 0.5)",
         }}>
-        {clickedObj ? <span>Clicked line point id: {clickedObjId} </span> : <span>Click on any lines</span>}
+        <div>{msg}</div>
       </div>
     </Worldview>
   );

--- a/docs/src/jsx/commands/LinesHitmap.js
+++ b/docs/src/jsx/commands/LinesHitmap.js
@@ -8,6 +8,8 @@
 import React, { useState } from "react";
 import Worldview, { Lines, DEFAULT_CAMERA_STATE } from "regl-worldview";
 
+import LinesWithClickableInterior from "../utils/LinesWithClickableInterior";
+
 // #BEGIN EDITABLE
 function Example() {
   const defaultMsg = "Click on top of the green lines or inside the red area.";
@@ -43,7 +45,7 @@ function Example() {
         }}>
         {lines}
       </Lines>
-      <Lines
+      <LinesWithClickableInterior
         onClick={(ev, { object, objectId }) => {
           setMsg(`Clicked on the interior of the lines. objectId: ${objectId}`);
         }}
@@ -58,7 +60,7 @@ function Example() {
             points: points.map(({ x, y, z }) => ({ x: x - 1, y: y - 1, z: z - 1 })),
           },
         ]}
-      </Lines>
+      </LinesWithClickableInterior>
       <div
         style={{
           position: "absolute",

--- a/docs/src/jsx/utils/LinesWithClickableInterior.js
+++ b/docs/src/jsx/utils/LinesWithClickableInterior.js
@@ -1,0 +1,59 @@
+//@flow
+//  Copyright (c) 2018-present, GM Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+import React from "react";
+import { Lines, FilledPolygons, type Line, type Color, type CommandProps } from "regl-worldview";
+
+type LineProps = CommandProps<Line> & {
+  // when enabled, a polygon will be drawn using the line points, and the user will get the original
+  // line object after clicking inside the polygon
+  enableClickableInterior?: boolean,
+  // visually turn lines into polygons using custom fillColor
+  fillColor: Color,
+  // draw the lines around the polygon if enableClickableInterior is true
+  showBorder: boolean,
+};
+
+function LinesWithClickableInterior({
+  children,
+  enableClickableInterior,
+  fillColor,
+  onClick,
+  showBorder,
+  ...rest
+}: LineProps) {
+  if (enableClickableInterior) {
+    return (
+      <>
+        {showBorder && <Lines {...rest}>{children}</Lines>}
+        <FilledPolygons
+          onClick={(ev, { object, ...rest }) => {
+            onClick(ev, { ...rest, object: object.lineObject, objectId: object.lineObject.id });
+          }}>
+          {children.map((item) => ({
+            id: item.id,
+            points: item.points,
+            lineObject: item,
+            color: fillColor,
+          }))}
+        </FilledPolygons>
+      </>
+    );
+  }
+  return (
+    <Lines {...rest} onClick={onClick}>
+      {children}
+    </Lines>
+  );
+}
+
+LinesWithClickableInterior.defaultProps = {
+  fillColor: { r: 0, g: 0, b: 0, a: 0 },
+  showBorder: false,
+};
+
+export default LinesWithClickableInterior;

--- a/docs/src/jsx/utils/WorldviewCodeEditor.js
+++ b/docs/src/jsx/utils/WorldviewCodeEditor.js
@@ -43,6 +43,7 @@ import CodeEditor from "./CodeEditor";
 import duckModel from "./Duck.glb";
 import InputNumber from "./InputNumber";
 import LineControls from "./LineControls";
+import LinesWithClickableInterior from "./LinesWithClickableInterior";
 import useRange from "./useRange";
 
 // Add required packages and files for all examples to run
@@ -109,6 +110,7 @@ export const scope = {
   DEFAULT_CAMERA_STATE,
   CameraStateInfo,
   LineControls,
+  LinesWithClickableInterior,
   InputNumber,
 
   Command,

--- a/packages/regl-worldview/src/commands/Command.js
+++ b/packages/regl-worldview/src/commands/Command.js
@@ -40,6 +40,8 @@ export type Props<T> = {
   reglCommand: RawCommand<T>,
 };
 
+export type CommandProps = Props;
+
 export type MakeCommandOptions = {
   getHitmapProps: GetHitmapProps,
   getObjectFromHitmapId: GetObjectFromHitmapId,

--- a/packages/regl-worldview/src/commands/Cones.js
+++ b/packages/regl-worldview/src/commands/Cones.js
@@ -15,10 +15,10 @@ import { createCylinderGeometry } from "./Cylinders";
 const { points, sideFaces, endCapFaces } = createCylinderGeometry(30, true);
 
 const cones = fromGeometry(points, sideFaces.concat(endCapFaces));
-// prettier-ignore
-const Cylinders = makeCommand<BaseShape>('Cylinders', cones, {
-    getHitmapProps,
-    getObjectFromHitmapId,
-} );
+
+const Cylinders = makeCommand<BaseShape>("Cylinders", cones, {
+  getHitmapProps,
+  getObjectFromHitmapId,
+});
 
 export default Cylinders;

--- a/packages/regl-worldview/src/commands/Cubes.js
+++ b/packages/regl-worldview/src/commands/Cubes.js
@@ -45,8 +45,8 @@ const cubes = fromGeometry(
     [1, 4, 5],
   ]
 );
-// prettier-ignore
-const Cubes = makeCommand<Cube>('Cubes', cubes, {
+
+const Cubes = makeCommand<Cube>("Cubes", cubes, {
   getHitmapProps,
   getObjectFromHitmapId,
 });

--- a/packages/regl-worldview/src/commands/Cylinders.js
+++ b/packages/regl-worldview/src/commands/Cylinders.js
@@ -46,8 +46,8 @@ export function createCylinderGeometry(numSegments: number, cone: boolean) {
 const { points, sideFaces, endCapFaces } = createCylinderGeometry(30, false);
 
 const cylinders = fromGeometry(points, sideFaces.concat(endCapFaces));
-// prettier-ignore
-const Cylinders = makeCommand<Cylinder>('Cylinders', cylinders, {
+
+const Cylinders = makeCommand<Cylinder>("Cylinders", cylinders, {
   getHitmapProps,
   getObjectFromHitmapId,
 });

--- a/packages/regl-worldview/src/commands/FilledPolygons.js
+++ b/packages/regl-worldview/src/commands/FilledPolygons.js
@@ -53,12 +53,7 @@ type Props = {
 };
 
 // command to draw a filled polygon
-export default function FilledPolygons({
-  children: polygons = [],
-  getHitmapProps = getHitmapPropsForFilledPolygons,
-  getObjectFromHitmapId = getObjectFromHitmapIdForFilledPolygons,
-  ...rest
-}: Props) {
+function FilledPolygons({ children: polygons = [], getHitmapProps, getObjectFromHitmapId, ...rest }: Props) {
   const triangles = [];
   for (const poly of polygons) {
     // $FlowFixMe flow doesn't know how shouldConvert works
@@ -78,3 +73,10 @@ export default function FilledPolygons({
     </Triangles>
   );
 }
+
+FilledPolygons.defaultProps = {
+  getHitmapProps: getHitmapPropsForFilledPolygons,
+  getObjectFromHitmapId: getObjectFromHitmapIdForFilledPolygons,
+};
+
+export default FilledPolygons;

--- a/packages/regl-worldview/src/commands/Lines.js
+++ b/packages/regl-worldview/src/commands/Lines.js
@@ -7,7 +7,11 @@
 //  You may not use this file except in compliance with the License.
 
 import type { Line } from "../types";
-import { defaultBlend, withPose, toRGBA, shouldConvert, pointToVec3 } from "../utils/commandUtils";
+import { blend, withPose, toRGBA, shouldConvert, pointToVec3 } from "../utils/commandUtils";
+import {
+  getHitmapPropsForInstancedCommands as getHitmapProps,
+  getObjectForInstancedCommands as getObjectFromHitmapId,
+} from "../utils/hitmapDefaults";
 import { makeCommand } from "./Command";
 
 /*
@@ -252,7 +256,7 @@ const lines = (regl: any) => {
     withPose({
       vert,
       frag,
-      blend: defaultBlend,
+      blend,
       uniforms: {
         thickness: regl.prop("scale.x"),
         viewportWidth: regl.context("viewportWidth"),
@@ -350,6 +354,8 @@ const lines = (regl: any) => {
     if (debug) {
       regl({ depth: { enable: false } })(commands);
     } else {
+      // regl({ depth: { enable: false } })(commands);
+
       commands();
     }
   };
@@ -429,6 +435,9 @@ const lines = (regl: any) => {
 };
 
 // prettier-ignore
-const Lines = makeCommand<Line>('Lines', lines);
+const Lines = makeCommand<Line>('Lines', lines, {
+  getHitmapProps,
+  getObjectFromHitmapId
+});
 
 export default Lines;

--- a/packages/regl-worldview/src/commands/Lines.js
+++ b/packages/regl-worldview/src/commands/Lines.js
@@ -6,16 +6,13 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 
-import React from "react";
-
-import type { Line, Color } from "../types";
+import type { Line } from "../types";
 import { defaultBlend, withPose, toRGBA, shouldConvert, pointToVec3 } from "../utils/commandUtils";
 import {
   getHitmapPropsForInstancedCommands as getHitmapProps,
   getObjectForInstancedCommands as getObjectFromHitmapId,
 } from "../utils/hitmapDefaults";
-import { makeCommand, type Props } from "./Command";
-import FilledPolygons from "./FilledPolygons";
+import { makeCommand } from "./Command";
 
 /*
 Triangle-based line drawing.
@@ -440,48 +437,4 @@ const Lines = makeCommand<Line>("Lines", lines, {
   getObjectFromHitmapId,
 });
 
-export type LineProps = Props<Line> & {
-  enableClickableInterior?: boolean,
-  fillColor: Color, // visually turn lines into polygons using custom fillColor
-  showBorder: boolean,
-};
-
-function LinesWithClickableInterior({
-  children,
-  enableClickableInterior,
-  fillColor,
-  onClick,
-  showBorder,
-  ...rest
-}: LineProps) {
-  if (enableClickableInterior) {
-    return (
-      <>
-        {showBorder && <Lines {...rest}>{children}</Lines>}
-        <FilledPolygons
-          onClick={(ev, { object, ...rest }) => {
-            onClick(ev, { ...rest, object: object.lineObject, objectId: object.lineObject.id });
-          }}>
-          {children.map((item) => ({
-            id: item.id,
-            points: item.points,
-            lineObject: item,
-            color: fillColor,
-          }))}
-        </FilledPolygons>
-      </>
-    );
-  }
-  return (
-    <Lines {...rest} onClick={onClick}>
-      {children}
-    </Lines>
-  );
-}
-
-LinesWithClickableInterior.defaultProps = {
-  fillColor: { r: 0, g: 0, b: 0, a: 0 },
-  showBorder: false,
-};
-
-export default LinesWithClickableInterior;
+export default Lines;

--- a/packages/regl-worldview/src/commands/Lines.js
+++ b/packages/regl-worldview/src/commands/Lines.js
@@ -6,13 +6,16 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 
-import type { Line } from "../types";
-import { blend, withPose, toRGBA, shouldConvert, pointToVec3 } from "../utils/commandUtils";
+import React from "react";
+
+import type { Line, Color } from "../types";
+import { defaultBlend, withPose, toRGBA, shouldConvert, pointToVec3 } from "../utils/commandUtils";
 import {
   getHitmapPropsForInstancedCommands as getHitmapProps,
   getObjectForInstancedCommands as getObjectFromHitmapId,
 } from "../utils/hitmapDefaults";
-import { makeCommand } from "./Command";
+import { makeCommand, type Props } from "./Command";
+import FilledPolygons from "./FilledPolygons";
 
 /*
 Triangle-based line drawing.
@@ -256,7 +259,7 @@ const lines = (regl: any) => {
     withPose({
       vert,
       frag,
-      blend,
+      blend: defaultBlend,
       uniforms: {
         thickness: regl.prop("scale.x"),
         viewportWidth: regl.context("viewportWidth"),
@@ -354,8 +357,6 @@ const lines = (regl: any) => {
     if (debug) {
       regl({ depth: { enable: false } })(commands);
     } else {
-      // regl({ depth: { enable: false } })(commands);
-
       commands();
     }
   };
@@ -434,10 +435,53 @@ const lines = (regl: any) => {
   };
 };
 
-// prettier-ignore
-const Lines = makeCommand<Line>('Lines', lines, {
+const Lines = makeCommand<Line>("Lines", lines, {
   getHitmapProps,
-  getObjectFromHitmapId
+  getObjectFromHitmapId,
 });
 
-export default Lines;
+export type LineProps = Props<Line> & {
+  enableClickableInterior?: boolean,
+  fillColor: Color, // visually turn lines into polygons using custom fillColor
+  showBorder: boolean,
+};
+
+function LinesWithClickableInterior({
+  children,
+  enableClickableInterior,
+  fillColor,
+  onClick,
+  showBorder,
+  ...rest
+}: LineProps) {
+  if (enableClickableInterior) {
+    return (
+      <>
+        {showBorder && <Lines {...rest}>{children}</Lines>}
+        <FilledPolygons
+          onClick={(ev, { object, ...rest }) => {
+            onClick(ev, { ...rest, object: object.lineObject, objectId: object.lineObject.id });
+          }}>
+          {children.map((item) => ({
+            id: item.id,
+            points: item.points,
+            lineObject: item,
+            color: fillColor,
+          }))}
+        </FilledPolygons>
+      </>
+    );
+  }
+  return (
+    <Lines {...rest} onClick={onClick}>
+      {children}
+    </Lines>
+  );
+}
+
+LinesWithClickableInterior.defaultProps = {
+  fillColor: { r: 0, g: 0, b: 0, a: 0 },
+  showBorder: false,
+};
+
+export default LinesWithClickableInterior;

--- a/packages/regl-worldview/src/commands/Points.js
+++ b/packages/regl-worldview/src/commands/Points.js
@@ -61,8 +61,7 @@ const points = (regl: Regl) => {
   });
 };
 
-// prettier-ignore
-const Points = makeCommand<PointType>('Points', points,  {
+const Points = makeCommand<PointType>("Points", points, {
   getHitmapProps: getHitmapPropsForInstancedCommands,
   getObjectFromHitmapId: getObjectForInstancedCommands,
 });

--- a/packages/regl-worldview/src/commands/Triangles.js
+++ b/packages/regl-worldview/src/commands/Triangles.js
@@ -164,8 +164,7 @@ const triangles = (regl: Regl) => {
   };
 };
 
-// prettier-ignore
-const Triangles = makeCommand<TriangleList>('Triangles', triangles, {
+const Triangles = makeCommand<TriangleList>("Triangles", triangles, {
   getHitmapProps: getHitmapPropsForInstancedCommands,
   getObjectFromHitmapId: getObjectForInstancedCommands,
 });

--- a/packages/regl-worldview/src/utils/hitmapDefaults.js
+++ b/packages/regl-worldview/src/utils/hitmapDefaults.js
@@ -61,7 +61,7 @@ export function getObjectFromHitmapId<HitmapProp: HitmapMarkerDefault>(objectId:
 }
 
 //
-// ─── Points and Triangles (separate triangles props into their own if needed) ─────────────────────────────────
+// ─── Points, Lines and Triangles (separate triangles props into their own if needed) ─────────────────────────────────
 //
 export function getHitmapPropsForInstancedCommands<T: MarkerDefault>(children: T[]): ?(HitmapProp<T>[]) {
   if (!children || children.length === 0) {


### PR DESCRIPTION
## Summary
Add hitmap support to Lines so the user can click on the lines.

A few other small changes:
- Fix the props doc for Lines 
- Add query param `disableScroll` (nice to keep the page's scroll position during development)
- Clean up some prettier disable lines
- Add a new file `LinesWithClickableInterior` for the hitmap example in order to show to click the interior of the Polygon created by connecting the lines' points. 

## Test plan
Add a new `LinesHitmap` example:
```
const greenLines = {id: 191, points: ...}
const redLines = {id: 200, points: ...}
// Green lines, each point has different `objectId` which will be returned after clicking
<Lines onClick={...} >{greenLines} </Lines>
// Red lines with fillColor and border
<LinesWithClickableInterior onClick={...}  enableClickableInterior showBorder fillColor={{ r: 1, g: 0, b: 0, a: 0.2 }}>{redLines}</LinesWithClickableInterior>
```
![now](https://user-images.githubusercontent.com/10999093/56322400-d7901280-611d-11e9-94b2-0b998e6df6a0.gif)


## Versioning impact
No impact.