### PR TITLE
Pushing encoder changes to support the encoder version RGB

### DIFF
--- a/packages/webviz-core/src/panels/ImageView/ImageCanvas.js
+++ b/packages/webviz-core/src/panels/ImageView/ImageCanvas.js
@@ -14,6 +14,7 @@ import CameraModel from "./CameraModel";
 import {
   decodeYUV,
   decodeBGR,
+  decodeRGB,
   decodeFloat1c,
   decodeBayerRGGB8,
   decodeBayerBGGR8,
@@ -92,6 +93,7 @@ export default class ImageCanvas extends React.Component<Props, State> {
         switch (encoding) {
           case "yuv422": decodeYUV(rawData, width, height, image.data); break;
           case "bgr8": decodeBGR(rawData, width, height, image.data); break;
+          case "rgb8": decodeRGB(rawData, width, height, image.data); break;
           case "32FC1": decodeFloat1c(rawData, width, height, is_bigendian, image.data); break;
           case "bayer_rggb8": decodeBayerRGGB8(rawData, width, height, image.data); break;
           case "bayer_bggr8": decodeBayerBGGR8(rawData, width, height, image.data); break;

--- a/packages/webviz-core/src/panels/ImageView/decodings.js
+++ b/packages/webviz-core/src/panels/ImageView/decodings.js
@@ -51,6 +51,25 @@ export function decodeBGR(bgr: Uint8Array, width: number, height: number, output
   }
 }
 
+//Handle the encoding version rgb
+export function decodeRGB(rgb: Uint8Array, width: number, height: number, output: Uint8ClampedArray) {
+  let inIdx = 0;
+  let outIdx = 0;
+
+  for (let i = 0; i < width * height; i++) {
+    const r = rgb[inIdx++];
+    const g = rgb[inIdx++];
+    const b = rgb[inIdx++];
+
+
+    output[outIdx++] = r;
+    output[outIdx++] = g;
+    output[outIdx++] = b;
+
+    output[outIdx++] = 255;
+  }
+}
+
 export function decodeFloat1c(
   gray: Uint8Array,
   width: number,


### PR DESCRIPTION
<!-- Thanks for contributing to Webviz! To help us understand and review your PR, please fill out the following sections: -->

## Summary

This change is being requested to support Image View for ROS bag files that have been recorded with RGB Image encoding. BGR is already supported, but this change adds support for RGB images too.

## Test plan

This change was tested by loading the /camera/rgb/image_raw view with a ROS Bag file that was recorded with RGB encoding format. The Camera image and video feed load and work fine.

## Versioning impact

Requires a patched version.
