### PR TITLE
Update `max_old_space_size`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             - regl-worldview-deps-{{ checksum "packages/regl-worldview/package-lock.json" }}
             - regl-worldview-deps-
 
-      - run: docker run -v `pwd`:`pwd` -w `pwd` -it --rm -e CI cruise/webviz-ci:0.0.7 npm run ci
+      - run: docker run -v `pwd`:`pwd` -w `pwd` -it --rm -e CI cruise/webviz-ci:0.0.8 npm run ci
 
       - save_cache:
           paths: ["node_modules"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,6 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 ENV WEBVIZ_IN_DOCKER=true
+
+# Bumped up from the default old_space size (512mb) as it was being exceeded during builds.
 ENV NODE_OPTIONS="--max_old_space_size=4096"

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 ENV WEBVIZ_IN_DOCKER=true
-ENV NODE_OPTIONS="--max_old_space_size=128"
+ENV NODE_OPTIONS="--max_old_space_size=4096"

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,4 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 ENV WEBVIZ_IN_DOCKER=true
+ENV NODE_OPTIONS="--max_old_space_size=128"


### PR DESCRIPTION
## Summary

Some open source builds are failing due to a heap allocation exceeded error. This PR simply increases the size to ~4gb (the default is 512mb).

## Test plan

Builds will pass!

## Versioning impact

Image will be bumped to `0.0.8`.
