### PR TITLE
Worldview: fix hitmap bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9446,21 +9446,21 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
@@ -9478,14 +9478,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
@@ -9503,28 +9503,28 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
@@ -9548,14 +9548,14 @@
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
@@ -9572,14 +9572,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -9611,7 +9611,7 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
@@ -9638,7 +9638,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -9656,14 +9656,14 @@
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
@@ -9673,14 +9673,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
@@ -9690,7 +9690,7 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
@@ -9718,7 +9718,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
@@ -9766,7 +9766,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -9795,7 +9795,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -9808,21 +9808,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
@@ -9832,21 +9832,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -9857,7 +9857,7 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
@@ -9884,7 +9884,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -9893,7 +9893,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -9926,14 +9926,14 @@
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
@@ -9947,21 +9947,21 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
@@ -9973,7 +9973,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -9983,7 +9983,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
@@ -9993,7 +9993,7 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
@@ -10016,7 +10016,7 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
@@ -10033,7 +10033,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true

--- a/packages/regl-worldview/package-lock.json
+++ b/packages/regl-worldview/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "regl-worldview",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/regl-worldview/package-lock.json
+++ b/packages/regl-worldview/package-lock.json
@@ -132,6 +132,11 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
 			"integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc="
+		},
+		"shallowequal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+			"integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
 		}
 	}
 }

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "license": "Apache-2.0",
   "repository": "cruise-automation/webviz/tree/master/packages/regl-worldview",

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -36,7 +36,8 @@
     "normalize-wheel": "1.0.1",
     "react-container-dimensions": "1.3.3",
     "regl": "^1.3.1",
-    "reselect": "^3.0.1"
+    "reselect": "^3.0.1",
+    "shallowequal": "1.1.0"
   },
   "devDependencies": {
     "flow-bin": "0.80.0"

--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -86,9 +86,9 @@ export class WorldviewContext {
   _paintCalls: Map<PaintFn, PaintFn> = new Map();
   _hitmapObjectIdManager: HitmapObjectIdManager = new HitmapObjectIdManager();
   _cachedReadHitmapCall: ?{
-    arguments: Array<any>,
+    arguments: any[],
     result: Array<[MouseEventObject, Command<any>]>,
-  } = null;
+  } = undefined;
   // store every compiled command object compiled for debugging purposes
   reglCommandObjects: { stats: { count: number } }[] = [];
   counters: { paint?: number, render?: number } = {};
@@ -237,7 +237,7 @@ export class WorldviewContext {
       maxStackedObjectCount: number
     ): Promise<Array<[MouseEventObject, Command<any>]>> => {
       if (!this.initializedData) {
-        return new Promise((_, reject) => reject(new Error("regl data not initialized yet")));
+        return Promise.reject(new Error("regl data not initialized yet"));
       }
       const args = [canvasX, canvasY, enableStackedObjectEvents, maxStackedObjectCount];
 
@@ -252,7 +252,7 @@ export class WorldviewContext {
           ]);
           return Promise.resolve(result);
         }
-        this._cachedReadHitmapCall = null;
+        this._cachedReadHitmapCall = undefined;
       }
 
       const { regl, camera, _fbo } = this.initializedData;

--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -26,6 +26,7 @@ import type {
 import { getIdFromPixel, intToRGB } from "./utils/commandUtils";
 import { getNodeEnv } from "./utils/common";
 import HitmapObjectIdManager from "./utils/HitmapObjectIdManager";
+import queuePromise from "./utils/queuePromise";
 import { getRayFromClick } from "./utils/Raycast";
 
 type Props = any;
@@ -222,113 +223,115 @@ export class WorldviewContext {
 
   _debouncedPaint = debounce(this.paint, 10);
 
-  readHitmap(
-    canvasX: number,
-    canvasY: number,
-    enableStackedObjectEvents: boolean,
-    maxStackedObjectCount: number
-  ): Promise<Array<[MouseEventObject, Command<any>]>> {
-    if (!this.initializedData) {
-      return new Promise((_, reject) => reject(new Error("regl data not initialized yet")));
-    }
+  readHitmap = queuePromise(
+    (
+      canvasX: number,
+      canvasY: number,
+      enableStackedObjectEvents: boolean,
+      maxStackedObjectCount: number
+    ): Promise<Array<[MouseEventObject, Command<any>]>> => {
+      if (!this.initializedData) {
+        return new Promise((_, reject) => reject(new Error("regl data not initialized yet")));
+      }
 
-    const { regl, camera, _fbo } = this.initializedData;
-    const { width, height } = this.dimension;
+      const { regl, camera, _fbo } = this.initializedData;
+      const { width, height } = this.dimension;
 
-    const x = canvasX;
-    // 0,0 corresponds to the bottom left in the webgl context, but the top left in window coordinates
-    const y = height - canvasY;
+      const x = canvasX;
+      // 0,0 corresponds to the bottom left in the webgl context, but the top left in window coordinates
+      const y = height - canvasY;
 
-    // regl will only resize the framebuffer if the size changed
-    // it uses floored whole pixel values
-    _fbo.resize(Math.floor(width), Math.floor(height));
+      // regl will only resize the framebuffer if the size changed
+      // it uses floored whole pixel values
+      _fbo.resize(Math.floor(width), Math.floor(height));
 
-    return new Promise((resolve) => {
-      // tell regl to use a framebuffer for this render
-      regl({ framebuffer: _fbo })(() => {
-        // clear the framebuffer
-        regl.clear({ color: intToRGB(0), depth: 1 });
-        let currentObjectId = 0;
-        const excludedObjects = [];
-        const mouseEventsWithCommands = [];
-        let counter = 0;
+      return new Promise((resolve) => {
+        // tell regl to use a framebuffer for this render
+        regl({ framebuffer: _fbo })(() => {
+          // clear the framebuffer
+          regl.clear({ color: intToRGB(0), depth: 1 });
+          let currentObjectId = 0;
+          const excludedObjects = [];
+          const mouseEventsWithCommands = [];
+          let counter = 0;
 
-        camera.draw(this.cameraStore.state, () => {
-          // Every iteration in this loop clears the framebuffer, draws the hitmap objects that have NOT already been
-          // seen to the framebuffer, and then reads the pixel under the cursor to find the object on top.
-          // If `enableStackedObjectEvents` is false, we only do this iteration once - we only resolve with 0 or 1
-          // objects.
-          do {
-            if (counter >= maxStackedObjectCount) {
-              // Provide a max number of layers so this while loop doesn't crash the page.
-              console.error(
-                `Hit ${maxStackedObjectCount} iterations. There is either a bug or that number of rendered hitmap layers under the mouse cursor.`
-              );
-              break;
-            }
-            counter++;
-            regl.clear({ color: intToRGB(0), depth: 1 });
-            this._drawInput(true, excludedObjects);
-
-            // it's possible to get x/y values outside the framebuffer size
-            // if the mouse quickly leaves the draw area during a read operation
-            // reading outside the bounds of the framebuffer causes errors
-            // and puts regl into a bad internal state.
-            // https://github.com/regl-project/regl/blob/28fbf71c871498c608d9ec741d47e34d44af0eb5/lib/read.js#L57
-            if (x < Math.floor(width) && y < Math.floor(height) && x >= 0 && y >= 0) {
-              const pixel = new Uint8Array(4);
-
-              // read pixel value from the frame buffer
-              regl.read({
-                x,
-                y,
-                width: 1,
-                height: 1,
-                data: pixel,
-              });
-
-              currentObjectId = getIdFromPixel(pixel);
-              const mouseEventObject = this._hitmapObjectIdManager.getObjectByObjectHitmapId(currentObjectId);
-
-              // Check an error case: if we see an ID/color that we don't know about, it means that some command is
-              // drawing a color into the hitmap that it shouldn't be.
-              if (currentObjectId > 0 && !mouseEventObject) {
+          camera.draw(this.cameraStore.state, () => {
+            // Every iteration in this loop clears the framebuffer, draws the hitmap objects that have NOT already been
+            // seen to the framebuffer, and then reads the pixel under the cursor to find the object on top.
+            // If `enableStackedObjectEvents` is false, we only do this iteration once - we only resolve with 0 or 1
+            // objects.
+            do {
+              if (counter >= maxStackedObjectCount) {
+                // Provide a max number of layers so this while loop doesn't crash the page.
                 console.error(
-                  `Clicked on an unknown object with id ${currentObjectId}. This likely means that a command is painting an incorrect color into the hitmap.`
-                );
-              }
-              // Check an error case: if we've already seen this object, then the getHitmapFromChildren function
-              // is not respecting the excludedObjects correctly and we should notify the user of a bug.
-              if (
-                excludedObjects.some(
-                  ({ object, instanceIndex }) =>
-                    object === mouseEventObject.object && instanceIndex === mouseEventObject.instanceIndex
-                )
-              ) {
-                console.error(
-                  `Saw object twice when reading from hitmap. There is likely an error in getHitmapFromChildren`,
-                  mouseEventObject
+                  `Hit ${maxStackedObjectCount} iterations. There is either a bug or that number of rendered hitmap layers under the mouse cursor.`
                 );
                 break;
               }
+              counter++;
+              regl.clear({ color: intToRGB(0), depth: 1 });
+              this._drawInput(true, excludedObjects);
 
-              if (currentObjectId > 0 && mouseEventObject.object) {
-                const command = this._hitmapObjectIdManager.getCommandForObject(mouseEventObject.object);
-                excludedObjects.push(mouseEventObject);
-                if (command) {
-                  mouseEventsWithCommands.push([mouseEventObject, command]);
+              // it's possible to get x/y values outside the framebuffer size
+              // if the mouse quickly leaves the draw area during a read operation
+              // reading outside the bounds of the framebuffer causes errors
+              // and puts regl into a bad internal state.
+              // https://github.com/regl-project/regl/blob/28fbf71c871498c608d9ec741d47e34d44af0eb5/lib/read.js#L57
+              if (x < Math.floor(width) && y < Math.floor(height) && x >= 0 && y >= 0) {
+                const pixel = new Uint8Array(4);
+
+                // read pixel value from the frame buffer
+                regl.read({
+                  x,
+                  y,
+                  width: 1,
+                  height: 1,
+                  data: pixel,
+                });
+
+                currentObjectId = getIdFromPixel(pixel);
+                const mouseEventObject = this._hitmapObjectIdManager.getObjectByObjectHitmapId(currentObjectId);
+
+                // Check an error case: if we see an ID/color that we don't know about, it means that some command is
+                // drawing a color into the hitmap that it shouldn't be.
+                if (currentObjectId > 0 && !mouseEventObject) {
+                  console.error(
+                    `Clicked on an unknown object with id ${currentObjectId}. This likely means that a command is painting an incorrect color into the hitmap.`
+                  );
+                }
+                // Check an error case: if we've already seen this object, then the getHitmapFromChildren function
+                // is not respecting the excludedObjects correctly and we should notify the user of a bug.
+                if (
+                  excludedObjects.some(
+                    ({ object, instanceIndex }) =>
+                      object === mouseEventObject.object && instanceIndex === mouseEventObject.instanceIndex
+                  )
+                ) {
+                  console.error(
+                    `Saw object twice when reading from hitmap. There is likely an error in getHitmapFromChildren`,
+                    mouseEventObject
+                  );
+                  break;
+                }
+
+                if (currentObjectId > 0 && mouseEventObject.object) {
+                  const command = this._hitmapObjectIdManager.getCommandForObject(mouseEventObject.object);
+                  excludedObjects.push(mouseEventObject);
+                  if (command) {
+                    mouseEventsWithCommands.push([mouseEventObject, command]);
+                  }
                 }
               }
-            }
-            // If we haven't enabled stacked object events, break out of the loop immediately.
-            // eslint-disable-next-line no-unmodified-loop-condition
-          } while (currentObjectId !== 0 && enableStackedObjectEvents);
+              // If we haven't enabled stacked object events, break out of the loop immediately.
+              // eslint-disable-next-line no-unmodified-loop-condition
+            } while (currentObjectId !== 0 && enableStackedObjectEvents);
 
-          resolve(mouseEventsWithCommands);
+            resolve(mouseEventsWithCommands);
+          });
         });
       });
-    });
-  }
+    }
+  );
 
   _drawInput = (isHitmap?: boolean, excludedObjects?: MouseEventObject[]) => {
     if (isHitmap) {

--- a/packages/regl-worldview/src/stories/assertionStories/Worldview.stories.js
+++ b/packages/regl-worldview/src/stories/assertionStories/Worldview.stories.js
@@ -14,7 +14,7 @@ import React from "react";
 import { withScreenshot } from "storybook-chrome-screenshot";
 
 import Cubes from "../../commands/Cubes";
-import { WorldviewWrapper, clickAtOrigin, WORLDVIEW_SIZE } from "../worldviewAssertionUtils";
+import { WorldviewWrapper, clickAtOrigin, WORLDVIEW_SIZE, defaultCameraState } from "../worldviewAssertionUtils";
 import { assertionTest, timeout } from "stories/assertionTestUtils";
 
 const cube = {
@@ -35,15 +35,19 @@ const underCube = {
   color: { r: 0, g: 1, b: 1, a: 0.5 },
 };
 
-async function emitMouseEvent(eventName: "mousemove" | "mousedown" | "mouseup" | "dblclick"): Promise<void> {
+async function emitMouseEvent(
+  eventName: "mousemove" | "mousedown" | "mouseup" | "dblclick",
+  clientX: number = WORLDVIEW_SIZE / 2,
+  clientY: number = WORLDVIEW_SIZE / 2
+): Promise<void> {
   const [element] = document.getElementsByTagName("canvas");
   if (!element) {
     throw new Error("Could not find canvas element");
   }
   const mouseEvent = new MouseEvent(eventName, {
     bubbles: true,
-    clientX: WORLDVIEW_SIZE / 2,
-    clientY: WORLDVIEW_SIZE / 2,
+    clientX,
+    clientY,
   });
   element.dispatchEvent(mouseEvent);
   await timeout(100);
@@ -232,6 +236,82 @@ stories
         const result = await getTestData();
         expect(result.length).toEqual(1);
         expect(result[0].object).toEqual(cube);
+      },
+    })
+  )
+  .add(
+    `Firing two mouse events at the same time does not cause an error`,
+    assertionTest({
+      story: (setTestData) => (
+        <WorldviewWrapper onMouseDown={(_, clickInfo) => setTestData(clickInfo)}>
+          <Cubes>{[cube]}</Cubes>
+        </WorldviewWrapper>
+      ),
+      assertions: async (getTestData) => {
+        emitMouseEvent("mousedown");
+        await emitMouseEvent("mousedown");
+        const result1 = await getTestData();
+        expect(result1.objects[0].object).toEqual(cube);
+      },
+    })
+  )
+  .add(
+    `(cached hitmap test) A second event at the same point correctly selects the same object`,
+    assertionTest({
+      story: (setTestData) => (
+        <WorldviewWrapper onMouseDown={(_, clickInfo) => setTestData(clickInfo)}>
+          <Cubes>{[cube]}</Cubes>
+        </WorldviewWrapper>
+      ),
+      assertions: async (getTestData) => {
+        await emitMouseEvent("mousedown");
+        const result1 = await getTestData();
+        expect(result1.objects[0].object).toEqual(cube);
+        await emitMouseEvent("mousedown");
+        const result2 = await getTestData();
+        expect(result2.objects[0].object).toEqual(cube);
+      },
+    })
+  )
+  .add(
+    `(cached hitmap test) repainting busts the cache`,
+    assertionTest({
+      story: (setTestData, state) => (
+        <WorldviewWrapper
+          cameraState={state || defaultCameraState}
+          onMouseDown={(_, clickInfo) => setTestData(clickInfo)}>
+          <Cubes>{[cube]}</Cubes>
+        </WorldviewWrapper>
+      ),
+      assertions: async (getTestData, setState) => {
+        await emitMouseEvent("mousedown");
+        const result1 = await getTestData();
+        expect(result1.objects[0].object).toEqual(cube);
+
+        setState({ ...defaultCameraState, target: [100, 0, 0] });
+        await timeout(100);
+        await emitMouseEvent("mousedown");
+        const result2 = await getTestData();
+        expect(result2.objects.length).toEqual(0);
+      },
+    })
+  )
+  .add(
+    `(cached hitmap test) A second event at a different point does not use the first cached point`,
+    assertionTest({
+      story: (setTestData) => (
+        <WorldviewWrapper onMouseDown={(_, clickInfo) => setTestData(clickInfo)}>
+          <Cubes>{[cube]}</Cubes>
+        </WorldviewWrapper>
+      ),
+      assertions: async (getTestData) => {
+        await emitMouseEvent("mousedown");
+        const result1 = await getTestData();
+        expect(result1.objects[0].object).toEqual(cube);
+
+        await emitMouseEvent("mousedown", 0, 0);
+        const result2 = await getTestData();
+        expect(result2.objects.length).toEqual(0);
       },
     })
   );

--- a/packages/regl-worldview/src/stories/assertionStories/Worldview.stories.js
+++ b/packages/regl-worldview/src/stories/assertionStories/Worldview.stories.js
@@ -274,7 +274,7 @@ stories
     })
   )
   .add(
-    `(cached hitmap test) repainting busts the cache`,
+    `(cached hitmap test) Repainting busts the cache`,
     assertionTest({
       story: (setTestData, state) => (
         <WorldviewWrapper

--- a/packages/regl-worldview/src/stories/worldviewAssertionUtils.js
+++ b/packages/regl-worldview/src/stories/worldviewAssertionUtils.js
@@ -16,7 +16,7 @@ import type { CameraState } from "../types";
 import Worldview, { type Props } from "../Worldview";
 import { assertionTest, timeout } from "stories/assertionTestUtils";
 
-const defaultCameraState: $Shape<CameraState> = {
+export const defaultCameraState: $Shape<CameraState> = {
   distance: 75,
   perspective: true,
   phi: Math.PI / 2,

--- a/packages/regl-worldview/src/utils/queuePromise.js
+++ b/packages/regl-worldview/src/utils/queuePromise.js
@@ -6,33 +6,44 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 
-type QueuedFn = ((...args: Array<any>) => void) & { currentPromise: ?Promise<any> };
+import { signal } from "./signal";
+
+type QueuedFn = ((...args: Array<any>) => Promise<any>) & { currentPromise: ?Promise<any> };
 
 // Wait for the previous promise to resolve before starting the next call to the function.
 export default function queuePromise(fn: (...args: Array<any>) => Promise<any>): QueuedFn {
   // Whether we are currently waiting for a promise returned by `fn` to resolve.
   let calling = false;
   // Whether another call to the function was made while a call was in progress.
-  let nextCallsArguments = [];
+  const nextCallsArguments = [];
+  const nextCallPromises = [];
 
   function queuedFn(...args) {
     if (calling) {
       nextCallsArguments.push(args);
-    } else {
-      start(...args);
+      const returnPromise = signal();
+      nextCallPromises.push(returnPromise);
+      return returnPromise;
     }
+    return start(...args);
   }
 
   function start(...args) {
     calling = true;
 
-    queuedFn.currentPromise = fn(...args).finally(() => {
+    const promise = fn(...args).finally(() => {
       calling = false;
       queuedFn.currentPromise = undefined;
       if (nextCallsArguments.length) {
-        start(...nextCallsArguments.shift());
+        const nextPromise = nextCallPromises.shift();
+        start(...nextCallsArguments.shift())
+          .then((result) => nextPromise.resolve(result))
+          .catch((error) => nextPromise.reject(error));
       }
     });
+    queuedFn.currentPromise = promise;
+
+    return promise;
   }
 
   return queuedFn;

--- a/packages/regl-worldview/src/utils/queuePromise.js
+++ b/packages/regl-worldview/src/utils/queuePromise.js
@@ -6,23 +6,21 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 
-import { signal } from "./signal";
+import { signal, type Signal } from "./signal";
 
-type QueuedFn = ((...args: Array<any>) => Promise<any>) & { currentPromise: ?Promise<any> };
+type QueuedFn = ((...args: any[]) => Promise<any>) & { currentPromise: ?Promise<any> };
 
 // Wait for the previous promise to resolve before starting the next call to the function.
-export default function queuePromise(fn: (...args: Array<any>) => Promise<any>): QueuedFn {
+export default function queuePromise(fn: (...args: any[]) => Promise<any>): QueuedFn {
   // Whether we are currently waiting for a promise returned by `fn` to resolve.
   let calling = false;
-  // Whether another call to the function was made while a call was in progress.
-  const nextCallsArguments = [];
-  const nextCallPromises = [];
+  // The list of calls made to the function was made while a call was in progress.
+  const nextCalls: {| args: any[], promise: Signal<any> |}[] = [];
 
   function queuedFn(...args) {
     if (calling) {
-      nextCallsArguments.push(args);
       const returnPromise = signal();
-      nextCallPromises.push(returnPromise);
+      nextCalls.push({ args, promise: returnPromise });
       return returnPromise;
     }
     return start(...args);
@@ -34,9 +32,9 @@ export default function queuePromise(fn: (...args: Array<any>) => Promise<any>):
     const promise = fn(...args).finally(() => {
       calling = false;
       queuedFn.currentPromise = undefined;
-      if (nextCallsArguments.length) {
-        const nextPromise = nextCallPromises.shift();
-        start(...nextCallsArguments.shift())
+      if (nextCalls.length) {
+        const { promise: nextPromise, args: nextArgs } = nextCalls.shift();
+        start(...nextArgs)
           .then((result) => nextPromise.resolve(result))
           .catch((error) => nextPromise.reject(error));
       }

--- a/packages/regl-worldview/src/utils/queuePromise.js
+++ b/packages/regl-worldview/src/utils/queuePromise.js
@@ -1,0 +1,39 @@
+// @flow
+//
+//  Copyright (c) 2019-present, Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+type QueuedFn = ((...args: Array<any>) => void) & { currentPromise: ?Promise<any> };
+
+// Wait for the previous promise to resolve before starting the next call to the function.
+export default function queuePromise(fn: (...args: Array<any>) => Promise<any>): QueuedFn {
+  // Whether we are currently waiting for a promise returned by `fn` to resolve.
+  let calling = false;
+  // Whether another call to the function was made while a call was in progress.
+  let nextCallsArguments = [];
+
+  function queuedFn(...args) {
+    if (calling) {
+      nextCallsArguments.push(args);
+    } else {
+      start(...args);
+    }
+  }
+
+  function start(...args) {
+    calling = true;
+
+    queuedFn.currentPromise = fn(...args).finally(() => {
+      calling = false;
+      queuedFn.currentPromise = undefined;
+      if (nextCallsArguments.length) {
+        start(...nextCallsArguments.shift());
+      }
+    });
+  }
+
+  return queuedFn;
+}

--- a/packages/regl-worldview/src/utils/queuePromise.test.js
+++ b/packages/regl-worldview/src/utils/queuePromise.test.js
@@ -1,0 +1,79 @@
+// @flow
+//
+//  Copyright (c) 2019-present, Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+import queuePromise from "./queuePromise";
+
+type Signal<T> = Promise<T> & {
+  resolve: (T) => void,
+  reject: (Error) => void,
+};
+
+function signal<T>(): Signal<T> {
+  let resolve;
+  let reject;
+  const promise: any = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  promise.resolve = resolve;
+  promise.reject = reject;
+  return promise;
+}
+
+/* eslint-disable jest/valid-expect-in-promise */
+
+describe("queuePromise", () => {
+  it("queues with resolved and rejected promises", async () => {
+    const secondPromise = signal();
+    const promises = [Promise.resolve(), secondPromise, Promise.resolve()];
+
+    let calls = 0;
+    const callArgs = [];
+    const queuedFn = queuePromise((...args) => {
+      callArgs.push(args);
+      ++calls;
+      return promises.shift();
+    });
+
+    expect(calls).toBe(0);
+
+    queuedFn(1, 2);
+    queuedFn(3, 4);
+    queuedFn(5, 6);
+    expect(calls).toBe(1);
+    expect(callArgs).toEqual([[1, 2]]);
+    expect(queuedFn.currentPromise).not.toBeUndefined();
+
+    await secondPromise.reject(new Error(""));
+    expect(calls).toBe(2);
+    expect(callArgs).toEqual([[1, 2], [3, 4]]);
+    await Promise.resolve();
+
+    expect(calls).toBe(3);
+    expect(callArgs).toEqual([[1, 2], [3, 4], [5, 6]]);
+    expect(queuedFn.currentPromise).toBeUndefined();
+  });
+
+  it("handles nested calls", async () => {
+    expect.assertions(3);
+
+    let calls = 0;
+    const queuedFn = queuePromise(async () => {
+      ++calls;
+      if (calls === 1) {
+        queuedFn();
+        expect(calls).toBe(1);
+      }
+    });
+
+    queuedFn();
+    expect(calls).toBe(1);
+    await Promise.resolve();
+    expect(calls).toBe(2);
+  });
+});

--- a/packages/regl-worldview/src/utils/queuePromise.test.js
+++ b/packages/regl-worldview/src/utils/queuePromise.test.js
@@ -7,23 +7,7 @@
 //  You may not use this file except in compliance with the License.
 
 import queuePromise from "./queuePromise";
-
-type Signal<T> = Promise<T> & {
-  resolve: (T) => void,
-  reject: (Error) => void,
-};
-
-function signal<T>(): Signal<T> {
-  let resolve;
-  let reject;
-  const promise: any = new Promise((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  promise.resolve = resolve;
-  promise.reject = reject;
-  return promise;
-}
+import { signal } from "./signal";
 
 /* eslint-disable jest/valid-expect-in-promise */
 

--- a/packages/regl-worldview/src/utils/signal.js
+++ b/packages/regl-worldview/src/utils/signal.js
@@ -1,0 +1,24 @@
+// @flow
+//
+//  Copyright (c) 2019-present, Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+export type Signal<T> = Promise<T> & {
+  resolve: (T) => void,
+  reject: (Error) => void,
+};
+
+export function signal<T>(): Signal<T> {
+  let resolve;
+  let reject;
+  const promise: any = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  promise.resolve = resolve;
+  promise.reject = reject;
+  return promise;
+}

--- a/stories/assertionTestUtils.js
+++ b/stories/assertionTestUtils.js
@@ -16,8 +16,8 @@ export async function timeout(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-type Story = (setTestData: (any) => void) => React$Element<any>;
-type Assertion = (getTestData: () => any) => Promise<void>;
+type Story = (setTestData: (any) => void, state: any) => React$Element<any>;
+type Assertion = (getTestData: () => any, setState: (any) => void) => Promise<void>;
 type AssertionTest = {|
   story: Story,
   assertions: Assertion,
@@ -55,11 +55,12 @@ export function assertionTest({ story, assertions }: AssertionTest): () => React
 
   function Component() {
     const [error, setError] = useState<any>();
+    const [state, setState] = useState(null);
     useLayoutEffect(() => {
       const assertionPromise = async () => {
         await timeout(100);
         try {
-          await assertions(getTestData);
+          await assertions(getTestData, setState);
         } catch (error) {
           console.warn(error);
           throw error;
@@ -95,7 +96,7 @@ export function assertionTest({ story, assertions }: AssertionTest): () => React
         <pre>{error.stack}</pre>
       </div>
     ) : (
-      story(setTestData)
+      story(setTestData, state)
     );
   }
   return () => <Component />;


### PR DESCRIPTION
I'm seeing an error in our logs: "(regl) can not resize a framebuffer
which is currently in use" in the readHitmap function. Fix by debouncing
the readHitmap function because the framebuffer can only be used in
one function at a time. Also add caching to our readHitmap function: if
we haven't repainted or changed the pixel that we're looking at, we return
the previous result.

Test plan: test added for queuePromise for caching. Testing that caching
actually works (an implementation detail) seems a bit difficult right now
given our test harness.

Release plan: minor release required
