### PR TITLE
Add engines to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "root",
   "private": true,
+  "engines": {
+    "node": ">=10.0.0 <12.0.0",
+    "npm": ">=6.0.0"
+  },
   "devDependencies": {
     "@babel/cli": "^7.1.5",
     "@babel/core": "^7.2.0",


### PR DESCRIPTION
Add "engines" section because our build currently doesn't work with
node v8. Prints a warning when using the wrong node version.

Test plan: manual
