### PR TITLE
Add monaco editor fix

### DIFF
--- a/packages/webviz-core/package-lock.json
+++ b/packages/webviz-core/package-lock.json
@@ -952,11 +952,6 @@
         "moment": ">= 2.9.0"
       }
     },
-    "monaco-editor": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.17.1.tgz",
-      "integrity": "sha512-JAc0mtW7NeO+0SwPRcdkfDbWLgkqL9WfP1NbpP9wNASsW6oWqgZqNIWt4teymGjZIXTElx3dnQmUYHmVrJ7HxA=="
-    },
     "monaco-editor-webpack-plugin": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-1.7.0.tgz",

--- a/packages/webviz-core/package.json
+++ b/packages/webviz-core/package.json
@@ -26,7 +26,6 @@
     "moment": "2.22.2",
     "moment-duration-format": "2.2.2",
     "moment-timezone": "0.5.23",
-    "monaco-editor": "0.17.1",
     "monaco-vim": "0.1.3",
     "natsort": "2.0.0",
     "nearley": "2.15.1",


### PR DESCRIPTION
## Summary

There was a duplicate `monaco-editor` dependency in the `webviz-core` package.json, causing that instantiation to not load the Typescript language service. I'll take out the corresponding dependency out of the private repo. 

## Test plan

Tested locally with docs.

## Versioning impact

None