### PR TITLE
add OpenGraph tags to landing page

### DIFF
--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -17,7 +17,11 @@ maximum-scale=1.0, user-scalable=no" />
     <meta name="description" content="Visualizing robotics data in the browser">
     <title>Webviz</title>
     <link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Mono&display=swap" rel="stylesheet">
-    <link rel="stylesheet" type="text/css" href="./style.css">
+    <meta property="og:title" content="Webviz" />
+    <meta property="og:description" content="Visualizing robotics data in the browser" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://webviz.io" />
+    <meta property="og:image" content="https://open-source-webviz-ui.s3-us-west-2.amazonaws.com/landing/og-image.png" />
     <style>
       @import url('https://rsms.me/inter/inter.css');
       html {


### PR DESCRIPTION
For better embedding in Slack and other sites/tools that support [OpenGraph](http://ogp.me/).

Also removed a `<link>` to a CSS file that didn't exist.