### PR TITLE
Add stories setup config flow for webviz-core

### DIFF
--- a/packages/webviz-core/src/stories/setup.js
+++ b/packages/webviz-core/src/stories/setup.js
@@ -1,0 +1,10 @@
+// @flow
+//
+//  Copyright (c) 2018-present, Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+// Run setup logic for webviz core before storybook is launched
+export default function storiesSetup() {}

--- a/stories/config.js
+++ b/stories/config.js
@@ -11,9 +11,11 @@ import { initScreenshot, setScreenshotOptions } from "storybook-chrome-screensho
 
 import "webviz-core/src/styles/global.scss";
 import prepareForScreenshots from "./prepareForScreenshots";
+import storiesSetup from "webviz-core/src/stories/setup";
 import waitForFonts from "webviz-core/src/styles/waitForFonts";
 import installChartjs from "webviz-core/src/util/installChartjs";
 
+storiesSetup();
 global.GIT_INFO = {};
 installChartjs();
 


### PR DESCRIPTION
## Summary

We'd like to be able to run custom setup code for storybook to support new features we're adding internally. For now it'll just be a no op.

## Test plan

Tested build and storybook locally, brought over internally repo and confirmed we can use this change to address our current issues.

## Versioning impact

No, only a test change.
