### PR TITLE
RosOut: add TopicToRenderMenu

### DIFF
--- a/packages/webviz-core/src/panels/Rosout/index.stories.js
+++ b/packages/webviz-core/src/panels/Rosout/index.stories.js
@@ -93,6 +93,17 @@ storiesOf("<RosoutPanel>", module)
       </PanelSetup>
     );
   })
+  .add("topicToRender", () => {
+    return (
+      <PanelSetup
+        fixture={{
+          topics: [{ name: "/foo/rosout", datatype: "dummy" }],
+          frame: { "/foo/rosout": fixture.frame["/rosout"].map((msg) => ({ ...msg, topic: "/foo/rosout" })) },
+        }}>
+        <Rosout config={{ searchTerms: [], minLogLevel: 1, topicToRender: "/foo/rosout" }} />
+      </PanelSetup>
+    );
+  })
   .add("with toolbar active", () => {
     return (
       <PanelSetup
@@ -111,14 +122,14 @@ storiesOf("<RosoutPanel>", module)
   .add(`filtered terms: "multiple", "/some_topic"`, () => {
     return (
       <PanelSetup fixture={fixture}>
-        <Rosout config={{ searchTerms: ["multiple", "/some_topic"], minLogLevel: 1 }} />
+        <Rosout config={{ searchTerms: ["multiple", "/some_topic"], minLogLevel: 1, topicToRender: "/rosout" }} />
       </PanelSetup>
     );
   })
   .add(`case insensitive message filtering: "could", "Ipsum"`, () => {
     return (
       <PanelSetup fixture={fixture}>
-        <Rosout config={{ searchTerms: ["could", "Ipsum"], minLogLevel: 1 }} />
+        <Rosout config={{ searchTerms: ["could", "Ipsum"], minLogLevel: 1, topicToRender: "/rosout" }} />
       </PanelSetup>
     );
   });

--- a/packages/webviz-core/src/panels/Rosout/index.stories.js
+++ b/packages/webviz-core/src/panels/Rosout/index.stories.js
@@ -94,11 +94,32 @@ storiesOf("<RosoutPanel>", module)
     );
   })
   .add("topicToRender", () => {
+    function makeMessages(topic) {
+      return fixture.frame["/rosout"].map((msg) => ({
+        ...msg,
+        topic,
+        message: { ...msg.message, name: `${topic}${msg.message.name}` },
+      }));
+    }
     return (
       <PanelSetup
         fixture={{
-          topics: [{ name: "/foo/rosout", datatype: "dummy" }],
-          frame: { "/foo/rosout": fixture.frame["/rosout"].map((msg) => ({ ...msg, topic: "/foo/rosout" })) },
+          topics: [
+            { name: "/rosout", datatype: "rosgraph_msgs/Log" },
+            { name: "/foo/rosout", datatype: "rosgraph_msgs/Log" },
+            { name: "/webviz_bag_2/rosout", datatype: "rosgraph_msgs/Log" },
+          ],
+          frame: {
+            "/rosout": makeMessages("/rosout"),
+            "/foo/rosout": makeMessages("/foo/rosout"),
+            "/webviz_bag_2/rosout": makeMessages("/webviz_bag_2/rosout"),
+          },
+        }}
+        onMount={(el) => {
+          TestUtils.Simulate.mouseEnter(document.querySelector("[data-test=panel-mouseenter-container]"));
+          setTimeout(() => {
+            TestUtils.Simulate.click(document.querySelector("[data-test=topic-set]"));
+          });
         }}>
         <Rosout config={{ searchTerms: [], minLogLevel: 1, topicToRender: "/foo/rosout" }} />
       </PanelSetup>
@@ -109,10 +130,9 @@ storiesOf("<RosoutPanel>", module)
       <PanelSetup
         fixture={fixture}
         onMount={(el) => {
-          const mouseEnterContainer = document.querySelectorAll("[data-test=panel-mouseenter-container")[0];
-          TestUtils.Simulate.mouseEnter(mouseEnterContainer);
+          TestUtils.Simulate.mouseEnter(document.querySelector("[data-test=panel-mouseenter-container]"));
           setTimeout(() => {
-            document.querySelectorAll("[data-test=panel-settings]")[0].click();
+            TestUtils.Simulate.click(document.querySelector("[data-test=panel-settings]"));
           });
         }}>
         <Rosout />

--- a/packages/webviz-core/src/panels/Rosout/index.stories.js
+++ b/packages/webviz-core/src/panels/Rosout/index.stories.js
@@ -116,9 +116,9 @@ storiesOf("<RosoutPanel>", module)
           },
         }}
         onMount={(el) => {
-          TestUtils.Simulate.mouseEnter(document.querySelector("[data-test=panel-mouseenter-container]"));
+          TestUtils.Simulate.mouseEnter(document.querySelectorAll("[data-test=panel-mouseenter-container]")[0]);
           setTimeout(() => {
-            TestUtils.Simulate.click(document.querySelector("[data-test=topic-set]"));
+            TestUtils.Simulate.click(document.querySelectorAll("[data-test=topic-set]")[0]);
           });
         }}>
         <Rosout config={{ searchTerms: [], minLogLevel: 1, topicToRender: "/foo/rosout" }} />
@@ -130,9 +130,9 @@ storiesOf("<RosoutPanel>", module)
       <PanelSetup
         fixture={fixture}
         onMount={(el) => {
-          TestUtils.Simulate.mouseEnter(document.querySelector("[data-test=panel-mouseenter-container]"));
+          TestUtils.Simulate.mouseEnter(document.querySelectorAll("[data-test=panel-mouseenter-container]")[0]);
           setTimeout(() => {
-            TestUtils.Simulate.click(document.querySelector("[data-test=panel-settings]"));
+            TestUtils.Simulate.click(document.querySelectorAll("[data-test=panel-settings]")[0]);
           });
         }}>
         <Rosout />

--- a/packages/webviz-core/src/util/globalConstants.js
+++ b/packages/webviz-core/src/util/globalConstants.js
@@ -25,6 +25,7 @@ export const DEFAULT_WEBVIZ_NODE_PREFIX = "/webviz_node/";
 
 export const TRANSFORM_TOPIC = "/tf";
 export const DIAGNOSTIC_TOPIC = "/diagnostics";
+export const ROSOUT_TOPIC = "/rosout";
 export const SOCKET_KEY = "dataSource.websocket";
 export const SECOND_BAG_PREFIX = "/webviz_bag_2";
 


### PR DESCRIPTION
Adds `<TopicToRenderMenu>` to the RosOut panel. No version impact (backward compatible).

![image](https://user-images.githubusercontent.com/14237/72948141-24ea8180-3d39-11ea-868e-680673702127.png)
