### PR TITLE
Add option to only render triangles in the hitmap

### DIFF
--- a/docs/src/4.11.Triangles.mdx
+++ b/docs/src/4.11.Triangles.mdx
@@ -35,6 +35,8 @@ type Triangle = {
   colors?: Color[],
   points: [{ x: number, y: number, z: number }]
   // Pass true to not render the triangles to the screen - just the hitmap.
+  // This can be used to render the interior of a group of lines as transparent during normal rendering, but as 
+  // clickable for hitmap purposes.
   onlyRenderInHitmap?: boolean,
 }
 ```

--- a/docs/src/4.11.Triangles.mdx
+++ b/docs/src/4.11.Triangles.mdx
@@ -34,6 +34,8 @@ type Triangle = {
   color: Color,
   colors?: Color[],
   points: [{ x: number, y: number, z: number }]
+  // Pass true to not render the triangles to the screen - just the hitmap.
+  onlyRenderInHitmap?: boolean,
 }
 ```
 

--- a/packages/regl-worldview/package-lock.json
+++ b/packages/regl-worldview/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "regl-worldview",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "license": "Apache-2.0",
   "repository": "cruise-automation/webviz/tree/master/packages/regl-worldview",

--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -347,10 +347,10 @@ export class WorldviewContext {
         };
         const hitmapProps = getChildrenForHitmap(children, assignNextColorsFn, excludedObjects || []);
         if (hitmapProps) {
-          cmd(hitmapProps);
+          cmd(hitmapProps, true);
         }
       } else if (!isHitmap) {
-        cmd(children);
+        cmd(children, false);
       }
     });
   };

--- a/packages/regl-worldview/src/commands/Cones.js
+++ b/packages/regl-worldview/src/commands/Cones.js
@@ -18,6 +18,7 @@ const { points, sideFaces, endCapFaces } = createCylinderGeometry(30, true);
 
 const cones = fromGeometry(points, sideFaces.concat(endCapFaces));
 
+const getChildrenForHitmap = createInstancedGetChildrenForHitmap(1);
 export default function Cones(props: { ...CommonCommandProps, children: Cone[] }) {
-  return <Command getChildrenForHitmap={createInstancedGetChildrenForHitmap(1)} {...props} reglCommand={cones} />;
+  return <Command getChildrenForHitmap={getChildrenForHitmap} {...props} reglCommand={cones} />;
 }

--- a/packages/regl-worldview/src/commands/Cubes.js
+++ b/packages/regl-worldview/src/commands/Cubes.js
@@ -48,6 +48,7 @@ const cubes = fromGeometry(
   ]
 );
 
+const getChildrenForHitmap = createInstancedGetChildrenForHitmap(1);
 export default function Cubes(props: { ...CommonCommandProps, children: Cube[] }) {
-  return <Command getChildrenForHitmap={createInstancedGetChildrenForHitmap(1)} {...props} reglCommand={cubes} />;
+  return <Command getChildrenForHitmap={getChildrenForHitmap} {...props} reglCommand={cubes} />;
 }

--- a/packages/regl-worldview/src/commands/Cylinders.js
+++ b/packages/regl-worldview/src/commands/Cylinders.js
@@ -49,6 +49,7 @@ const { points, sideFaces, endCapFaces } = createCylinderGeometry(30, false);
 
 const cylinders = fromGeometry(points, sideFaces.concat(endCapFaces));
 
+const getChildrenForHitmap = createInstancedGetChildrenForHitmap(1);
 export default function Cylinders(props: { ...CommonCommandProps, children: Cylinder[] }) {
-  return <Command getChildrenForHitmap={createInstancedGetChildrenForHitmap(1)} {...props} reglCommand={cylinders} />;
+  return <Command getChildrenForHitmap={getChildrenForHitmap} {...props} reglCommand={cylinders} />;
 }

--- a/packages/regl-worldview/src/commands/GLTFScene.js
+++ b/packages/regl-worldview/src/commands/GLTFScene.js
@@ -205,9 +205,9 @@ const drawModel = (regl) => {
     },
   });
 
-  return (props) => {
+  return (props, isHitmap) => {
     const drawCalls = getDrawCalls(props.model);
-    withContext(props, () => {
+    withContext({ ...props, isHitmap }, () => {
       command(drawCalls);
     });
   };
@@ -269,15 +269,6 @@ function useModel(model: string | (() => Promise<GLBModel>)): ?GLBModel {
   );
 }
 
-// Override the default getChildrenForHitmap with our own implementation.
-const getChildrenForHitmap: GetChildrenForHitmap = <T: any>(prop: T, assignNextColors, excludedObjects) => {
-  const hitmapProp = getChildrenForHitmapWithOriginalMarker(prop, assignNextColors, excludedObjects);
-  if (hitmapProp) {
-    return { ...hitmapProp, isHitmap: true };
-  }
-  return hitmapProp;
-};
-
 export default function GLTFScene(props: Props) {
   const { children, model, ...rest } = props;
 
@@ -297,7 +288,7 @@ export default function GLTFScene(props: Props) {
   }
 
   return (
-    <Command {...rest} reglCommand={drawModel} getChildrenForHitmap={getChildrenForHitmap}>
+    <Command {...rest} reglCommand={drawModel} getChildrenForHitmap={getChildrenForHitmapWithOriginalMarker}>
       {{ ...children, model: loadedModel, originalMarker: children }}
     </Command>
   );

--- a/packages/regl-worldview/src/commands/GLTFScene.js
+++ b/packages/regl-worldview/src/commands/GLTFScene.js
@@ -207,7 +207,7 @@ const drawModel = (regl) => {
 
   return (props, isHitmap) => {
     const drawCalls = getDrawCalls(props.model);
-    withContext({ ...props, isHitmap }, () => {
+    withContext(isHitmap ? { ...props, isHitmap } : props, () => {
       command(drawCalls);
     });
   };

--- a/packages/regl-worldview/src/commands/GLTFScene.js
+++ b/packages/regl-worldview/src/commands/GLTFScene.js
@@ -10,7 +10,7 @@ import { mat4 } from "gl-matrix";
 import memoizeWeak from "memoize-weak";
 import React, { useContext, useState, useEffect, useCallback, useDebugValue } from "react";
 
-import type { Pose, Scale, MouseHandler, GetChildrenForHitmap } from "../types";
+import type { Pose, Scale, MouseHandler } from "../types";
 import { defaultBlend, pointToVec3, orientationToVec4 } from "../utils/commandUtils";
 import { getChildrenForHitmapWithOriginalMarker } from "../utils/getChildrenForHitmapDefaults";
 import parseGLB, { type GLBModel } from "../utils/parseGLB";

--- a/packages/regl-worldview/src/commands/Points.js
+++ b/packages/regl-worldview/src/commands/Points.js
@@ -63,6 +63,7 @@ const points = (regl: Regl) => {
   });
 };
 
+const getChildrenForHitmap = createInstancedGetChildrenForHitmap(1);
 export default function Points(props: { ...CommonCommandProps, children: PointType[] }) {
-  return <Command getChildrenForHitmap={createInstancedGetChildrenForHitmap(1)} {...props} reglCommand={points} />;
+  return <Command getChildrenForHitmap={getChildrenForHitmap} {...props} reglCommand={points} />;
 }

--- a/packages/regl-worldview/src/commands/Spheres.js
+++ b/packages/regl-worldview/src/commands/Spheres.js
@@ -56,6 +56,7 @@ for (let j = 0; j < NUM_MERIDIANS; j++) {
 
 const spheres = fromGeometry(points, faces);
 
+const getChildrenForHitmap = createInstancedGetChildrenForHitmap(1);
 export default function Spheres(props: { ...CommonCommandProps, children: SphereList[] }) {
-  return <Command getChildrenForHitmap={createInstancedGetChildrenForHitmap(1)} {...props} reglCommand={spheres} />;
+  return <Command getChildrenForHitmap={getChildrenForHitmap} {...props} reglCommand={spheres} />;
 }

--- a/packages/regl-worldview/src/commands/Triangles.js
+++ b/packages/regl-worldview/src/commands/Triangles.js
@@ -166,6 +166,7 @@ const triangles = (regl: Regl) => {
   };
 };
 
+const getChildrenForHitmap = createInstancedGetChildrenForHitmap(3);
 export default function Triangles(props: { ...CommonCommandProps, children: TriangleList[] }) {
-  return <Command getChildrenForHitmap={createInstancedGetChildrenForHitmap(3)} {...props} reglCommand={triangles} />;
+  return <Command getChildrenForHitmap={getChildrenForHitmap} {...props} reglCommand={triangles} />;
 }

--- a/packages/regl-worldview/src/commands/Triangles.js
+++ b/packages/regl-worldview/src/commands/Triangles.js
@@ -149,15 +149,18 @@ const vertexColors = (regl) =>
 const triangles = (regl: Regl) => {
   const single = regl(singleColor(regl));
   const vertex = regl(vertexColors(regl));
-  return (props: any) => {
-    const items = Array.isArray(props) ? props : [props];
+  return (props: any, isHitmap: boolean) => {
+    const items: TriangleList[] = Array.isArray(props) ? props : [props];
     const singleColorItems = [];
     const vertexColorItems = [];
     items.forEach((item) => {
-      if (item.colors && item.colors.length) {
-        vertexColorItems.push(item);
-      } else {
-        singleColorItems.push(item);
+      // If the item has onlyRenderInHitmap set, only render it in the hitmap.
+      if (isHitmap || !item.onlyRenderInHitmap) {
+        if (item.colors && item.colors.length) {
+          vertexColorItems.push(item);
+        } else {
+          singleColorItems.push(item);
+        }
       }
     });
 

--- a/packages/regl-worldview/src/stories/assertionStories/Triangles.stories.js
+++ b/packages/regl-worldview/src/stories/assertionStories/Triangles.stories.js
@@ -57,6 +57,11 @@ const stories = storiesOf("Integration/Triangles", module).addDecorator(withScre
 generateNonInstancedClickAssertions<TriangleList>("Triangle", Triangles, twoTrianglesInARow).forEach(
   ({ name, story }) => stories.add(name, story)
 );
+generateNonInstancedClickAssertions<TriangleList>(
+  "Triangle with onlyRenderInHitmap=true",
+  Triangles,
+  twoTrianglesInARow.map((triangle) => ({ ...triangle, onlyRenderInHitmap: true }))
+).forEach(({ name, story }) => stories.add(name, story));
 generateInstancedClickAssertions<TriangleList>("Triangle", Triangles, instancedTriangles).forEach(({ name, story }) =>
   stories.add(name, story)
 );

--- a/packages/regl-worldview/src/types/index.js
+++ b/packages/regl-worldview/src/types/index.js
@@ -194,6 +194,8 @@ export type SphereList = BaseShape & {
 export type TriangleList = BaseShape & {
   points: (Point | Vec3)[],
   colors?: (Color | Vec4)[],
+  // Pass true to not render the triangles to the screen - just the hitmap.
+  onlyRenderInHitmap?: boolean,
 };
 
 export type PolygonType = BaseShape & {


### PR DESCRIPTION
## Summary

For performance reasons we sometimes want to only render triangles when clicking. Add an option to allow this. Modify the command API somewhat to enable this. Also do a small cleanup: move all of the `createInstancedGetChildrenForHitmap` calls out of the render functions of commands.

## Test plan

Added a story with this new behavior.

## Versioning impact

Minor package increment needed.
