### PR TITLE
Add explanation of how to view a rosbag

### DIFF
--- a/packages/webviz-core/README.md
+++ b/packages/webviz-core/README.md
@@ -2,6 +2,8 @@
 
 This is the open source version of Webviz, the browser-based rosbag analysis tool.
 
+Run `npm run docs` and then browse to http://localhost:8080/try. After a few moments the ui will load and bag files can be dragged in to be loaded. 
+
 This directory gets synced from a Cruise-internal directory into
 [http://github.com/cruise-automation/webviz/packages/webviz](http://github.com/cruise-automation/webviz/packages/webviz) and is hosted at
 [https://cruise-automation.github.io/webviz](https://cruise-automation.github.io/webviz/).


### PR DESCRIPTION
From #161


## Summary

I couldn't figure out how to load a rosbag until coming across #161

## Test plan

I ran npm run docs and browsed to try, then dragged in a rosbag.

## Versioning impact

No.
