### PR TITLE
Add mouse interaction to GLTFScene

### DIFF
--- a/docs/src/4.12.GLTFScene.mdx
+++ b/docs/src/4.12.GLTFScene.mdx
@@ -1,4 +1,5 @@
-import {DuckScene} from './jsx/allLiveEditors';
+import { DuckScene } from './jsx/allLiveEditors';
+import { DuckSceneHitmap } from './jsx/allLiveEditors';
 
 # GLTFScene
 
@@ -18,3 +19,7 @@ import {DuckScene} from './jsx/allLiveEditors';
 This example shows a common sample model from [KhronosGroup/glTF-Sample-Models](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0).
 
 <DuckScene />
+
+## Mouse Interaction
+
+<DuckSceneHitmap />

--- a/docs/src/jsx/allLiveEditors.js
+++ b/docs/src/jsx/allLiveEditors.js
@@ -61,6 +61,8 @@ export const Cylinders = makeCodeComponent(require("!!raw-loader!./commands/Cyli
 
 export const DuckScene = makeCodeComponent(require("!!raw-loader!./commands/DuckScene"), "DuckScene");
 
+export const DuckSceneHitmap = makeCodeComponent(require("!!raw-loader!./commands/DuckSceneHitmap"), "DuckSceneHitmap");
+
 export const FilledPolygons = makeCodeComponent(require("!!raw-loader!./commands/FilledPolygons"), "FilledPolygons");
 
 export const FilledPolygonsHitmap = makeCodeComponent(

--- a/docs/src/jsx/commands/DuckSceneHitmap.js
+++ b/docs/src/jsx/commands/DuckSceneHitmap.js
@@ -1,0 +1,71 @@
+//  Copyright (c) 2019-present, GM Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+// #BEGIN EXAMPLE
+import React, { useState } from "react";
+import Worldview, { Axes, GLTFScene, DEFAULT_CAMERA_STATE } from "regl-worldview";
+
+import duckModel from "../utils/Duck.glb"; // URL pointing to a .glb file
+
+// #BEGIN EDITABLE
+function Example() {
+  const defaultMsg = "Click on any ducks";
+  const [msg, setMsg] = useState(defaultMsg);
+
+  const duckMarkerIds = new Array(3).fill().map((_, idx) => 12323 + idx);
+  const duckMarkers = duckMarkerIds.map((id, idx) => ({
+    id,
+    pose: {
+      position: { x: idx, y: idx, z: 0 },
+      orientation: { x: 0, y: 0, z: 0, w: 1 },
+    },
+    scale: { x: 1, y: 1, z: 1 },
+  }));
+
+  return (
+    <Worldview
+      defaultCameraState={{
+        ...DEFAULT_CAMERA_STATE,
+        distance: 15,
+        thetaOffset: (-3 * Math.PI) / 4,
+      }}
+      onClick={(ev, { objectId }) => {
+        if (!duckMarkerIds.includes(objectId)) {
+          setMsg(defaultMsg);
+        }
+      }}>
+      <Axes />
+      {duckMarkers.map((duckMarker) => (
+        <GLTFScene
+          key={duckMarker.id}
+          onClick={(ev, { object, objectId }) => {
+            setMsg(`Clicked on the duck. objectId: ${objectId}`);
+          }}
+          model={duckModel}>
+          {duckMarker}
+        </GLTFScene>
+      ))}
+      <div
+        style={{
+          position: "absolute",
+          display: "flex",
+          flexDirection: "column",
+          padding: 8,
+          left: 0,
+          top: 0,
+          right: 0,
+          maxWidth: "100%",
+          color: "white",
+          backgroundColor: "rgba(0, 0, 0, 0.5)",
+        }}>
+        <div>{msg}</div>
+      </div>
+    </Worldview>
+  );
+}
+// #END EXAMPLE
+
+export default Example;


### PR DESCRIPTION
## Summary
Add hitmap support for `GLTFScene` so the user can interact with the 3D models. 

## Test plan
Add `DuckSceneHitmap.js` example:
![now](https://user-images.githubusercontent.com/10999093/56329844-5bf08e80-613a-11e9-9d79-90df2ea03ecf.gif)

## Versioning impact
Minor: new api added and it's backward compatible.  

