### PR TITLE
Fix grid not rendering

### DIFF
--- a/docs/src/4.14.Grid.mdx
+++ b/docs/src/4.14.Grid.mdx
@@ -1,0 +1,13 @@
+import { Grid } from './jsx/allLiveEditors'
+
+# Grid
+
+`<Grid/>` draws a grid on the X-Y plane.
+
+## Props
+
+| Name       | Type     | Default | Description                     |
+| ---------- | -------- | ------- | ------------------------------- |
+| `count`    | `number` | 6       | Count of boxes in each direction created for the grid. |
+
+<Grid />

--- a/docs/src/jsx/allLiveEditors.js
+++ b/docs/src/jsx/allLiveEditors.js
@@ -77,6 +77,8 @@ export const GLTFScene = makeCodeComponent(require("!!raw-loader!./commands/GLTF
 
 export const GLTFSceneHitmap = makeCodeComponent(require("!!raw-loader!./commands/GLTFSceneHitmap"), "GLTFSceneHitmap");
 
+export const Grid = makeCodeComponent(require("!!raw-loader!./commands/Grid"), "Grid");
+
 export const LinesDemo = makeCodeComponent(require("!!raw-loader!./commands/LinesDemo"), "LinesDemo");
 
 export const LinesHitmap = makeCodeComponent(require("!!raw-loader!./commands/LinesHitmap"), "LinesHitmap");

--- a/docs/src/jsx/commands/Grid.js
+++ b/docs/src/jsx/commands/Grid.js
@@ -1,0 +1,47 @@
+//  Copyright (c) 2018-present, GM Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+// #BEGIN EXAMPLE
+import React, { useState } from "react";
+import Worldview, { Grid, Axes } from "regl-worldview";
+
+// #BEGIN EDITABLE
+function Example() {
+  const [count, setCount] = useState(6);
+  const validatedCount = isNaN(count) || count < 1 ? 6 : Math.round(count);
+
+  return (
+    <Worldview>
+      <Grid count={validatedCount} />
+      <Axes />
+      <div
+        style={{
+          position: "absolute",
+          display: "flex",
+          flexDirection: "column",
+          padding: 8,
+          left: 0,
+          top: 0,
+          right: 0,
+          maxWidth: "100%",
+          color: "white",
+          backgroundColor: "rgba(0, 0, 0, 0.5)",
+        }}>
+        <div>
+          Set grid count:
+          <input
+            style={{ width: 32, marginLeft: 8 }}
+            value={count}
+            onChange={(event) => setCount(Number(event.target.value))}
+          />
+        </div>
+      </div>
+    </Worldview>
+  );
+}
+// #END EXAMPLE
+
+export default Example;

--- a/docs/src/routes.js
+++ b/docs/src/routes.js
@@ -26,6 +26,7 @@ import Text from "./4.10.Text.mdx";
 import Triangles from "./4.11.Triangles.mdx";
 import GLTFScene from "./4.12.GLTFScene.mdx";
 import DrawPolygons from "./4.13.DrawPolygons.mdx";
+import Grid from "./4.14.Grid.mdx";
 import Cones from "./4.2.Cones.mdx";
 import Cubes from "./4.3.Cubes.mdx";
 import Cylinders from "./4.4.Cylinders.mdx";
@@ -64,6 +65,7 @@ export const componentList = {
   Flow,
   GLTFScene,
   DrawPolygons,
+  Grid,
   BrowserSupport,
   Glossary,
 };
@@ -98,6 +100,7 @@ const ROUTE_CONFIG = [
       "Triangles",
       "GLTFScene",
       "DrawPolygons",
+      "Grid",
     ],
   },
 ];

--- a/packages/regl-worldview/src/commands/Grid.js
+++ b/packages/regl-worldview/src/commands/Grid.js
@@ -10,7 +10,9 @@ import React from "react";
 
 import { withPose } from "../utils/commandUtils";
 import { nonInstancedGetChildrenForHitmap } from "../utils/getChildrenForHitmapDefaults";
-import Command from "./Command";
+import Command, { type CommonCommandProps } from "./Command";
+
+const DEFAULT_GRID_COLOR = [0.3, 0.3, 0.3, 1];
 
 export function grid() {
   return withPose({
@@ -19,8 +21,11 @@ export function grid() {
     uniform mat4 projection, view;
 
     attribute vec3 point;
+    attribute vec4 color;
+    varying vec4 fragColor;
 
     void main () {
+      fragColor = color;
       vec3 p = point;
       gl_Position = projection * view * vec4(p, 1);
     }
@@ -44,9 +49,13 @@ export function grid() {
         }
         return points;
       },
+      color: (context, props) => {
+        const color = props.color || DEFAULT_GRID_COLOR;
+        return new Array(props.count * 4 * 2).fill(color);
+      },
     },
     count: (context, props) => {
-      // 6 points per count
+      // 8 points per count
       const count = props.count * 4 * 2;
       return count;
     },
@@ -54,14 +63,21 @@ export function grid() {
 }
 
 type Props = {
-  layerIndex?: ?number,
   count: number,
+  ...CommonCommandProps,
 };
 
 // useful for rendering a grid for debugging in stories
 
-export default function Grid(props: Props) {
-  return <Command getChildrenForHitmap={nonInstancedGetChildrenForHitmap} {...props} reglCommand={grid} />;
+function Grid({ count, ...rest }: Props) {
+  const children = { count };
+  return (
+    <Command getChildrenForHitmap={nonInstancedGetChildrenForHitmap} {...rest} reglCommand={grid}>
+      {children}
+    </Command>
+  );
 }
 
 Grid.defaultProps = { count: 6 };
+
+export default React.memo<Props>(Grid);


### PR DESCRIPTION
## Summary

Because of the changes to hitmap rendering, grid rendering broke.
Fix it by updating the shader to handle new hitmapId mapping, and
also add a doc page for grids.

## Test plan

Added grid doc route, manually tested

## Versioning impact

May require a 0.2.1 package for fixes.