### PR TITLE
Fix for controlled camera with state change callback.

### DIFF
--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -262,8 +262,11 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
   }
 
   render() {
-    const { width, height, showDebug, keyMap, shiftKeys, style, cameraState } = this.props;
+    const { width, height, showDebug, keyMap, shiftKeys, style, cameraState, onCameraStateChange } = this.props;
     const { worldviewContext } = this.state;
+    // If we are supplied controlled camera state and no onCameraStateChange callback
+    // then there is a 'fixed' camera from outside of worldview itself.
+    const isFixedCamera = cameraState && !onCameraStateChange;
     const canvasHtml = (
       <React.Fragment>
         <canvas
@@ -282,8 +285,8 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
 
     return (
       <div style={{ position: "relative", overflow: "hidden", ...style }}>
-        {/* skip rendering CameraListener if Worldview is controlled */}
-        {cameraState ? (
+        {/* skip rendering CameraListener if Worldview has a fixed camera */}
+        {isFixedCamera ? (
           canvasHtml
         ) : (
           <CameraListener cameraStore={worldviewContext.cameraStore} keyMap={keyMap} shiftKeys={shiftKeys}>


### PR DESCRIPTION
<!-- Thanks for contributing to Webviz! To help us understand and review your PR, please fill out the following sections: -->

## Summary

[This PR](https://github.com/cruise-automation/webviz/pull/114) disabled the camera listener and `onCameraStateChange` callback if the user supplied a `cameraState` to the component.  This breaks controlled components which register an `onCameraStateChange` callback + `cameraState` and use the callback + last camera state to control the component.  

The original change was similar to removing the `onChange` callback to an `<input />` element if the `value` property is supplied....it makes controlling the component based on user input impossible, since you are never notified of a change event.

## Test plan

Tested storybooks locally & docs locally.  Controlled cameras respond to mouse movement as expected now.

## Versioning impact

This is a semver patch change (bugfix only).
