### PR TITLE
Add FOV and frustum plane distances to cameraState

### DIFF
--- a/docs/src/2.5.AddingInteractivity.mdx
+++ b/docs/src/2.5.AddingInteractivity.mdx
@@ -34,7 +34,7 @@ Let's also enable manual camera movement, so we can see the duck better.
 
 ```js
 // use `defaultCameraState` to turn Worldview to uncontrolled component
-<Worldview defaultCameraState={{ ...DEFAULT_CAMERA_STATE, distance: 160 }}>
+<Worldview defaultCameraState={{ distance: 160 }}>
 ```
 
 Next, let's add a `clickedObjectIds` state to keep track of the clicked spheres. We'll also use this `clickedObjectIds` state to generate cube obstacles.

--- a/docs/src/3.2.Camera.mdx
+++ b/docs/src/3.2.Camera.mdx
@@ -24,7 +24,7 @@ You can move the camera around using the mouse/trackpad, or by using the keyboar
 | `distance`          | `number`  | `75`           | distance between the camera and target                                                          |
 | `phi`               | `number`  | `Math.PI/4`    | angle in radians from +z pole to -z pole, range: [0, π]. Ignored when `perspective` is false    |
 | `thetaOffset`       | `number`  | `0`            | offset azimuth angle in radians, +θ corresponds to +x→+y, range: [0, 2π]                        |
-| `fov`               | `number`  | `Math.PI/4`    | field of view in radians                                                                        |
+| `fovy`              | `number`  | `Math.PI/4`    | field of view in the y direction, in radians                                                    |
 | `near`              | `number`  | `0.01`         | distance to the frustum near plane                                                              |
 | `far`               | `number`  | `5000`         | distance to the frustum far plane                                                               |
 

--- a/docs/src/3.2.Camera.mdx
+++ b/docs/src/3.2.Camera.mdx
@@ -24,6 +24,9 @@ You can move the camera around using the mouse/trackpad, or by using the keyboar
 | `distance`          | `number`  | `75`           | distance between the camera and target                                                          |
 | `phi`               | `number`  | `Math.PI/4`    | angle in radians from +z pole to -z pole, range: [0, π]. Ignored when `perspective` is false    |
 | `thetaOffset`       | `number`  | `0`            | offset azimuth angle in radians, +θ corresponds to +x→+y, range: [0, 2π]                        |
+| `fov`               | `number`  | `Math.PI/4`    | field of view in radians                                                                        |
+| `near`              | `number`  | `0.01`         | distance to the frustum near plane                                                              |
+| `far`               | `number`  | `5000`         | distance to the frustum far plane                                                               |
 
 <CameraState />
 

--- a/docs/src/jsx/api/CameraState.js
+++ b/docs/src/jsx/api/CameraState.js
@@ -8,7 +8,15 @@
 
 import { quat, vec3 } from "gl-matrix";
 import React, { useState } from "react";
-import Worldview, { Arrows, Spheres, Axes, Grid, cameraStateSelectors, type CameraState } from "regl-worldview";
+import Worldview, {
+  DEFAULT_CAMERA_STATE,
+  Arrows,
+  Spheres,
+  Axes,
+  Grid,
+  cameraStateSelectors,
+  type CameraState,
+} from "regl-worldview";
 
 import CameraStateControls from "../utils/CameraStateControls";
 
@@ -29,6 +37,9 @@ export default function Example() {
     target: [0, 0, 0],
     targetOrientation: [0, 0, 0, 1],
     targetOffset: [0, 0, 0],
+    fov: Math.PI / 4,
+    near: 0.01,
+    far: 1000,
   });
 
   const targetHeading = cameraStateSelectors.targetHeading(cameraState);
@@ -101,6 +112,7 @@ export default function Example() {
         <div style={{ flex: "1 1 0" }}>
           <Worldview
             defaultCameraState={{
+              ...DEFAULT_CAMERA_STATE,
               perspective: true,
               distance: 150,
               thetaOffset: 0.5,

--- a/docs/src/jsx/api/CameraState.js
+++ b/docs/src/jsx/api/CameraState.js
@@ -8,15 +8,7 @@
 
 import { quat, vec3 } from "gl-matrix";
 import React, { useState } from "react";
-import Worldview, {
-  DEFAULT_CAMERA_STATE,
-  Arrows,
-  Spheres,
-  Axes,
-  Grid,
-  cameraStateSelectors,
-  type CameraState,
-} from "regl-worldview";
+import Worldview, { Arrows, Spheres, Axes, Grid, cameraStateSelectors, type CameraState } from "regl-worldview";
 
 import CameraStateControls from "../utils/CameraStateControls";
 
@@ -112,7 +104,6 @@ export default function Example() {
         <div style={{ flex: "1 1 0" }}>
           <Worldview
             defaultCameraState={{
-              ...DEFAULT_CAMERA_STATE,
               perspective: true,
               distance: 150,
               thetaOffset: 0.5,

--- a/docs/src/jsx/api/CameraState.js
+++ b/docs/src/jsx/api/CameraState.js
@@ -37,7 +37,7 @@ export default function Example() {
     target: [0, 0, 0],
     targetOrientation: [0, 0, 0, 1],
     targetOffset: [0, 0, 0],
-    fov: Math.PI / 4,
+    fovy: Math.PI / 4,
     near: 0.01,
     far: 1000,
   });

--- a/docs/src/jsx/api/CameraStateControlled.js
+++ b/docs/src/jsx/api/CameraStateControlled.js
@@ -6,14 +6,14 @@
 
 // #BEGIN EXAMPLE
 import React, { useState } from "react";
-import Worldview, { Axes, Grid, DEFAULT_CAMERA_STATE } from "regl-worldview";
+import Worldview, { Axes, Grid } from "regl-worldview";
 
 import InputNumber from "../utils/InputNumber";
 
 // #BEGIN EDITABLE
 function Example() {
   const [distance, setDistance] = useState(100);
-  const [cameraState, setCameraState] = useState({ ...DEFAULT_CAMERA_STATE, distance });
+  const [cameraState, setCameraState] = useState({ distance });
 
   return (
     <Worldview

--- a/docs/src/jsx/api/CameraStateUncontrolled.js
+++ b/docs/src/jsx/api/CameraStateUncontrolled.js
@@ -6,7 +6,7 @@
 
 // #BEGIN EXAMPLE
 import React, { useState } from "react";
-import Worldview, { Axes, Grid, DEFAULT_CAMERA_STATE } from "regl-worldview";
+import Worldview, { Axes, Grid } from "regl-worldview";
 
 import InputNumber from "../utils/InputNumber";
 
@@ -17,7 +17,6 @@ function Example() {
   return (
     <Worldview
       defaultCameraState={{
-        ...DEFAULT_CAMERA_STATE,
         distance,
       }}>
       <div

--- a/docs/src/jsx/commands/GLTFScene.js
+++ b/docs/src/jsx/commands/GLTFScene.js
@@ -6,7 +6,7 @@
 
 // #BEGIN EXAMPLE
 import React, { useState } from "react";
-import Worldview, { Axes, Grid, GLTFScene, DEFAULT_CAMERA_STATE } from "regl-worldview";
+import Worldview, { Axes, Grid, GLTFScene } from "regl-worldview";
 
 import cesiumManModel from "../utils/CesiumMan.glb";
 import duckModel from "../utils/Duck.glb"; // URL pointing to a .glb file
@@ -17,7 +17,6 @@ function Example() {
   return (
     <Worldview
       defaultCameraState={{
-        ...DEFAULT_CAMERA_STATE,
         distance: 25,
         thetaOffset: (-3 * Math.PI) / 4,
       }}>

--- a/docs/src/jsx/commands/GLTFSceneHitmap.js
+++ b/docs/src/jsx/commands/GLTFSceneHitmap.js
@@ -6,7 +6,7 @@
 
 // #BEGIN EXAMPLE
 import React, { useState } from "react";
-import Worldview, { Axes, GLTFScene, DEFAULT_CAMERA_STATE } from "regl-worldview";
+import Worldview, { Axes, GLTFScene } from "regl-worldview";
 
 import duckModel from "../utils/Duck.glb"; // URL pointing to a .glb file
 
@@ -28,7 +28,6 @@ function Example() {
   return (
     <Worldview
       defaultCameraState={{
-        ...DEFAULT_CAMERA_STATE,
         distance: 15,
         thetaOffset: (-3 * Math.PI) / 4,
       }}

--- a/docs/src/jsx/commands/LinesHitmap.js
+++ b/docs/src/jsx/commands/LinesHitmap.js
@@ -6,7 +6,7 @@
 
 // #BEGIN EXAMPLE
 import React, { useState } from "react";
-import Worldview, { Lines, DEFAULT_CAMERA_STATE } from "regl-worldview";
+import Worldview, { Lines } from "regl-worldview";
 
 import LinesWithClickableInterior from "../utils/LinesWithClickableInterior";
 
@@ -38,7 +38,7 @@ function Example() {
           setMsg(defaultMsg);
         }
       }}
-      defaultCameraState={{ ...DEFAULT_CAMERA_STATE, distance: 10 }}>
+      defaultCameraState={{ distance: 10 }}>
       <Lines
         onClick={(ev, { objects }) => {
           setMsg(`Clicked on the lines. objectId: ${objects[0].object.id}`);

--- a/docs/src/jsx/commands/LinesInstability.js
+++ b/docs/src/jsx/commands/LinesInstability.js
@@ -6,7 +6,7 @@
 
 // #BEGIN EXAMPLE
 import React from "react";
-import Worldview, { Lines, DEFAULT_CAMERA_STATE } from "regl-worldview";
+import Worldview, { Lines } from "regl-worldview";
 
 // #BEGIN EDITABLE
 function Example() {
@@ -49,7 +49,6 @@ function Example() {
   return (
     <Worldview
       defaultCameraState={{
-        ...DEFAULT_CAMERA_STATE,
         perspective: false,
         target: [-812, 2959.64, 0],
         distance: 5,

--- a/docs/src/jsx/commands/LinesWireframe.js
+++ b/docs/src/jsx/commands/LinesWireframe.js
@@ -6,7 +6,7 @@
 
 // #BEGIN EXAMPLE
 import React from "react";
-import Worldview, { Lines, DEFAULT_CAMERA_STATE } from "regl-worldview";
+import Worldview, { Lines } from "regl-worldview";
 
 // #BEGIN EDITABLE
 function Example() {
@@ -55,7 +55,7 @@ function Example() {
     },
   ];
   return (
-    <Worldview defaultCameraState={{ ...DEFAULT_CAMERA_STATE, distance: 10 }}>
+    <Worldview defaultCameraState={{ distance: 10 }}>
       <Lines>{lines}</Lines>
     </Worldview>
   );

--- a/docs/src/jsx/commands/Points.js
+++ b/docs/src/jsx/commands/Points.js
@@ -6,7 +6,7 @@
 
 // #BEGIN EXAMPLE
 import React from "react";
-import Worldview, { Axes, Points, DEFAULT_CAMERA_STATE } from "regl-worldview";
+import Worldview, { Axes, Points } from "regl-worldview";
 
 import useRange from "../utils/useRange";
 
@@ -38,7 +38,6 @@ function Example() {
   return (
     <Worldview
       defaultCameraState={{
-        ...DEFAULT_CAMERA_STATE,
         distance: 124,
         phi: 1,
         targetOffset: [3, 6, 0],

--- a/docs/src/jsx/commands/SpheresInstancedColor.js
+++ b/docs/src/jsx/commands/SpheresInstancedColor.js
@@ -6,7 +6,7 @@
 
 // #BEGIN EXAMPLE
 import React from "react";
-import Worldview, { Spheres, DEFAULT_CAMERA_STATE } from "regl-worldview";
+import Worldview, { Spheres } from "regl-worldview";
 import seedrandom from "seedrandom";
 
 // #BEGIN EDITABLE
@@ -46,7 +46,6 @@ function Example() {
   return (
     <Worldview
       defaultCameraState={{
-        ...DEFAULT_CAMERA_STATE,
         target: [20, 20, 100],
       }}>
       <Spheres>{[marker]}</Spheres>

--- a/docs/src/jsx/examples/Composition.js
+++ b/docs/src/jsx/examples/Composition.js
@@ -6,7 +6,7 @@
 
 // #BEGIN EXAMPLE
 import React from "react";
-import Worldview, { Axes, Triangles, Text, DEFAULT_CAMERA_STATE } from "regl-worldview";
+import Worldview, { Axes, Triangles, Text } from "regl-worldview";
 
 // #BEGIN EDITABLE
 function Example() {
@@ -96,7 +96,6 @@ function Example() {
   return (
     <Worldview
       defaultCameraState={{
-        ...DEFAULT_CAMERA_STATE,
         distance: 12,
         phi: 0.4,
         targetOffset: [2, 3, 0],

--- a/docs/src/jsx/examples/Hitmap.js
+++ b/docs/src/jsx/examples/Hitmap.js
@@ -6,7 +6,7 @@
 
 // #BEGIN EXAMPLE
 import React, { useState } from "react";
-import Worldview, { Axes, Cubes, DEFAULT_CAMERA_STATE, Overlay, Spheres, getCSSColor } from "regl-worldview";
+import Worldview, { Axes, Cubes, Overlay, Spheres, getCSSColor } from "regl-worldview";
 
 // #BEGIN EDITABLE
 function Example() {
@@ -20,7 +20,6 @@ function Example() {
 
   const [clickedId, setClickedId] = useState(7);
   const [cameraState, setCameraState] = useState({
-    ...DEFAULT_CAMERA_STATE,
     distance: 145,
     phi: 1.22,
     thetaOffset: 0,

--- a/docs/src/jsx/tutorials/AddRemoveObstacles.js
+++ b/docs/src/jsx/tutorials/AddRemoveObstacles.js
@@ -7,7 +7,7 @@
 // #BEGIN EXAMPLE
 import { useAnimationFrame } from "@cruise-automation/hooks";
 import React, { useState } from "react";
-import Worldview, { Cubes, Spheres, Axes, GLTFScene, DEFAULT_CAMERA_STATE } from "regl-worldview";
+import Worldview, { Cubes, Spheres, Axes, GLTFScene } from "regl-worldview";
 
 import duckModel from "../utils/Duck.glb";
 
@@ -81,7 +81,6 @@ function Example() {
   return (
     <Worldview
       defaultCameraState={{
-        ...DEFAULT_CAMERA_STATE,
         distance: 160,
         thetaOffset: -Math.PI / 2, // rotate the camera so the duck is facing right
       }}>

--- a/docs/src/jsx/tutorials/FollowObject.js
+++ b/docs/src/jsx/tutorials/FollowObject.js
@@ -7,7 +7,7 @@
 // #BEGIN EXAMPLE
 import { useAnimationFrame } from "@cruise-automation/hooks";
 import React, { useState } from "react";
-import Worldview, { Spheres, Axes, GLTFScene, DEFAULT_CAMERA_STATE } from "regl-worldview";
+import Worldview, { Spheres, Axes, GLTFScene } from "regl-worldview";
 
 import duckModel from "../utils/Duck.glb";
 
@@ -64,9 +64,6 @@ function Example() {
   return (
     <Worldview
       cameraState={{
-        // Default setting for cameraState.
-        // Learn more at https://cruise-automation.github.io/webviz/worldview/#/docs/api/camera
-        ...DEFAULT_CAMERA_STATE,
         // This is the magic! Simply supply the target position and the camera will follow
         target: [duckPosition.x, duckPosition.y, duckPosition.z],
         thetaOffset: -Math.PI / 2, // rotate the camera so the duck is facing right

--- a/docs/src/jsx/tutorials/FollowObjectOrientation.js
+++ b/docs/src/jsx/tutorials/FollowObjectOrientation.js
@@ -8,7 +8,7 @@
 import { useAnimationFrame } from "@cruise-automation/hooks";
 import { quat, vec3 } from "gl-matrix";
 import React, { useState } from "react";
-import Worldview, { Spheres, Axes, GLTFScene, DEFAULT_CAMERA_STATE } from "regl-worldview";
+import Worldview, { Spheres, Axes, GLTFScene } from "regl-worldview";
 
 import duckModel from "../utils/Duck.glb";
 
@@ -82,9 +82,6 @@ function Example() {
   return (
     <Worldview
       cameraState={{
-        // Default setting for cameraState.
-        // Learn more at https://cruise-automation.github.io/webviz/worldview/#/docs/api/camera
-        ...DEFAULT_CAMERA_STATE,
         target: [duckPosition.x, duckPosition.y, duckPosition.z],
         // This is the magic! The `targetOrientation` input will make sure the camera follows the duck's orientation
         targetOrientation: duckOrientation,

--- a/docs/src/jsx/tutorials/MoveCamea.js
+++ b/docs/src/jsx/tutorials/MoveCamea.js
@@ -7,7 +7,7 @@
 // #BEGIN EXAMPLE
 import { useAnimationFrame } from "@cruise-automation/hooks";
 import React, { useState } from "react";
-import Worldview, { Spheres, Axes, GLTFScene, DEFAULT_CAMERA_STATE } from "regl-worldview";
+import Worldview, { Spheres, Axes, GLTFScene } from "regl-worldview";
 
 import duckModel from "../utils/Duck.glb";
 
@@ -65,9 +65,6 @@ function Example() {
   return (
     <Worldview
       cameraState={{
-        // Default setting for cameraState.
-        // Learn more at https://cruise-automation.github.io/webviz/worldview/#/docs/api/camera
-        ...DEFAULT_CAMERA_STATE,
         phi: count * cameraMoveSpeed,
         thetaOffset: count * cameraMoveSpeed,
       }}>

--- a/docs/src/jsx/tutorials/StopReleaseDuck.js
+++ b/docs/src/jsx/tutorials/StopReleaseDuck.js
@@ -7,7 +7,7 @@
 // #BEGIN EXAMPLE
 import { useAnimationFrame } from "@cruise-automation/hooks";
 import React, { useState, useEffect } from "react";
-import Worldview, { Cubes, Spheres, Axes, GLTFScene, DEFAULT_CAMERA_STATE } from "regl-worldview";
+import Worldview, { Cubes, Spheres, Axes, GLTFScene } from "regl-worldview";
 
 import duckModel from "../utils/Duck.glb";
 
@@ -94,7 +94,6 @@ function Example() {
   return (
     <Worldview
       defaultCameraState={{
-        ...DEFAULT_CAMERA_STATE,
         distance: 160,
         thetaOffset: -Math.PI / 2, // rotate the camera so the duck is facing right
       }}>

--- a/docs/src/jsx/utils/CameraStateControls.js
+++ b/docs/src/jsx/utils/CameraStateControls.js
@@ -143,6 +143,51 @@ export default function CameraStateControls({ cameraState, setCameraState }: Pro
             />
           </td>
         </tr>
+        <tr>
+          <td>fov</td>
+          <td>
+            <Slider
+              showEndpoints
+              minLabel
+              maxLabel="π"
+              value={cameraState.fov}
+              min={0}
+              max={Math.PI}
+              step={0.01}
+              onChange={(fov) => setCameraState({ ...cameraState, fov })}
+            />
+          </td>
+        </tr>
+        <tr>
+          <td>near</td>
+          <td>
+            <Slider
+              showEndpoints
+              minLabel
+              maxLabel
+              value={cameraState.near}
+              min={0.01}
+              max={200}
+              step={0.01}
+              onChange={(near) => setCameraState({ ...cameraState, near })}
+            />
+          </td>
+        </tr>
+        <tr>
+          <td>far</td>
+          <td>
+            <Slider
+              showEndpoints
+              minLabel
+              maxLabel
+              value={cameraState.far}
+              min={10}
+              max={1000}
+              step={0.001}
+              onChange={(far) => setCameraState({ ...cameraState, far })}
+            />
+          </td>
+        </tr>
       </tbody>
     </ControlsTable>
   );

--- a/docs/src/jsx/utils/CameraStateControls.js
+++ b/docs/src/jsx/utils/CameraStateControls.js
@@ -144,17 +144,17 @@ export default function CameraStateControls({ cameraState, setCameraState }: Pro
           </td>
         </tr>
         <tr>
-          <td>fov</td>
+          <td>fovy</td>
           <td>
             <Slider
               showEndpoints
               minLabel
               maxLabel="π"
-              value={cameraState.fov}
+              value={cameraState.fovy}
               min={0}
               max={Math.PI}
               step={0.01}
-              onChange={(fov) => setCameraState({ ...cameraState, fov })}
+              onChange={(fovy) => setCameraState({ ...cameraState, fovy })}
             />
           </td>
         </tr>

--- a/docs/src/jsx/utils/CameraStateControls.js
+++ b/docs/src/jsx/utils/CameraStateControls.js
@@ -11,7 +11,7 @@ import type { CameraState, Quat } from "regl-worldview";
 import styled from "styled-components";
 
 import Scrubber from "./Scrubber";
-import Slider from "./Slider";
+import Slider, { SWrapper, SEndpoint } from "./Slider";
 import Switch from "./Switch";
 import { color } from "./theme";
 
@@ -25,6 +25,16 @@ const ControlsTable = styled.table`
   }
   tr {
     background-color: transparent !important;
+  }
+  /* Right-align the min label */
+  ${SWrapper} ${SEndpoint} {
+    text-align: right;
+    min-width: 2.5em; /* approximate width of the widest min label */
+  }
+  /* Don't right-align any other SEndpoint labels */
+  ${SWrapper} ${SEndpoint} ~ ${SEndpoint} {
+    text-align: initial;
+    min-width: initial;
   }
 `;
 

--- a/docs/src/jsx/utils/Slider.js
+++ b/docs/src/jsx/utils/Slider.js
@@ -60,6 +60,8 @@ type Props = {
   maxLabel: boolean | string,
 };
 
+export { SWrapper, SEndpoint };
+
 export default function Slider({ onChange, minLabel, maxLabel, ...props }: Props) {
   return (
     <SWrapper>

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -46,7 +46,7 @@ export type BaseProps = {|
   children?: React.Node,
   style: { [styleAttribute: string]: number | string },
 
-  cameraState?: CameraState,
+  cameraState?: $Shape<CameraState>,
   onCameraStateChange?: (CameraState) => void,
   defaultCameraState?: CameraState,
   // interactions

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -48,7 +48,7 @@ export type BaseProps = {|
 
   cameraState?: $Shape<CameraState>,
   onCameraStateChange?: (CameraState) => void,
-  defaultCameraState?: CameraState,
+  defaultCameraState?: $Shape<CameraState>,
   // interactions
   onDoubleClick?: MouseHandler,
   onMouseDown?: MouseHandler,

--- a/packages/regl-worldview/src/camera/CameraStore.js
+++ b/packages/regl-worldview/src/camera/CameraStore.js
@@ -54,11 +54,11 @@ export default class CameraStore {
 
   constructor(handler: (CameraState) => void = () => {}, initialCameraState: CameraState = DEFAULT_CAMERA_STATE) {
     this._onChange = handler;
-    this.state = initialCameraState;
+    this.setCameraState(initialCameraState);
   }
 
   setCameraState = (state: CameraState) => {
-    this.state = state;
+    this.state = { ...DEFAULT_CAMERA_STATE, ...state };
   };
 
   cameraRotate = ([x, y]: Vec2) => {

--- a/packages/regl-worldview/src/camera/CameraStore.js
+++ b/packages/regl-worldview/src/camera/CameraStore.js
@@ -61,7 +61,12 @@ export default class CameraStore {
   }
 
   setCameraState = (state: $Shape<CameraState>) => {
-    this.state = { ...DEFAULT_CAMERA_STATE, ...state };
+    this.state = { ...DEFAULT_CAMERA_STATE };
+    for (const [key, value] of Object.entries(state)) {
+      if (value != null) {
+        this.state[key] = value;
+      }
+    }
   };
 
   cameraRotate = ([x, y]: Vec2) => {
@@ -112,4 +117,5 @@ export default class CameraStore {
     this._onChange(this.state);
   };
 }
+
 export { selectors };

--- a/packages/regl-worldview/src/camera/CameraStore.js
+++ b/packages/regl-worldview/src/camera/CameraStore.js
@@ -61,12 +61,18 @@ export default class CameraStore {
   }
 
   setCameraState = (state: $Shape<CameraState>) => {
-    this.state = { ...DEFAULT_CAMERA_STATE };
-    for (const [key, value] of Object.entries(state)) {
-      if (value != null) {
-        this.state[key] = value;
+    // Fill in missing properties from DEFAULT_CAMERA_STATE.
+    // Mutate the `state` parameter instead of copying -- this
+    // matches the previous behavior of this method, which didn't
+    // fill in missing properties but also didn't copy `state`.
+    for (const [key, value] of Object.entries(DEFAULT_CAMERA_STATE)) {
+      if (state[key] == null) {
+        state[key] = value;
       }
     }
+    // `state` must be a valid CameraState now, because we filled in
+    // missing properties from DEFAULT_CAMERA_STATE.
+    this.state = (state: any);
   };
 
   cameraRotate = ([x, y]: Vec2) => {

--- a/packages/regl-worldview/src/camera/CameraStore.js
+++ b/packages/regl-worldview/src/camera/CameraStore.js
@@ -19,6 +19,9 @@ export type CameraState = {|
   targetOffset: Vec3,
   targetOrientation: Vec4,
   thetaOffset: number,
+  fov: number,
+  near: number,
+  far: number,
 |};
 
 //  we use up on the +z axis
@@ -34,6 +37,9 @@ export const DEFAULT_CAMERA_STATE: CameraState = {
   targetOffset: [0, 0, 0],
   targetOrientation: [0, 0, 0, 1],
   thetaOffset: 0,
+  fov: Math.PI / 4,
+  near: 0.01,
+  far: 5000,
 };
 
 function distanceAfterZoom(startingDistance: number, zoomPercent: number): number {

--- a/packages/regl-worldview/src/camera/CameraStore.js
+++ b/packages/regl-worldview/src/camera/CameraStore.js
@@ -52,12 +52,15 @@ export default class CameraStore {
 
   _onChange: (CameraState) => void;
 
-  constructor(handler: (CameraState) => void = () => {}, initialCameraState: CameraState = DEFAULT_CAMERA_STATE) {
+  constructor(
+    handler: (CameraState) => void = () => {},
+    initialCameraState: $Shape<CameraState> = DEFAULT_CAMERA_STATE
+  ) {
     this._onChange = handler;
     this.setCameraState(initialCameraState);
   }
 
-  setCameraState = (state: CameraState) => {
+  setCameraState = (state: $Shape<CameraState>) => {
     this.state = { ...DEFAULT_CAMERA_STATE, ...state };
   };
 

--- a/packages/regl-worldview/src/camera/CameraStore.js
+++ b/packages/regl-worldview/src/camera/CameraStore.js
@@ -75,11 +75,11 @@ export default class CameraStore {
       return;
     }
     const { thetaOffset, phi } = this.state;
-    this.state = {
+    this.setCameraState({
       ...this.state,
       thetaOffset: thetaOffset - x,
       phi: Math.max(0, Math.min(phi + y, Math.PI)),
-    };
+    });
     this._onChange(this.state);
   };
 
@@ -96,10 +96,10 @@ export default class CameraStore {
     const result = [x, y, 0];
     const offset = vec3.transformQuat(result, result, quat.setAxisAngle(TEMP_QUAT, UNIT_Z_VECTOR, -thetaOffset));
 
-    this.state = {
+    this.setCameraState({
       ...this.state,
       targetOffset: vec3.add(offset, targetOffset, offset),
-    };
+    });
     this._onChange(this.state);
   };
 
@@ -110,10 +110,10 @@ export default class CameraStore {
       return;
     }
 
-    this.state = {
+    this.setCameraState({
       ...this.state,
       distance: newDistance,
-    };
+    });
     this._onChange(this.state);
   };
 }

--- a/packages/regl-worldview/src/camera/CameraStore.js
+++ b/packages/regl-worldview/src/camera/CameraStore.js
@@ -19,7 +19,7 @@ export type CameraState = {|
   targetOffset: Vec3,
   targetOrientation: Vec4,
   thetaOffset: number,
-  fov: number,
+  fovy: number,
   near: number,
   far: number,
 |};
@@ -37,7 +37,7 @@ export const DEFAULT_CAMERA_STATE: CameraState = {
   targetOffset: [0, 0, 0],
   targetOrientation: [0, 0, 0, 1],
   thetaOffset: 0,
-  fov: Math.PI / 4,
+  fovy: Math.PI / 4,
   near: 0.01,
   far: 5000,
 };

--- a/packages/regl-worldview/src/camera/CameraStore.test.js
+++ b/packages/regl-worldview/src/camera/CameraStore.test.js
@@ -127,7 +127,7 @@ describe("camera store", () => {
       targetOffset: [0, 0, 0],
       targetOrientation: [0, 0, 0, 1],
       perspective: false,
-      fov: Math.PI / 3,
+      fovy: Math.PI / 3,
       near: 0.2,
       far: 1000,
     };
@@ -150,7 +150,7 @@ describe("camera store", () => {
       targetOffset: [0, 0, 0],
       targetOrientation: [0, 0, 0, 1],
       perspective: false,
-      fov: Math.PI / 3,
+      fovy: Math.PI / 3,
       near: 0.2,
       far: 1000,
     };
@@ -189,7 +189,7 @@ describe("camera store", () => {
         targetOffset: [25, 0, 0],
         targetOrientation: [0, 0, 0, 1],
         perspective: true,
-        fov: Math.PI / 2,
+        fovy: Math.PI / 2,
         near: 0.01,
         far: 10000,
       });
@@ -213,7 +213,7 @@ describe("camera store", () => {
         targetOffset: [25, 0, 0],
         targetOrientation: quat.rotateZ([0, 0, 0, 1], [0, 0, 0, 1], Math.PI / 2),
         perspective: true,
-        fov: Math.PI / 2,
+        fovy: Math.PI / 2,
         near: 0.01,
         far: 10000,
       });
@@ -230,7 +230,7 @@ describe("camera store", () => {
         targetOffset: [25, 0, 0],
         targetOrientation: [0, 0, 0, 1],
         perspective: true,
-        fov: Math.PI / 2,
+        fovy: Math.PI / 2,
         near: 0.01,
         far: 10000,
       });
@@ -246,7 +246,7 @@ describe("camera store", () => {
         targetOffset: [25, 0, 0],
         targetOrientation: quat.rotateX([0, 0, 0, 1], [0, 0, 0, 1], Math.PI / 8),
         perspective: true,
-        fov: Math.PI / 2,
+        fovy: Math.PI / 2,
         near: 0.01,
         far: 10000,
       });

--- a/packages/regl-worldview/src/camera/CameraStore.test.js
+++ b/packages/regl-worldview/src/camera/CameraStore.test.js
@@ -150,6 +150,15 @@ describe("camera store", () => {
       store.setCameraState({ near: 10 });
       expect(store.state).toEqual({ ...DEFAULT_CAMERA_STATE, near: 10 });
     });
+
+    it("has null properties filled in from DEFAULT_CAMERA_STATE", () => {
+      // Null properties are not allowed according to the Flow types,
+      // but CameraStore should handle them anyway.
+      store = new CameraStore(undefined, ({ near: null }: any));
+      expect(store.state).toEqual(DEFAULT_CAMERA_STATE);
+      store.setCameraState(({ far: null }: any));
+      expect(store.state).toEqual(DEFAULT_CAMERA_STATE);
+    });
   });
 
   describe("selectors", () => {

--- a/packages/regl-worldview/src/camera/CameraStore.test.js
+++ b/packages/regl-worldview/src/camera/CameraStore.test.js
@@ -154,10 +154,10 @@ describe("camera store", () => {
     it("has null properties filled in from DEFAULT_CAMERA_STATE", () => {
       // Null properties are not allowed according to the Flow types,
       // but CameraStore should handle them anyway.
-      store = new CameraStore(undefined, ({ near: null }: any));
-      expect(store.state).toEqual(DEFAULT_CAMERA_STATE);
-      store.setCameraState(({ far: null }: any));
-      expect(store.state).toEqual(DEFAULT_CAMERA_STATE);
+      store = new CameraStore(undefined, ({ near: null, far: undefined, fovy: 0 }: any));
+      expect(store.state).toEqual({ ...DEFAULT_CAMERA_STATE, fovy: 0 });
+      store.setCameraState(({ near: 0, far: null, fovy: undefined }: any));
+      expect(store.state).toEqual({ ...DEFAULT_CAMERA_STATE, near: 0 });
     });
   });
 

--- a/packages/regl-worldview/src/camera/CameraStore.test.js
+++ b/packages/regl-worldview/src/camera/CameraStore.test.js
@@ -8,7 +8,7 @@
 
 import { vec3, quat } from "gl-matrix";
 
-import CameraStore, { selectors } from "./CameraStore";
+import CameraStore, { selectors, DEFAULT_CAMERA_STATE } from "./CameraStore";
 
 class NearlyEqual {
   value: number;
@@ -138,6 +138,17 @@ describe("camera store", () => {
         store = new CameraStore(undefined, cameraState);
         expect(store.state).toEqual(cameraState);
       });
+
+      it("has missing properties filled in from DEFAULT_CAMERA_STATE", () => {
+        store = new CameraStore(undefined, { near: 10 });
+        expect(store.state).toEqual({ ...DEFAULT_CAMERA_STATE, near: 10 });
+      });
+    });
+
+    it("has missing properties filled in from DEFAULT_CAMERA_STATE on update", () => {
+      store = new CameraStore(undefined, cameraState);
+      store.setCameraState({ near: 10 });
+      expect(store.state).toEqual({ ...DEFAULT_CAMERA_STATE, near: 10 });
     });
   });
 

--- a/packages/regl-worldview/src/camera/CameraStore.test.js
+++ b/packages/regl-worldview/src/camera/CameraStore.test.js
@@ -127,6 +127,9 @@ describe("camera store", () => {
       targetOffset: [0, 0, 0],
       targetOrientation: [0, 0, 0, 1],
       perspective: false,
+      fov: Math.PI / 3,
+      near: 0.2,
+      far: 1000,
     };
     let store;
 
@@ -147,6 +150,9 @@ describe("camera store", () => {
       targetOffset: [0, 0, 0],
       targetOrientation: [0, 0, 0, 1],
       perspective: false,
+      fov: Math.PI / 3,
+      near: 0.2,
+      far: 1000,
     };
 
     it("orientation selector returns camera orientation", () => {
@@ -183,6 +189,9 @@ describe("camera store", () => {
         targetOffset: [25, 0, 0],
         targetOrientation: [0, 0, 0, 1],
         perspective: true,
+        fov: Math.PI / 2,
+        near: 0.01,
+        far: 10000,
       });
 
       expect(vec3.transformMat4([0, 0, 0], [2, 0, 0], view1)).toEqual([-25, 0, -3]);
@@ -204,6 +213,9 @@ describe("camera store", () => {
         targetOffset: [25, 0, 0],
         targetOrientation: quat.rotateZ([0, 0, 0, 1], [0, 0, 0, 1], Math.PI / 2),
         perspective: true,
+        fov: Math.PI / 2,
+        near: 0.01,
+        far: 10000,
       });
       expect(vec3.transformMat4([0, 0, 0], [2, 0, 0], view2)).toEqual([-25, 0, -3]);
       expect(vec3.transformMat4([0, 0, 0], [2, 25, 0], view2)).toEqual([0, nearlyZero, -3]);
@@ -218,6 +230,9 @@ describe("camera store", () => {
         targetOffset: [25, 0, 0],
         targetOrientation: [0, 0, 0, 1],
         perspective: true,
+        fov: Math.PI / 2,
+        near: 0.01,
+        far: 10000,
       });
 
       expect(vec3.transformMat4([0, 0, 0], [2, 0, 0], view1)).toEqual([-25, 0, -3]);
@@ -231,6 +246,9 @@ describe("camera store", () => {
         targetOffset: [25, 0, 0],
         targetOrientation: quat.rotateX([0, 0, 0, 1], [0, 0, 0, 1], Math.PI / 8),
         perspective: true,
+        fov: Math.PI / 2,
+        near: 0.01,
+        far: 10000,
       });
       expect(vec3.transformMat4([0, 0, 0], [2, 0, 0], view2)).toEqual([-25, 0, -3]);
       expect(vec3.transformMat4([0, 0, 0], [2 + 25, 7, 0], view2)).toEqual([0, 7, -3]);

--- a/packages/regl-worldview/src/camera/camera.js
+++ b/packages/regl-worldview/src/camera/camera.js
@@ -24,15 +24,14 @@ export default (regl: any) => {
     cameraState: CameraState = DEFAULT_CAMERA_STATE;
 
     getProjection(): Mat4 {
-      const { near, far } = this.cameraState;
+      const { near, far, distance, fovy } = this.cameraState;
       if (!this.cameraState.perspective) {
-        const bounds = getOrthographicBounds(this.cameraState.distance, this.viewportWidth, this.viewportHeight);
+        const bounds = getOrthographicBounds(distance, this.viewportWidth, this.viewportHeight);
         const { left, right, bottom, top } = bounds;
         return mat4.ortho([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], left, right, bottom, top, near, far);
       }
-      const fov = this.cameraState.fovy;
       const aspect = this.viewportWidth / this.viewportHeight;
-      return mat4.perspective([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], fov, aspect, near, far);
+      return mat4.perspective([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], fovy, aspect, near, far);
     }
 
     getView(): Mat4 {

--- a/packages/regl-worldview/src/camera/camera.js
+++ b/packages/regl-worldview/src/camera/camera.js
@@ -38,7 +38,7 @@ export default (regl: any) => {
           far
         );
       }
-      const fov = this.cameraState.fov;
+      const fov = this.cameraState.fovy;
       const aspect = this.viewportWidth / this.viewportHeight;
       return mat4.perspective(
         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],

--- a/packages/regl-worldview/src/camera/camera.js
+++ b/packages/regl-worldview/src/camera/camera.js
@@ -13,9 +13,6 @@ import getOrthographicBounds from "../utils/getOrthographicBounds";
 import project from "./cameraProject";
 import { selectors, DEFAULT_CAMERA_STATE, type CameraState } from "./CameraStore";
 
-const NEAR_PLANE_DISTANCE = 0.01;
-const FAR_PLANE_DISTANCE = 5000;
-
 const TEMP_MAT = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 
 // This is the regl command which encapsulates the camera projection and view matrices.
@@ -27,6 +24,7 @@ export default (regl: any) => {
     cameraState: CameraState = DEFAULT_CAMERA_STATE;
 
     getProjection(): Mat4 {
+      const { near, far } = this.cameraState;
       if (!this.cameraState.perspective) {
         const bounds = getOrthographicBounds(this.cameraState.distance, this.viewportWidth, this.viewportHeight);
         const { left, right, bottom, top } = bounds;
@@ -36,18 +34,18 @@ export default (regl: any) => {
           right,
           bottom,
           top,
-          NEAR_PLANE_DISTANCE,
-          FAR_PLANE_DISTANCE
+          near,
+          far
         );
       }
-      const fov = Math.PI / 4;
+      const fov = this.cameraState.fov;
       const aspect = this.viewportWidth / this.viewportHeight;
       return mat4.perspective(
         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         fov,
         aspect,
-        NEAR_PLANE_DISTANCE,
-        FAR_PLANE_DISTANCE
+        near,
+        far
       );
     }
 

--- a/packages/regl-worldview/src/camera/camera.js
+++ b/packages/regl-worldview/src/camera/camera.js
@@ -28,25 +28,11 @@ export default (regl: any) => {
       if (!this.cameraState.perspective) {
         const bounds = getOrthographicBounds(this.cameraState.distance, this.viewportWidth, this.viewportHeight);
         const { left, right, bottom, top } = bounds;
-        return mat4.ortho(
-          [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-          left,
-          right,
-          bottom,
-          top,
-          near,
-          far
-        );
+        return mat4.ortho([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], left, right, bottom, top, near, far);
       }
       const fov = this.cameraState.fovy;
       const aspect = this.viewportWidth / this.viewportHeight;
-      return mat4.perspective(
-        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        fov,
-        aspect,
-        near,
-        far
-      );
+      return mat4.perspective([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], fov, aspect, near, far);
     }
 
     getView(): Mat4 {

--- a/packages/regl-worldview/src/stories/Cubes.stories.js
+++ b/packages/regl-worldview/src/stories/Cubes.stories.js
@@ -38,7 +38,6 @@ class Wrapper extends React.Component<any> {
 }
 
 const instancedCameraState = {
-  ...DEFAULT_CAMERA_STATE,
   phi: 1.625,
   thetaOffset: 0.88,
   target: [20, 20, 100],
@@ -90,7 +89,7 @@ storiesOf("Worldview/Cubes", module)
     withRange((range) => {
       const marker = cube(range);
       return (
-        <Container cameraState={{ ...DEFAULT_CAMERA_STATE, perspective: true }}>
+        <Container cameraState={{ perspective: true }}>
           <Wrapper cubes={[marker]} />
         </Container>
       );

--- a/packages/regl-worldview/src/stories/Worldview.stories.js
+++ b/packages/regl-worldview/src/stories/Worldview.stories.js
@@ -57,7 +57,6 @@ storiesOf("Worldview", module)
     return (
       <Container
         cameraState={{
-          ...DEFAULT_CAMERA_STATE,
           perspective: false,
           target: [-812, 2959.64, 0],
           distance: 5,

--- a/packages/regl-worldview/src/stories/cameraState.stories.js
+++ b/packages/regl-worldview/src/stories/cameraState.stories.js
@@ -12,7 +12,6 @@ import { quat, vec3 } from "gl-matrix";
 import * as React from "react";
 import { withScreenshot } from "storybook-chrome-screenshot";
 
-import { DEFAULT_CAMERA_STATE } from "../camera";
 import Container from "./Container";
 
 import { Arrows, Spheres, Axes, Grid, cameraStateSelectors, type CameraState } from "..";
@@ -130,7 +129,6 @@ class CameraStateStory extends React.Component<Props, State> {
           <Container
             hideState
             defaultCameraState={{
-              ...DEFAULT_CAMERA_STATE,
               perspective: true,
               distance: 150,
               thetaOffset: 0.5,

--- a/packages/regl-worldview/src/stories/cameraState.stories.js
+++ b/packages/regl-worldview/src/stories/cameraState.stories.js
@@ -12,6 +12,7 @@ import { quat, vec3 } from "gl-matrix";
 import * as React from "react";
 import { withScreenshot } from "storybook-chrome-screenshot";
 
+import { DEFAULT_CAMERA_STATE } from "../camera";
 import Container from "./Container";
 
 import { Arrows, Spheres, Axes, Grid, cameraStateSelectors, type CameraState } from "..";
@@ -129,6 +130,7 @@ class CameraStateStory extends React.Component<Props, State> {
           <Container
             hideState
             defaultCameraState={{
+              ...DEFAULT_CAMERA_STATE,
               perspective: true,
               distance: 150,
               thetaOffset: 0.5,
@@ -231,6 +233,25 @@ stories
       step: 0.1,
     });
 
+    const fovy = number("fovy", Math.PI / 4, {
+      range: true,
+      min: 0,
+      max: Math.PI,
+      step: 0.01,
+    });
+    const near = number("near", 0.01, {
+      range: true,
+      min: 0.001,
+      max: 1000,
+      step: 0.01,
+    });
+    const far = number("far", 5000, {
+      range: true,
+      min: 10,
+      max: 10000,
+      step: 0.01,
+    });
+
     let length = Math.hypot(orientationX, orientationY, orientationZ);
     if (length > 1) {
       length /= 2;
@@ -248,6 +269,9 @@ stories
       target,
       targetOffset,
       targetOrientation,
+      fovy,
+      near,
+      far,
     };
     return <CameraStateStory controlled={controlled} cameraStateFromKnobs={cameraState} />;
   });


### PR DESCRIPTION
## Summary

Add `fov`, `near`, and `far` to `cameraState` so they can be customized. Also add these new properties to the interactive documentation:

![CameraStateControls2](https://user-images.githubusercontent.com/54377485/63810316-57529880-c8d9-11e9-92ca-d0867577066f.png)

## Test plan

Unit tests pass with no regressions; added the new properties to `CameraStore` tests. Manual inspection confirms that the properties behave as expected.

## Versioning impact

Minor update due to the backward-compatible new features.