### PR TITLE
Fix clickable interior example for codesandbox

### DIFF
--- a/docs/src/jsx/utils/LinesWithClickableInterior.js
+++ b/docs/src/jsx/utils/LinesWithClickableInterior.js
@@ -6,29 +6,22 @@
 //  You may not use this file except in compliance with the License.
 
 import React from "react";
-import { Lines, FilledPolygons, type Line, type Color, type CommandProps } from "regl-worldview";
+import { Lines, FilledPolygons } from "regl-worldview";
 
-type LineProps = CommandProps<Line> & {
-  // when enabled, a polygon will be drawn using the line points, and the user will get the original
-  // line object after clicking inside the polygon
-  enableClickableInterior?: boolean,
-  // visually turn lines into polygons using custom fillColor
-  fillColor: Color,
-  // draw the lines around the polygon if enableClickableInterior is true
-  showBorder: boolean,
-};
+// type LineProps = CommandProps<Line> & {
+//   // when enabled, a polygon will be drawn using the line points, and the user will get the original
+//   // line object after clicking inside the polygon
+//   enableClickableInterior?: boolean,
+//   // visually turn lines into polygons using custom fillColor
+//   fillColor: Color,
+//   // draw the lines around the polygon if enableClickableInterior is true
+//   showBorder: boolean,
+// };
 
-function LinesWithClickableInterior({
-  children,
-  enableClickableInterior,
-  fillColor,
-  onClick,
-  showBorder,
-  ...rest
-}: LineProps) {
+function LinesWithClickableInterior({ children, enableClickableInterior, fillColor, onClick, showBorder, ...rest }) {
   if (enableClickableInterior) {
     return (
-      <>
+      <React.Fragment>
         {showBorder && <Lines {...rest}>{children}</Lines>}
         <FilledPolygons
           onClick={(ev, { object, ...rest }) => {
@@ -41,7 +34,7 @@ function LinesWithClickableInterior({
             color: fillColor,
           }))}
         </FilledPolygons>
-      </>
+      </React.Fragment>
     );
   }
   return (

--- a/docs/src/jsx/utils/WorldviewCodeEditor.js
+++ b/docs/src/jsx/utils/WorldviewCodeEditor.js
@@ -73,6 +73,9 @@ const CODE_SANDBOX_CONFIG = {
       content: "https://uploads.codesandbox.io/uploads/user/dfcf1de7-30d4-4c5b-9675-546a91ea8afb/04aB-CesiumMan.glb",
       isBinary: true,
     },
+    "utils/LinesWithClickableInterior.js": {
+      content: require("!!raw-loader!./LinesWithClickableInterior.js"),
+    },
     "utils/useRange.js": {
       content: require("!!raw-loader!./useRange.js"),
     },


### PR DESCRIPTION
## Summary
The Mouse Interaction example for lines is broken in codesandbox due to missing the util file and lacking support for flowtypes and `<></>`.

## Test plan
The new codesandbox link should work: https://codesandbox.io/s/delicate-violet-ytw2o

## Versioning impact
No impact. 
