### PR TITLE
Title capitalization

### DIFF
--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -24,9 +24,9 @@
     <meta name="viewport" content="width=device-width, initial-scale = 1.0,
 maximum-scale=1.0, user-scalable=no" />
     <meta name="description" content="Visualizing robotics data in the browser">
-    <title>Webviz</title>
+    <title>webviz</title>
     <link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Mono&display=swap" rel="stylesheet">
-    <meta property="og:title" content="Webviz" />
+    <meta property="og:title" content="webviz" />
     <meta property="og:description" content="Visualizing robotics data in the browser" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://webviz.io" />


### PR DESCRIPTION
Tiny consistency fix, it just bugged me that for webviz.io the title was "Webviz" but for webviz.io/app it's "webviz". We use the lowercase version in the title bar so I figured I'd just use that for the main page as well. 🙃
