### PR TITLE
Unify inScreenshotTests

### DIFF
--- a/docs/src/jsx/utils/codeSandboxUtils.js
+++ b/docs/src/jsx/utils/codeSandboxUtils.js
@@ -7,6 +7,7 @@
 //  You may not use this file except in compliance with the License.
 
 export function inScreenshotTests() {
-  // screenshot tests are not always in a headless Chrome, so we set a custom user agent for screenshot testing.
-  return navigator.userAgent.includes("HeadlessChrome") || navigator.userAgent.includes("PuppeteerTestingChrome");
+  // Integration tests and screenshot tests are not always in a headless Chrome, so need to check for a custom user
+  // agent.
+  return navigator.userAgent.includes("PuppeteerTestingChrome");
 }

--- a/stories/inScreenshotTests.js
+++ b/stories/inScreenshotTests.js
@@ -5,6 +5,7 @@
 //  You may not use this file except in compliance with the License.
 
 export default function inScreenshotTests() {
-  // screenshot tests are not always in a headless Chrome, so we set a custom user agent for screenshot testing.
-  return navigator.userAgent.includes("HeadlessChrome") || navigator.userAgent.includes("PuppeteerTestingChrome");
+  // Integration tests and screenshot tests are not always in a headless Chrome, so need to check for a custom user
+  // agent.
+  return navigator.userAgent.includes("PuppeteerTestingChrome");
 }


### PR DESCRIPTION
We have three copies of the same function. Unfortunately we can't
really share them since they have very different contexts and one
is inside the webviz-core package, but instead make sure they have
the same definition.

Test plan: tests pass