### PR TITLE
Re-bump wasm-lz4

### DIFF
--- a/packages/webviz-core/package-lock.json
+++ b/packages/webviz-core/package-lock.json
@@ -1844,9 +1844,9 @@
       }
     },
     "wasm-lz4": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wasm-lz4/-/wasm-lz4-0.0.2.tgz",
-      "integrity": "sha512-cUd61ai+Q8T9g9CB6vLfgXPigw0+11QXh3bWhUgrWWwFyCZBagQQC4dYv4JJz+Ii2L1Pz4jpw+6Zr7QzJPtTIg=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wasm-lz4/-/wasm-lz4-1.0.0.tgz",
+      "integrity": "sha512-PEgCHJIjBUvyvFjEwO5eH0w+RQZ7HWWyQccIQH9WoVM3tredHGqJ5/f0s5+BagLK8zriKZYuo5e379n5/Zef0w=="
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/packages/webviz-core/package.json
+++ b/packages/webviz-core/package.json
@@ -62,7 +62,7 @@
     "text-width": "1.2.0",
     "tinycolor2": "1.4.1",
     "uuid": "3.3.2",
-    "wasm-lz4": "0.0.2"
+    "wasm-lz4": "1.0.0"
   },
   "devDependencies": {
     "@testing-library/react-hooks": "1.1.0",


### PR DESCRIPTION
## Summary

Looks like things got out of sync with https://github.com/cruise-automation/webviz/pull/199. I forgot to bump the package.json in the internal repo, so when things got copied over, we got the old version of wasm-lz4.