### PR TITLE
Mock all workers in jest

### DIFF
--- a/jest/jest.config.js
+++ b/jest/jest.config.js
@@ -25,10 +25,7 @@ module.exports = {
   ],
   setupTestFrameworkScriptFile: "<rootDir>/packages/webviz-core/src/test/setupTestFramework.js",
   moduleNameMapper: {
-    "worker-loader!./ChartJSWorker": "<rootDir>/webviz-core/src/test/MockWorker.js",
-    "worker-loader!./PngWorker.js": "<rootDir>/packages/webviz-core/src/test/MockWorker.js",
-    "worker-loader!.*/UserNodePlayer/.+Worker":
-      "<rootDir>/packages/webviz-core/src/players/UserNodePlayer/worker.mock.js",
+    "worker-loader!.*": "<rootDir>/packages/webviz-core/src/test/MockWorker.js",
     "\\.svg$": "<rootDir>/packages/webviz-core/src/test/MockSvg.js",
     "react-monaco-editor": "<rootDir>/packages/webviz-core/src/test/stubs/MonacoEditor.js",
     "\\.css$": "<rootDir>/jest/styleMock.js",


### PR DESCRIPTION
Just mock out every worker-loader call in Jest, because Jest
doesn't like worker calls.
