### PR TITLE
chore: remove yarn workspace key

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,8 +138,5 @@
     "screenshot-debug": "npm run screenshot -- --parallel 1 --debug --puppeteer-launch-config '{\"headless\": false, \"--args\":[\"--user-agent=PuppeteerTestingChrome/72.\"]}'",
     "ci-commands-for-cruise-proprietary-repo": "npm run install-ci && NODE_ENV=production npm run build && npm run lint && npm run flow && npm test && NODE_ENV=production npm run screenshot-ci",
     "ci": "npm run ci-commands-for-cruise-proprietary-repo && reg-suit run --verbose"
-  },
-  "workspaces": [
-    "packages/*"
-  ]
+  }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Webviz! To help us understand and review your PR, please fill out the following sections: -->

## Summary

fixes: #321 

from a contributors standpoint, I think that this field is confusing as this repo is not using yarn workspaces. Thus, removing it would make working within this repo easier.

## Test plan

- install and bootstrap works as intended and symlinks are preserved

## Versioning impact

N/A
