### PR TITLE
Improve GLTF hitmap logic

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
   "eslint.autoFixOnSave": true,
   "flow.useNPMPackagedFlow": true,
   "javascript.validate.enable": false,
+  "typescript.validate.enable": false,
   "files.associations": {
     "*.mdx": "markdown"
   },

--- a/packages/regl-worldview/src/commands/GLTFScene.js
+++ b/packages/regl-worldview/src/commands/GLTFScene.js
@@ -261,18 +261,13 @@ export default class GLTFScene extends React.Component<Props, {| loadedModel: ?O
   }
 
   render() {
-    const {
-      children,
-      children: { id, ...restOfChildren },
-      ...rest
-    } = this.props;
-
+    const { children, ...rest } = this.props;
     const { loadedModel } = this.state;
     if (!loadedModel) {
       return null;
     }
 
-    const drawHitmap = id != null;
+    const drawHitmap = children.id != null;
 
     return (
       <WorldviewReactContext.Consumer>
@@ -282,7 +277,7 @@ export default class GLTFScene extends React.Component<Props, {| loadedModel: ?O
             <Command
               {...rest}
               reglCommand={drawModel}
-              drawProps={{ ...restOfChildren, model: loadedModel }}
+              drawProps={{ ...children, id: null, model: loadedModel }}
               hitmapProps={drawHitmap ? { ...children, model: loadedModel } : undefined}
               getObjectFromHitmapId={(objId, hitmapProps) => (hitmapProps.id === objId ? hitmapProps : undefined)}
             />

--- a/packages/regl-worldview/src/commands/GLTFScene.js
+++ b/packages/regl-worldview/src/commands/GLTFScene.js
@@ -200,7 +200,7 @@ const drawModel = (regl) => {
         ),
       globalAlpha: (context, props) => (props.alpha == null ? 1 : props.alpha),
       hitmapColor: (context, props) => intToRGB(props.id),
-      drawHitmap: (context, props) => !!props.drawHitmap,
+      drawHitmap: (context, props) => props.id != null,
     },
   });
 
@@ -261,16 +261,18 @@ export default class GLTFScene extends React.Component<Props, {| loadedModel: ?O
   }
 
   render() {
-    const { children, ...rest } = this.props;
+    const {
+      children,
+      children: { id, ...restOfChildren },
+      ...rest
+    } = this.props;
 
     const { loadedModel } = this.state;
     if (!loadedModel) {
       return null;
     }
 
-    const drawHitmap =
-      children.id && (rest.onDoubleClick || rest.onMouseDown || rest.onMouseUp || rest.onMouseMove || rest.onClick);
-    const sharedDrawProps = { model: loadedModel, ...children };
+    const drawHitmap = id != null;
 
     return (
       <WorldviewReactContext.Consumer>
@@ -280,8 +282,8 @@ export default class GLTFScene extends React.Component<Props, {| loadedModel: ?O
             <Command
               {...rest}
               reglCommand={drawModel}
-              drawProps={sharedDrawProps}
-              hitmapProps={drawHitmap ? { ...sharedDrawProps, drawHitmap } : undefined}
+              drawProps={{ ...restOfChildren, model: loadedModel }}
+              hitmapProps={drawHitmap ? { ...children, model: loadedModel } : undefined}
               getObjectFromHitmapId={(objId, hitmapProps) => (hitmapProps.id === objId ? hitmapProps : undefined)}
             />
           );


### PR DESCRIPTION
## Summary
Address Jacob's [comment](https://github.com/cruise-automation/webviz/pull/132/files#r277456567): remove redundant `drawHitmap` and always draw hitmap if `id` is present. This is helpful for preventing clicking through objects in the 3d space. (Currently Worldview doesn't automatically draw hitmap for all which may cause some overlay clicking issue. We'll discuss and address it later.)

## Test plan
The existing GLTF hitmap example continues to work as expected. 

## Versioning impact
No impact
