### PR TITLE
Bump wasm-lz4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,5 @@ __screenshots__/
 
 # build files
 dist/
-!/docs/public/dist/wasm-lz4.wasm # need this symlink to stay there
 lib/
 

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "flow": "flow",
     "flow-typed-rebuild": "rm -rf flow-typed/ && flow-typed install && flow-typed install --rootDir packages/@cruise-automation/hooks && flow-typed install --rootDir packages/@cruise-automation/button && flow-typed install --rootDir packages/@cruise-automation/tooltip && flow-typed install --rootDir packages/react-key-listener && flow-typed install --rootDir packages/regl-worldview",
     "docs": "DEV_SERVER=true webpack-dev-server",
-    "docs-deploy": "cp -r docs/public __temp_deploy__ && cp --remove-destination packages/webviz-core/public/index.html __temp_deploy__/try/index.html && cp --remove-destination packages/webviz-core/node_modules/wasm-lz4/wasm-lz4.wasm __temp_deploy__/dist/wasm-lz4.wasm && echo 'webviz.io' > __temp_deploy__/CNAME && gh-pages -d __temp_deploy__ && rm -rf __temp_deploy__",
+    "docs-deploy": "cp -r docs/public __temp_deploy__ && cp --remove-destination packages/webviz-core/public/index.html __temp_deploy__/try/index.html && echo 'webviz.io' > __temp_deploy__/CNAME && gh-pages -d __temp_deploy__ && rm -rf __temp_deploy__",
     "publish": "lerna run clean && lerna run build && lerna publish",
     "screenshot": "NODE_ENV=development storybook-chrome-screenshot -c stories --parallel 8 --inject-files stories/injected.js --browser-timeout 1200000",
     "screenshot-ci": "npm run screenshot -- --puppeteer-launch-config '{\"executablePath\": \"/usr/bin/google-chrome\", \"headless\": false, \"args\":[\"--use-gl=swiftshader\", \"--no-sandbox\",\"--disable-setuid-sandbox\", \"--disable-dev-shm-usage\", \"--headless\", \"--mute-audio\"]}'",

--- a/packages/webviz-core/package-lock.json
+++ b/packages/webviz-core/package-lock.json
@@ -1644,9 +1644,9 @@
       }
     },
     "wasm-lz4": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wasm-lz4/-/wasm-lz4-0.0.2.tgz",
-      "integrity": "sha512-cUd61ai+Q8T9g9CB6vLfgXPigw0+11QXh3bWhUgrWWwFyCZBagQQC4dYv4JJz+Ii2L1Pz4jpw+6Zr7QzJPtTIg=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wasm-lz4/-/wasm-lz4-1.0.0.tgz",
+      "integrity": "sha512-PEgCHJIjBUvyvFjEwO5eH0w+RQZ7HWWyQccIQH9WoVM3tredHGqJ5/f0s5+BagLK8zriKZYuo5e379n5/Zef0w=="
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/packages/webviz-core/package.json
+++ b/packages/webviz-core/package.json
@@ -60,7 +60,7 @@
     "text-width": "1.2.0",
     "tinycolor2": "1.4.1",
     "uuid": "3.3.2",
-    "wasm-lz4": "0.0.2"
+    "wasm-lz4": "1.0.0"
   },
   "devDependencies": {
     "eslint-plugin-react-hooks": "^1.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,8 +75,8 @@ module.exports = {
     rules: [
       {
         test: /\.wasm$/,
-        // Bypass webpack's default importing logic, and just import the file
-        // as-is.
+        // Bypass webpack's default importing logic for .wasm files.
+        // https://webpack.js.org/configuration/module/#ruletype
         type: "javascript/auto",
         use: {
           loader: "file-loader",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,6 +74,18 @@ module.exports = {
     strictExportPresence: true,
     rules: [
       {
+        test: /\.wasm$/,
+        // Bypass webpack's default importing logic, and just import the file
+        // as-is.
+        type: "javascript/auto",
+        use: {
+          loader: "file-loader",
+          options: {
+            name: "[name]-[hash].[ext]",
+          },
+        },
+      },
+      {
         test: /\.worker\.js$/,
         use: {
           loader: "worker-loader",


### PR DESCRIPTION
## Summary

Bump the lz4-wasm package with the corresponding webpack config. I also took out the old way of pulling in the wasm module (specified in the root `package.json`). 

## Test plan

Verified build was working, and the wasm dependency was pulled in. 

## Versioning impact

We don't distribute webviz-core as a package right?
