### PR TITLE
Updated follow TF to include Map

### DIFF
--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/FollowTFControl.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/FollowTFControl.js
@@ -89,13 +89,15 @@ type Props = {
   onFollowChange: (tfId?: string | false, followOrientation?: boolean) => void,
 };
 
-function* getDescendants(nodes: TfTreeNode[]) {
-  for (const node of nodes) {
-    if (node.tf.id !== getGlobalHooks().perPanelHooks().ThreeDimensionalViz.rootTransformFrame) {
-      yield node;
-    }
-    yield* getDescendants(node.children);
+function getDescendants(roots: TfTreeNode[]) {
+  const toVisit = [...roots]
+  const visited = []
+  while (toVisit.length >0){
+    const node = toVisit.pop();
+    visited.push(node);
+    node.children.forEach(child=>toVisit.push(child));
   }
+  return visited;
 }
 
 function getItemText(node: TfTreeNode | { tf: { id: string }, depth: number }) {

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/FollowTFControl.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/FollowTFControl.js
@@ -90,12 +90,12 @@ type Props = {
 };
 
 function getDescendants(roots: TfTreeNode[]) {
-  const toVisit = [...roots]
-  const visited = []
-  while (toVisit.length >0){
+  const toVisit = [...roots];
+  const visited = [];
+  while (toVisit.length > 0) {
     const node = toVisit.pop();
     visited.push(node);
-    node.children.forEach(child=>toVisit.push(child));
+    node.children.forEach((child) => toVisit.push(child));
   }
   return visited;
 }


### PR DESCRIPTION
## Summary

When I was viewing bags, I couldn't see the bags in the map frame. I was looking through the functions and I found a bug in the `getDescendants` function. It was ignoring the possibility of viewing the bag in the `rootTransformFrame`
![image](https://user-images.githubusercontent.com/4957157/71756844-c4a5a580-2e46-11ea-862a-647fd8baf681.png)

## Test plan
Tested the function using `npm run docs` with and without bag files. This always traverses down the tree producing the list expected including the root TF
## Versioning impact
Not as far as I know
