### PR TITLE
Fix minor Worldview issues and release new version

### DIFF
--- a/packages/regl-worldview/package-lock.json
+++ b/packages/regl-worldview/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "regl-worldview",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "license": "Apache-2.0",
   "repository": "cruise-automation/webviz/tree/master/packages/regl-worldview",

--- a/packages/regl-worldview/src/commands/Grid.js
+++ b/packages/regl-worldview/src/commands/Grid.js
@@ -70,7 +70,7 @@ type Props = {
 
 // useful for rendering a grid for debugging in stories
 
-function Grid({ count, ...rest }: Props) {
+export default function Grid({ count, ...rest }: Props) {
   const children = { count };
   return (
     <Command getChildrenForHitmap={nonInstancedGetChildrenForHitmap} {...rest} reglCommand={grid}>
@@ -80,5 +80,3 @@ function Grid({ count, ...rest }: Props) {
 }
 
 Grid.defaultProps = { count: 6 };
-
-export default React.memo<Props>(Grid);

--- a/packages/regl-worldview/src/utils/getChildrenForHitmapDefaults.js
+++ b/packages/regl-worldview/src/utils/getChildrenForHitmapDefaults.js
@@ -72,7 +72,7 @@ function instancedGetChildrenForHitmapFromSingleProp<T: any>(
   const idColors = assignNextColors(prop, instanceCount);
   const startColor = idColors[0];
   // We have to map these instance colors to `pointCountPerInstance` number of points
-  if (hitmapProp.colors && hitmapProp.points && hitmapProp.points.length) {
+  if (hitmapProp.points && hitmapProp.points.length) {
     const allColors = new Array(hitmapProp.points.length).fill().map(() => startColor);
     for (let i = 0; i < instanceCount; i++) {
       for (let j = 0; j < pointCountPerInstance; j++) {


### PR DESCRIPTION
## Summary

Fix two minor issues:
* Don't wrap Grid in a `React.memo` call. No other commands do this.
* Don't require "colors" in a command prop for instancing to be enabled for that command in our default `createInstancedGetChildrenForHitmap`. Instead we always populate the `colors` array if there is a `points` array. The current behavior is confusing, since many people expect instancing to be enabled even if they're using a single color, and the workaround (provide an empty color array) is a bit weird.

## Test plan

Automated testing/flow should be able to catch all issues here.

## Versioning impact

Release new version of Worldview that includes the changes to Lines.