### PR TITLE
Allow for multiple GLTFScenes

### DIFF
--- a/packages/regl-worldview/src/commands/GLTFScene.js
+++ b/packages/regl-worldview/src/commands/GLTFScene.js
@@ -232,6 +232,8 @@ export default class GLTFScene extends React.Component<Props, {| loadedModel: ?O
     loadedModel: undefined,
   };
   _context = undefined;
+  _drawModel = undefined;
+
   async _loadModel(): Promise<Object> {
     const { model } = this.props;
     if (typeof model === "function") {
@@ -248,6 +250,7 @@ export default class GLTFScene extends React.Component<Props, {| loadedModel: ?O
   }
 
   componentDidMount() {
+    this._drawModel = (regl) => drawModel(regl);
     this._loadModel()
       .then((loadedModel) => {
         this.setState({ loadedModel });
@@ -276,7 +279,7 @@ export default class GLTFScene extends React.Component<Props, {| loadedModel: ?O
           return (
             <Command
               {...rest}
-              reglCommand={drawModel}
+              reglCommand={this._drawModel}
               drawProps={{ ...children, id: null, model: loadedModel }}
               hitmapProps={drawHitmap ? { ...children, model: loadedModel } : undefined}
               getObjectFromHitmapId={(objId, hitmapProps) => (hitmapProps.id === objId ? hitmapProps : undefined)}


### PR DESCRIPTION
## Summary

You can only use one model across all `GLTFScene`s. `drawModel` keeps some internal state (`drawCalls`) which is not generated again when you provide different models. This is because `WorldViewContext._commands` is a `Set` and just checks to see whether `drawModel` has ever been registered in `onMount`. Since it has, subsequent `GLTFScene`s keep the same `drawCalls` state and therefore just draw the first mesh that got loaded.

The simplest solution here (if not a bit naive) is to hide `drawModel` behind a lambda in `componentDidMount` so that individual instances of `GLTFScene` all get `reglCommand`s with unique references.

## Test plan

Reproduced locally, I'm not sure how y'all usually test this stuff.

## Versioning impact

No idea, feel free to edit this PR
