### PR TITLE
A first take on stopPropagation within worldview

### DIFF
--- a/docs/src/3.4.MouseEvents.mdx
+++ b/docs/src/3.4.MouseEvents.mdx
@@ -1,17 +1,17 @@
-import { MouseEvents, MouseEventsInstanced } from './jsx/allLiveEditors';
+import { MouseEvents, MouseEventsInstanced } from "./jsx/allLiveEditors";
 
 # MouseEvents
 
 Currently Worldview supports the following mouse event handlers: `onDoubleClick`, `onMouseDown`, `onMouseUp`, `onMouseMove`, and `onClick`. When a supported DOM event is fired, the event handler will be triggered with the original event object and additional event information which can help build interactive views.
 
-| Name            | type              | Default | Description                                                                                                                                                              |
-| --------------- | ----------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `onDoubleClick` | `MouseHandler`    |         |                                                                                                                                                                          |
-| `onMouseDown`   | `MouseHandler`    |         |                                                                                                                                                                          |
-| `onMouseUp`     | `MouseHandler`    |         |                                                                                                                                                                          |
-| `onMouseMove`   | `MouseHandler`    |         | only available if the `hitmapOnMouseMove` prop is set to `true` on the Worldview component                                                                               |
-| `onClick`       | `MouseHandler`    |         |                                                                                                                                                                          |
-| `getChildrenForHitmap`     | `GetChildrenForHitmap` |         | Maps the `children` to props to be drawn on the hitmap. Optional, but required for any mouse interactions. Provided by default by all included Commands. See more below. |
+| Name                   | type                   | Default | Description                                                                                                                                                              |
+| ---------------------- | ---------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `onDoubleClick`        | `MouseHandler`         |         |                                                                                                                                                                          |
+| `onMouseDown`          | `MouseHandler`         |         |                                                                                                                                                                          |
+| `onMouseUp`            | `MouseHandler`         |         |                                                                                                                                                                          |
+| `onMouseMove`          | `MouseHandler`         |         | only available if the `hitmapOnMouseMove` prop is set to `true` on the Worldview component                                                                               |
+| `onClick`              | `MouseHandler`         |         |                                                                                                                                                                          |
+| `getChildrenForHitmap` | `GetChildrenForHitmap` |         | Maps the `children` to props to be drawn on the hitmap. Optional, but required for any mouse interactions. Provided by default by all included Commands. See more below. |
 
 ## Event Handler
 
@@ -26,7 +26,6 @@ There are two kinds of event handlers:
 
 - `ray`: the raw raycasting information including `dir` (direction), `origin`, and `point` (all in `Vec3` format).
 - `objects`: an array of objects (`{ object, instanceIndex }`) from this command that you interacted with. There will always be at least one object. The `enableStackedObjectEvents` option must be set to `true` on `<Worldview>` for this handler to return more than one object.
-
 
 ```js
 <Worldview onClick={(evt, { objects }) => console.log("You clicked on", objects.length && objects[0].object.id)}>
@@ -46,8 +45,9 @@ Example:
 ```js
 <Worldview>
   <Cubes
-    onClick={(evt, { objects }) => console.log(`You clicked on ${objects[0].object.id} at index ${objects[0].instanceIndex}`)}
-  >
+    onClick={(evt, { objects }) =>
+      console.log(`You clicked on ${objects[0].object.id} at index ${objects[0].instanceIndex}`)
+    }>
     {cubes}
   </Cubes>
 </Worldview>
@@ -59,23 +59,60 @@ How do we detect which object was interacted with? We use a process called picki
 
 The Worldview library allows a lot of control over this interaction, but most Commands can use one of three default `getChildrenForHitmap` functions.
 
-| Name                       | Description                                                                                                                                                                  | Usage                                                                                |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `nonInstancedGetChildrenForHitmap`    | A default `getChildrenForHitmap` function for non-instanced commands.                                                                                                                   | `<Command getChildrenForHitmap={nonInstancedGetChildrenForHitmap} ... />`                                  |
-| `getChildrenForHitmapWithOriginalMarker`  | Almost identical to nonInstancedGetChildrenForHitmap, but instead the object passed to event callbacks is the object at `prop.originalMarker`, not just `prop`. This is useful for composing commands: see the code for `Arrows` for an example. | `<Command getChildrenForHitmap={getChildrenForHitmapWithOriginalMarker} ... />` |
-| `createInstancedGetChildrenForHitmap` | A factory function for instanced commands. It takes the number of points per instance: for example, a triangle has 3 points, whereas a sphere has 1 point (just the center). | `<Command getChildrenForHitmap={createInstancedGetChildrenForHitmap(1)} ... />` |
+| Name                                     | Description                                                                                                                                                                                                                                      | Usage                                                                           |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
+| `nonInstancedGetChildrenForHitmap`       | A default `getChildrenForHitmap` function for non-instanced commands.                                                                                                                                                                            | `<Command getChildrenForHitmap={nonInstancedGetChildrenForHitmap} ... />`       |
+| `getChildrenForHitmapWithOriginalMarker` | Almost identical to nonInstancedGetChildrenForHitmap, but instead the object passed to event callbacks is the object at `prop.originalMarker`, not just `prop`. This is useful for composing commands: see the code for `Arrows` for an example. | `<Command getChildrenForHitmap={getChildrenForHitmapWithOriginalMarker} ... />` |
+| `createInstancedGetChildrenForHitmap`    | A factory function for instanced commands. It takes the number of points per instance: for example, a triangle has 3 points, whereas a sphere has 1 point (just the center).                                                                     | `<Command getChildrenForHitmap={createInstancedGetChildrenForHitmap(1)} ... />` |
 
 ##### Turning off interactivity for a layer
 
 All built in commands allow overriding the `getChildrenForHitmap` function, and we recommend that you also allow users to override it. If a user passes in `null` or `undefined` for `getChildrenForHitmap` in a command, any objects drawn by that command instance will not be visible for interaction purposes. Disabling interaction in this way may help improve performance.
+
+##### event.stopPropagation()
+
+`event.stopPropagation()` on Command Component Level Handlers will prevent other handlers from firing.
+
+```js
+/*
+  Command Component handler stopping the Worldview level one 
+*/
+<Worldview onClick={(evt, { objects }) => console.log("This wont fire")}>
+  <Cubes
+    onClick={(evt, { objects }) => {
+      evt.stopPropagation();
+      console.log("This will fire");
+    }}>
+    {cubes}
+  </Cubes>
+</Worldview>
+```
+
+```js
+/*
+  Command Component handler stopping another one (only happens when enableStackedObjectEvents={true})
+*/
+<Worldview enableStackedObjectEvents>
+  <Cubes
+    onClick={(evt, { objects }) => {
+      evt.stopPropagation();
+      console.log("This will fire");
+    }}>
+    {cubesInFront}
+  </Cubes>
+  <Cubes onClick={(evt, { objects }) => console.log("This wont fire")}>{cubesBehind}</Cubes>
+</Worldview>
+```
 
 ##### Customizing the getChildrenForHitmap function
 
 Each Command is passed the `reglCommand` function and `children`. Worldview compiles the `reglCommand` once by calling it with the `regl` object as an argument, and calls the resulting command each frame with `children`. `getChildrenForHitmap` takes in those `children` and returns new version of them that will be rendered into the hitmap.
 
 Some important things to remember:
- * The first argument of `getChildrenForHitmap` is the `children`.
- * The second argument is a function that helps us assign colors to each object. Each object or instance that you want to differentiate should receive a unique color, since these colors function as unique IDs.
+
+- The first argument of `getChildrenForHitmap` is the `children`.
+- The second argument is a function that helps us assign colors to each object. Each object or instance that you want to differentiate should receive a unique color, since these colors function as unique IDs.
+
 ```js
 /*
  * object: the object to pass to event callbacks when this object is interacted with.
@@ -84,8 +121,9 @@ Some important things to remember:
  */
 type AssignNextColorsFn = (object: Object, count: number) => Vec4[];
 ```
- *  * Each object that you want to support mouse events on requires a unique ID. If your command actually renders multiple items per input object (such as when using [instanced drawing](https://github.com/regl-project/regl/blob/gh-pages/example/instance-triangle.js)), you may want a separate ID for each item — in this case, call `assignNextColors` with a count gretaer than 1.
- * Once you have this ID, pass it to `intToRGB()` to get the color to paint your object. Don't apply any transparency or shading to your object or this will mess up the hitmap.
+
+- - Each object that you want to support mouse events on requires a unique ID. If your command actually renders multiple items per input object (such as when using [instanced drawing](https://github.com/regl-project/regl/blob/gh-pages/example/instance-triangle.js)), you may want a separate ID for each item — in this case, call `assignNextColors` with a count gretaer than 1.
+- Once you have this ID, pass it to `intToRGB()` to get the color to paint your object. Don't apply any transparency or shading to your object or this will mess up the hitmap.
 
 Example using composition of the default `getChildrenForHitmap` functions:
 
@@ -100,8 +138,7 @@ Example using composition of the default `getChildrenForHitmap` functions:
         hitmapProp.scale = { x: hitmapProps.scale.x * 1.1, y: hitmapProps.scale.y * 1.1, z: hitmapProps.scale.z * 1.1 };
       }
       return hitmapProps;
-    }}
-  >
+    }}>
     {points}
   </Points>
 </Worldview>

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "license": "Apache-2.0",
   "repository": "cruise-automation/webviz/tree/master/packages/regl-worldview",

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -62,7 +62,12 @@ type State = {|
   worldviewContext: WorldviewContext,
 |};
 
-function handleWorldviewMouseInteraction(objects: MouseEventObject[], ray: Ray, e: MouseEvent, handler: MouseHandler) {
+function handleWorldviewMouseInteraction(
+  objects: MouseEventObject[],
+  ray: Ray,
+  e: SyntheticMouseEvent<HTMLCanvasElement>,
+  handler: MouseHandler
+) {
   const args = { ray, objects };
 
   try {
@@ -158,20 +163,20 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     }
   }
 
-  _onDoubleClick = (e: MouseEvent) => {
+  _onDoubleClick = (e: SyntheticMouseEvent<HTMLCanvasElement>) => {
     this._onMouseInteraction(e, "onDoubleClick");
   };
 
-  _onMouseDown = (e: MouseEvent) => {
+  _onMouseDown = (e: SyntheticMouseEvent<HTMLCanvasElement>) => {
     this._dragStartPos = { x: e.clientX, y: e.clientY };
     this._onMouseInteraction(e, "onMouseDown");
   };
 
-  _onMouseMove = (e: MouseEvent) => {
+  _onMouseMove = (e: SyntheticMouseEvent<HTMLCanvasElement>) => {
     this._onMouseInteraction(e, "onMouseMove");
   };
 
-  _onMouseUp = (e: MouseEvent) => {
+  _onMouseUp = (e: SyntheticMouseEvent<HTMLCanvasElement>) => {
     this._onMouseInteraction(e, "onMouseUp");
     const { _dragStartPos } = this;
     if (_dragStartPos) {
@@ -185,7 +190,7 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     }
   };
 
-  _onMouseInteraction = (e: MouseEvent, mouseEventName: MouseEventEnum) => {
+  _onMouseInteraction = (e: SyntheticMouseEvent<HTMLCanvasElement>, mouseEventName: MouseEventEnum) => {
     const { worldviewContext } = this.state;
     const worldviewHandler = this.props[mouseEventName];
 

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -216,13 +216,16 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     worldviewContext
       .readHitmap(canvasX, canvasY, !!this.props.enableStackedObjectEvents, this.props.maxStackedObjectCount)
       .then((mouseEventsWithCommands) => {
-        if (worldviewHandler) {
-          const mouseEvents = mouseEventsWithCommands.map(([mouseEventObject]) => mouseEventObject);
-          handleWorldviewMouseInteraction(mouseEvents, ray, e, worldviewHandler);
-        }
         const mouseEventsByCommand: Map<Command, Array<MouseEventObject>> = aggregate(mouseEventsWithCommands);
         for (const [command, mouseEvents] of mouseEventsByCommand.entries()) {
           command.handleMouseEvent(mouseEvents, ray, e, mouseEventName);
+          if (e.isPropagationStopped()) {
+            break;
+          }
+        }
+        if (worldviewHandler && !e.isPropagationStopped()) {
+          const mouseEvents = mouseEventsWithCommands.map(([mouseEventObject]) => mouseEventObject);
+          handleWorldviewMouseInteraction(mouseEvents, ray, e, worldviewHandler);
         }
       })
       .catch((e) => {

--- a/packages/regl-worldview/src/commands/DrawPolygon/PolygonBuilder.test.js
+++ b/packages/regl-worldview/src/commands/DrawPolygon/PolygonBuilder.test.js
@@ -36,7 +36,7 @@ const getArgs: (number[], ?Object) => ReglClickInfo = (point, object) => {
   };
 };
 
-const event: (?boolean) => MouseEvent = (ctrlKey): any => ({
+const event: (?boolean) => SyntheticMouseEvent<HTMLCanvasElement> = (ctrlKey): any => ({
   ctrlKey,
   stopPropagation: () => {},
   preventDefault: () => {},

--- a/packages/regl-worldview/src/stories/assertionStories/Worldview.stories.js
+++ b/packages/regl-worldview/src/stories/assertionStories/Worldview.stories.js
@@ -26,6 +26,15 @@ const cube = {
   color: { r: 1, g: 0, b: 1, a: 0.5 },
 };
 
+const underCube = {
+  pose: {
+    orientation: { x: 0, y: 0, z: 0, w: 1 },
+    position: { x: 0, y: -30, z: 0 },
+  },
+  scale: { x: 10, y: 10, z: 10 },
+  color: { r: 0, g: 1, b: 1, a: 0.5 },
+};
+
 async function emitMouseEvent(eventName: "mousemove" | "mousedown" | "mouseup" | "dblclick"): Promise<void> {
   const [element] = document.getElementsByTagName("canvas");
   if (!element) {
@@ -170,6 +179,56 @@ stories
       ),
       assertions: async (getTestData) => {
         await emitMouseEvent("dblclick");
+        const result = await getTestData();
+        expect(result.length).toEqual(1);
+        expect(result[0].object).toEqual(cube);
+      },
+    })
+  )
+  .add(
+    `a component's mouse handlers can stop event propagation to worldview's global mouse handlers`,
+    assertionTest({
+      story: (setTestData) => (
+        <WorldviewWrapper onMouseDown={(_, { objects }) => setTestData([])}>
+          <Cubes
+            onMouseDown={(e, { objects }) => {
+              e.stopPropagation();
+              setTestData(objects);
+            }}>
+            {[cube]}
+          </Cubes>
+        </WorldviewWrapper>
+      ),
+      assertions: async (getTestData) => {
+        await emitMouseEvent("mousedown");
+        const result = await getTestData();
+        expect(result.length).toEqual(1);
+        expect(result[0].object).toEqual(cube);
+      },
+    })
+  )
+  .add(
+    `when there are overlapping objects from different commands, the command on top of the drawing layer can stop event propagation to other commands`,
+    assertionTest({
+      story: (setTestData) => (
+        <WorldviewWrapper onMouseDown={(_, { objects }) => setTestData([])}>
+          <Cubes
+            onMouseDown={() => {
+              setTestData([]);
+            }}>
+            {[underCube]}
+          </Cubes>
+          <Cubes
+            onMouseDown={(e, { objects }) => {
+              e.stopPropagation();
+              setTestData(objects);
+            }}>
+            {[cube]}
+          </Cubes>
+        </WorldviewWrapper>
+      ),
+      assertions: async (getTestData) => {
+        await emitMouseEvent("mousedown");
         const result = await getTestData();
         expect(result.length).toEqual(1);
         expect(result[0].object).toEqual(cube);

--- a/packages/regl-worldview/src/stories/assertionStories/Worldview.stories.js
+++ b/packages/regl-worldview/src/stories/assertionStories/Worldview.stories.js
@@ -211,19 +211,19 @@ stories
     `when there are overlapping objects from different commands, the command on top of the drawing layer can stop event propagation to other commands`,
     assertionTest({
       story: (setTestData) => (
-        <WorldviewWrapper onMouseDown={(_, { objects }) => setTestData([])}>
-          <Cubes
-            onMouseDown={() => {
-              setTestData([]);
-            }}>
-            {[underCube]}
-          </Cubes>
+        <WorldviewWrapper enableStackedObjectEvents>
           <Cubes
             onMouseDown={(e, { objects }) => {
               e.stopPropagation();
               setTestData(objects);
             }}>
             {[cube]}
+          </Cubes>
+          <Cubes
+            onMouseDown={() => {
+              setTestData([]);
+            }}>
+            {[underCube]}
           </Cubes>
         </WorldviewWrapper>
       ),

--- a/packages/regl-worldview/src/types/index.js
+++ b/packages/regl-worldview/src/types/index.js
@@ -110,7 +110,7 @@ export type ComponentReglClickInfo = {
   objects: Array<ClickedObject>,
 };
 
-export type MouseHandler = (MouseEvent, ReglClickInfo) => void;
+export type MouseHandler = (SyntheticMouseEvent<HTMLCanvasElement>, ReglClickInfo) => void;
 
 export type ComponentMouseHandler = (MouseEvent, ComponentReglClickInfo) => void;
 


### PR DESCRIPTION
## Summary

We want to mimic how the browser [Event.stopPropagation](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation) works in Worldview, e.g. calling `event.stopPropagation()` in a click handler on a nested div would prevent any click event handlers from firing off in ancestor divs. This PR accomplishes a similar behavior for Worldview by changing the order in which global vs command level mouse handlers are fired as well as using [React's synthetic event's isPropagationStopped](https://reactjs.org/docs/events.html#overview) property.


## Test plan

Added two storybook tests

## Versioning impact

This probably necessitates a major/minor patch as it can be a breaking change to those who use `e.stopPropagation` in command level mouse handlers or those who expect the worldview level mouse handlers to fire off before the command ones.
