### PR TITLE
Fix arrow doc

### DIFF
--- a/docs/src/4.1.Arrows.mdx
+++ b/docs/src/4.1.Arrows.mdx
@@ -17,7 +17,7 @@ type PoseArrow = {
   id?: number, // positive integer
   pose: {
     position: { x: number, y: number, z: number },
-    orientation: { x: number, y: number, z: number, q: number }
+    orientation: { x: number, y: number, z: number, w: number }
   }
   scale: {
     x: number, // arrow length


### PR DESCRIPTION
<!-- Thanks for contributing to Webviz! To help us understand and review your PR, please fill out the following sections: -->

## Summary
Fix small documentation error. `orientation` should take in a `w` field rather than `q`.

## Test plan

Doc change -- no need for test.

## Versioning impact

No need to update version.
