### PR TITLE
Fix worker loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,6 +87,7 @@ module.exports = {
       },
       {
         test: /\.worker\.js$/,
+        exclude: /node_modules/,
         use: {
           loader: "worker-loader",
           options: { name: "[name].[ext]?[hash]" },


### PR DESCRIPTION
<!-- Thanks for contributing to Webviz! To help us understand and review your PR, please fill out the following sections: -->

## Summary

Revisiting this old issue that I couldn't figure out a few months ago. After loading up https://webviz.io/app/?demo, I saw this error:

<img width="1177" alt="Screen Shot 2020-02-10 at 11 12 43 AM" src="https://user-images.githubusercontent.com/18633748/74181537-619df000-4bf6-11ea-90da-cb23f73cedd4.png">

Turns out our worker-loader was scooping up `*.worker.js` files in node_modules, and was doing a double-require (hence the syntax error shown above).

Solution is to just exclude `node_modules` from the worker-loader. Pretty straightforward, and mimics our private webpack.config.js.

## Test plan

Tested with `npm run docs`, and should pass CI.

## Versioning impact

Only effects webviz-core -- no version bump needed.
