### PR TITLE
Add paint hooks to Worldview

### DIFF
--- a/docs/src/3.1.Worldview.mdx
+++ b/docs/src/3.1.Worldview.mdx
@@ -20,6 +20,8 @@
 | `onMouseUp`           | `MouseHandler`                                  |                        |                                                                                                         |
 | `onMouseMove`         | `MouseHandler`                                  |                        |                                                                                                         |
 | `onClick`             | `MouseHandler`                                  |                        |                                                                                                         |
+| `onPaintStart`        | `() => void`                                    |                        |                                                                                                         |
+| `onPaintEnd`          | `() => void`                                    |                        |                                                                                                         |
 
 _All props are optional._
 

--- a/packages/regl-worldview/package-lock.json
+++ b/packages/regl-worldview/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "regl-worldview",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "license": "Apache-2.0",
   "repository": "cruise-automation/webviz/tree/master/packages/regl-worldview",

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -55,6 +55,10 @@ export type BaseProps = {|
   onMouseUp?: MouseHandler,
   onMouseMove?: MouseHandler,
   onClick?: MouseHandler,
+
+  // Hooks for our paint loop
+  onPaintStart?: () => void,
+  onPaintEnd?: () => void,
   ...Dimensions,
 |};
 
@@ -153,7 +157,13 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     if (!this._tick) {
       this._tick = requestAnimationFrame(() => {
         this._tick = undefined;
+        if (this.props.onPaintStart) {
+          this.props.onPaintStart();
+        }
         worldviewContext.paint();
+        if (this.props.onPaintEnd) {
+          this.props.onPaintEnd();
+        }
       });
     }
   }


### PR DESCRIPTION
## Summary

Add hooks for paint start/end of our painting loop. This will make it easier to measure paint performance.

## Test plan

Tested manually.

## Versioning impact

Incremented patch version.