### PR TITLE
<GLText> improvements for text rendering

### DIFF
--- a/docs/src/4.15.GLText.mdx
+++ b/docs/src/4.15.GLText.mdx
@@ -7,3 +7,9 @@ import { GLText } from "./jsx/allLiveEditors";
 The prop types are identical to `<Text />`, except that additionally each Text object supports an optional `billboard?: boolean` property. If true (the default), text will always face the camera; if false, text may be rotated in 3D according to `pose.orientation`.
 
 <GLText />
+
+## Scale Invariance
+
+`<GLText />` also supports rendering text at a constant scale regardless of the zoom level by using the optional `scaleInvariantFontSize?: number` property. If set (default is `undefined`), the text will be rendered always at the same size, resembling the behavior of the `<Text />` command. 
+
+Please note that `scaleInvariantFontSize` only works if the `billboard` property is set to true.

--- a/docs/src/4.15.GLText.mdx
+++ b/docs/src/4.15.GLText.mdx
@@ -1,4 +1,4 @@
-import { GLText } from "./jsx/allLiveEditors";
+import { GLText, GLTextScaleInvariant } from "./jsx/allLiveEditors";
 
 # Text
 
@@ -13,3 +13,5 @@ The prop types are identical to `<Text />`, except that additionally each Text o
 `<GLText />` also supports rendering text at a constant scale regardless of the zoom level by using the optional `scaleInvariantFontSize?: number` property. If set (default is `undefined`), the text will be rendered always at the same size, resembling the behavior of the `<Text />` command. 
 
 Please note that `scaleInvariantFontSize` only works if the `billboard` property is set to true.
+
+<GLTextScaleInvariant />

--- a/docs/src/jsx/allLiveEditors.js
+++ b/docs/src/jsx/allLiveEditors.js
@@ -80,6 +80,12 @@ export const FilledPolygonsHitmap = makeCodeComponent(
 
 export const GLText = makeCodeComponent(require("!!raw-loader!./commands/GLText"), "GLText", { noInline: true });
 
+export const GLTextScaleInvariant = makeCodeComponent(
+  require("!!raw-loader!./commands/GLTextScaleInvariant"),
+  "GLTextScaleInvariant",
+  { noInline: true }
+);
+
 export const GLTFScene = makeCodeComponent(require("!!raw-loader!./commands/GLTFScene"), "GLTFScene");
 
 export const GLTFSceneHitmap = makeCodeComponent(require("!!raw-loader!./commands/GLTFSceneHitmap"), "GLTFSceneHitmap");

--- a/docs/src/jsx/commands/GLTextScaleInvariant.js
+++ b/docs/src/jsx/commands/GLTextScaleInvariant.js
@@ -1,0 +1,85 @@
+//  Copyright (c) 2018-present, GM Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+// #BEGIN EXAMPLE
+import { quat } from "gl-matrix";
+import React, { useState } from "react";
+import Worldview, { GLText, Grid, DEFAULT_CAMERA_STATE } from "regl-worldview";
+
+// #BEGIN EDITABLE
+const RADIUS = 20; // distance from the origin for placing columns
+const FONT_SIZE = 20; // font size for scale invariant property
+
+const vec4ToOrientation = ([x, y, z, w]) => ({ x, y, z, w });
+
+// Build a set of markers with different sizes and poses
+function textMarkers(text) {
+  const radius = 7;
+  const count = 5;
+  return new Array(count).fill().map((_, i) => {
+    const angle = (2 * Math.PI * i) / count;
+    const color = { r: (i + 1) / count, g: (i + 1) / count, b: 0, a: 1 };
+    return {
+      text,
+      pose: {
+        position: { x: radius * Math.cos(angle), y: radius * Math.sin(angle), z: 0 },
+        orientation: vec4ToOrientation(quat.rotateZ(quat.create(), quat.create(), Math.PI / 2 + angle)),
+      },
+      scale: { x: 1 + i / count, y: 1 + i / count, z: 1 + i / count },
+      color,
+      billboard: true,
+    };
+  });
+}
+
+// Build a marker at the center of the world
+// Since the billboard property is set to false, scale
+// invariance cannot be used for this marker.
+function nonBillboardTextMarkers(text) {
+  return [
+    {
+      text,
+      pose: {
+        position: { x: 0, y: 0, z: 0 },
+        orientation: { x: 0, y: 0, z: 0, w: 1 },
+      },
+      scale: { x: 1, y: 1, z: 1 },
+      color: { r: 1, g: 1, b: 1, a: 1 },
+      billboard: false,
+    },
+  ];
+}
+
+function Example() {
+  const markers = textMarkers("Scale\nInvariant");
+  const centerMarker = nonBillboardTextMarkers("This text is\nnot a Billboard");
+  const [cameraState, setCameraState] = useState({
+    ...DEFAULT_CAMERA_STATE,
+    distance: RADIUS * 2,
+  });
+  return (
+    <Worldview
+      cameraState={cameraState}
+      onCameraStateChange={(newState) =>
+        setCameraState((oldState) => ({
+          ...oldState,
+          ...newState,
+          targetOffset: oldState.targetOffset,
+          phi: oldState.phi,
+        }))
+      }>
+      <GLText scaleInvariantFontSize={FONT_SIZE}>{markers}</GLText>
+      <GLText>{centerMarker}</GLText>
+      <Grid count={10} />
+    </Worldview>
+  );
+}
+
+// #DOCS ONLY: render(<Example />);
+
+// #END EXAMPLE
+
+export default Example;

--- a/packages/regl-worldview/src/commands/GLText.js
+++ b/packages/regl-worldview/src/commands/GLText.js
@@ -49,15 +49,15 @@ type Props = {
 
 type FontAtlas = {|
   textureData: Uint8Array,
-  textureWidth: number,
-  textureHeight: number,
-  charInfo: {
-    [char: string]: {|
-      x: number,
+    textureWidth: number,
+      textureHeight: number,
+        charInfo: {
+  [char: string]: {|
+    x: number,
       y: number,
-      width: number,
+        width: number,
     |},
-  },
+},
 |};
 
 // Font size used in rendering the atlas. This is independent of the `scale` of the rendered text.
@@ -461,6 +461,12 @@ export default function GLText(props: Props) {
   const context = useContext(WorldviewReactContext);
   const { dimension } = context;
   const scaleInvariantFontSize = props.scaleInvariantFontSize || DEFAULT_SCALE_INVARIANT_SIZE;
+
+  // Compute the actual size for the text object in NDC coordinates (from -1 to 1)
+  // In order to make sure the text is always shown at the same size regardless of
+  // the canvas dimensions (as Text does), we need to scale it based on both the desired 
+  // font size and the current worldview resolution. Otherwise, the text will be 
+  // displayed at different sizes depending on the worlview canvas dimension.
   const scaleInvariantSize = scaleInvariantFontSize / dimension.height;
 
   const [command] = useState(() => makeTextCommand());

--- a/packages/regl-worldview/src/commands/GLText.js
+++ b/packages/regl-worldview/src/commands/GLText.js
@@ -47,15 +47,15 @@ type Props = {
 
 type FontAtlas = {|
   textureData: Uint8Array,
-    textureWidth: number,
-      textureHeight: number,
-        charInfo: {
-  [char: string]: {|
-    x: number,
+  textureWidth: number,
+  textureHeight: number,
+  charInfo: {
+    [char: string]: {|
+      x: number,
       y: number,
-        width: number,
+      width: number,
     |},
-},
+  },
 |};
 
 // Font size used in rendering the atlas. This is independent of the `scale` of the rendered text.
@@ -451,20 +451,19 @@ function makeTextCommand() {
 export default function GLText(props: Props) {
   const context = useContext(WorldviewReactContext);
   const { dimension } = context;
-  const scaleInvariantFontSize = props.scaleInvariantFontSize;
-
-  // Compute the actual size for the text object in NDC coordinates (from -1 to 1)
-  // In order to make sure the text is always shown at the same size regardless of
-  // the canvas dimensions (as Text does), we need to scale it based on both the desired
-  // font size and the current worldview resolution. Otherwise, the text will be
-  // displayed at different sizes depending on the worlview canvas dimension.
-  const scaleInvariantSize = scaleInvariantFontSize / dimension.height;
 
   const [command] = useState(() => makeTextCommand());
   // HACK: Worldview doesn't provide an easy way to pass a command-level prop into the regl commands,
   // so just attach it to the command object for now.
   command.autoBackgroundColor = props.autoBackgroundColor;
-  command.scaleInvariant = !!scaleInvariantSize;
-  command.scaleInvariantSize = scaleInvariantSize;
+
+  command.scaleInvariant = !!props.scaleInvariantFontSize;
+  // Compute the actual size for the text object in NDC coordinates (from -1 to 1)
+  // In order to make sure the text is always shown at the same size regardless of
+  // the canvas dimensions (as Text does), we need to scale it based on both the desired
+  // font size and the current worldview resolution. Otherwise, the text will be
+  // displayed at different sizes depending on the worlview canvas dimension.
+  command.scaleInvariantSize = (props.scaleInvariantFontSize ?? 0) / dimension.height;
+
   return <Command reglCommand={command} {...props} />;
 }

--- a/packages/regl-worldview/src/commands/GLText.js
+++ b/packages/regl-worldview/src/commands/GLText.js
@@ -457,7 +457,7 @@ export default function GLText(props: Props) {
   // so just attach it to the command object for now.
   command.autoBackgroundColor = props.autoBackgroundColor;
 
-  command.scaleInvariant = !!props.scaleInvariantFontSize;
+  command.scaleInvariant = props.scaleInvariantFontSize != null;
   // Compute the actual size for the text object in NDC coordinates (from -1 to 1)
   // In order to make sure the text is always shown at the same size regardless of
   // the canvas dimensions (as Text does), we need to scale it based on both the desired

--- a/packages/regl-worldview/src/commands/GLText.js
+++ b/packages/regl-worldview/src/commands/GLText.js
@@ -42,28 +42,28 @@ type Props = {
   ...CommonCommandProps,
   children: $ReadOnlyArray<TextMarkerProps>,
   autoBackgroundColor?: boolean,
-  hiresFont?: boolean,
+  highResolutionFont?: boolean,
   scaleInvariant?: boolean,
   scaleInvariantFontSize?: number,
 };
 
 type FontAtlas = {|
   textureData: Uint8Array,
-    textureWidth: number,
-      textureHeight: number,
-        charInfo: {
-  [char: string]: {|
-    x: number,
+  textureWidth: number,
+  textureHeight: number,
+  charInfo: {
+    [char: string]: {|
+      x: number,
       y: number,
-        width: number,
+      width: number,
     |},
-},
+  },
 |};
 
 // Font size used in rendering the atlas. This is independent of the `scale` of the rendered text.
 const DEFAULT_FONT_SIZE = 40;
 const DEFAULT_SCALE_INVARIANT_SIZE = 10;
-const HIRES_FONT_SIZE = 160;
+const HIGH_RESOLUTION_FONT_SIZE = 160;
 const MAX_ATLAS_WIDTH = 512;
 const SDF_RADIUS = 8;
 const CUTOFF = 0.25;
@@ -464,8 +464,8 @@ export default function GLText(props: Props) {
 
   // Compute the actual size for the text object in NDC coordinates (from -1 to 1)
   // In order to make sure the text is always shown at the same size regardless of
-  // the canvas dimensions (as Text does), we need to scale it based on both the desired 
-  // font size and the current worldview resolution. Otherwise, the text will be 
+  // the canvas dimensions (as Text does), we need to scale it based on both the desired
+  // font size and the current worldview resolution. Otherwise, the text will be
   // displayed at different sizes depending on the worlview canvas dimension.
   const scaleInvariantSize = scaleInvariantFontSize / dimension.height;
 
@@ -473,7 +473,7 @@ export default function GLText(props: Props) {
   // HACK: Worldview doesn't provide an easy way to pass a command-level prop into the regl commands,
   // so just attach it to the command object for now.
   command.autoBackgroundColor = props.autoBackgroundColor;
-  command.fontSize = props.hiresFont ?? props.scaleInvariant ? HIRES_FONT_SIZE : DEFAULT_FONT_SIZE;
+  command.fontSize = props.highResolutionFont ?? props.scaleInvariant ? HIGH_RESOLUTION_FONT_SIZE : DEFAULT_FONT_SIZE;
   command.scaleInvariant = props.scaleInvariant === true;
   command.scaleInvariantSize = scaleInvariantSize;
   return <Command reglCommand={command} {...props} />;

--- a/packages/regl-worldview/src/commands/GLText.js
+++ b/packages/regl-worldview/src/commands/GLText.js
@@ -27,7 +27,6 @@ import WorldviewReactContext from "../WorldviewReactContext";
 // ============================
 // - Add hitmap support.
 // - Allow customization of font style, maybe highlight ranges.
-// - Add a scaleInvariant option.
 // - Consider a solid rectangular background instead of an outline. This is challenging because the
 //   instances currently overlap, so there will be z-fighting, but might be possible using the stencil buffer and multiple draw calls.
 // - Somehow support kerning and more advanced font metrics. However, the web font APIs may not
@@ -366,6 +365,12 @@ function makeTextCommand() {
           marker.colors?.[1] || (command.autoBackgroundColor && isColorDark(fgColor) ? BG_COLOR_LIGHT : BG_COLOR_DARK);
         const hlColor = marker?.highlightColor || { r: 1, b: 0, g: 1, a: 1 };
 
+        if (!marker.billboard && command.scaleInvariant) {
+          console.warn(
+            "Scale invariant option is only supported for billboard markers"
+          );
+        }
+
         for (let i = 0; i < marker.text.length; i++) {
           const char = marker.text[i];
           if (char === "\n") {
@@ -473,7 +478,7 @@ export default function GLText(props: Props) {
   // HACK: Worldview doesn't provide an easy way to pass a command-level prop into the regl commands,
   // so just attach it to the command object for now.
   command.autoBackgroundColor = props.autoBackgroundColor;
-  command.fontSize = props.hiresFont ? HIRES_FONT_SIZE : DEFAULT_FONT_SIZE;
+  command.fontSize = (props.hiresFont ?? props.scaleInvariant) ? HIRES_FONT_SIZE : DEFAULT_FONT_SIZE;
   command.debugSDF = props.debugSDF === true;
   command.scaleInvariant = props.scaleInvariant === true;
   command.scaleInvariantSize = scaleInvariantSize;

--- a/packages/regl-worldview/src/commands/GLText.js
+++ b/packages/regl-worldview/src/commands/GLText.js
@@ -358,10 +358,6 @@ function makeTextCommand() {
           marker.colors?.[1] || (command.autoBackgroundColor && isColorDark(fgColor) ? BG_COLOR_LIGHT : BG_COLOR_DARK);
         const hlColor = marker?.highlightColor || { r: 1, b: 0, g: 1, a: 1 };
 
-        if (!marker.billboard && command.scaleInvariant) {
-          console.warn("Scale invariant option is only supported for billboard markers");
-        }
-
         for (let i = 0; i < marker.text.length; i++) {
           const char = marker.text[i];
           if (char === "\n") {

--- a/packages/regl-worldview/src/commands/GLText.js
+++ b/packages/regl-worldview/src/commands/GLText.js
@@ -43,7 +43,6 @@ type Props = {
   children: $ReadOnlyArray<TextMarkerProps>,
   autoBackgroundColor?: boolean,
   hiresFont?: boolean,
-  debugSDF?: boolean,
   scaleInvariant?: boolean,
   scaleInvariantFontSize?: number,
 };
@@ -211,7 +210,6 @@ const frag = `
   uniform mat4 projection;
   uniform sampler2D atlas;
   uniform float cutoff;
-  uniform bool debugSDF;
   uniform bool scaleInvariant;
   uniform float scaleInvariantSize;
 
@@ -249,10 +247,6 @@ const frag = `
       gl_FragColor.a *= edgeStep;
     }
 
-    if (debugSDF) {
-      gl_FragColor = vec4( dist, dist, dist, 1.0 );
-    }
-
     if (gl_FragColor.a == 0.) {
       discard;
     }
@@ -277,7 +271,6 @@ function makeTextCommand() {
         atlasSize: () => [atlasTexture.width, atlasTexture.height],
         fontSize: command.fontSize,
         cutoff: CUTOFF,
-        debugSDF: command.debugSDF,
         scaleInvariant: command.scaleInvariant,
         scaleInvariantSize: command.scaleInvariantSize,
       },
@@ -479,7 +472,6 @@ export default function GLText(props: Props) {
   // so just attach it to the command object for now.
   command.autoBackgroundColor = props.autoBackgroundColor;
   command.fontSize = (props.hiresFont ?? props.scaleInvariant) ? HIRES_FONT_SIZE : DEFAULT_FONT_SIZE;
-  command.debugSDF = props.debugSDF === true;
   command.scaleInvariant = props.scaleInvariant === true;
   command.scaleInvariantSize = scaleInvariantSize;
   return <Command reglCommand={command} {...props} />;

--- a/packages/regl-worldview/src/commands/GLText.js
+++ b/packages/regl-worldview/src/commands/GLText.js
@@ -6,9 +6,9 @@ import React, { useState, useContext } from "react";
 
 import type { Color } from "../types";
 import { defaultBlend, defaultDepth } from "../utils/commandUtils";
+import WorldviewReactContext from "../WorldviewReactContext";
 import Command, { type CommonCommandProps } from "./Command";
 import { isColorDark, type TextMarker } from "./Text";
-import WorldviewReactContext from "../WorldviewReactContext";
 
 // The GLText command renders text from a Signed Distance Field texture.
 // There are many external resources about SDFs and text rendering in WebGL, including:
@@ -49,15 +49,15 @@ type Props = {
 
 type FontAtlas = {|
   textureData: Uint8Array,
-    textureWidth: number,
-      textureHeight: number,
-        charInfo: {
-  [char: string]: {|
-    x: number,
+  textureWidth: number,
+  textureHeight: number,
+  charInfo: {
+    [char: string]: {|
+      x: number,
       y: number,
-        width: number,
+      width: number,
     |},
-},
+  },
 |};
 
 // Font size used in rendering the atlas. This is independent of the `scale` of the rendered text.
@@ -359,9 +359,7 @@ function makeTextCommand() {
         const hlColor = marker?.highlightColor || { r: 1, b: 0, g: 1, a: 1 };
 
         if (!marker.billboard && command.scaleInvariant) {
-          console.warn(
-            "Scale invariant option is only supported for billboard markers"
-          );
+          console.warn("Scale invariant option is only supported for billboard markers");
         }
 
         for (let i = 0; i < marker.text.length; i++) {
@@ -461,9 +459,7 @@ function makeTextCommand() {
 
 export default function GLText(props: Props) {
   const context = useContext(WorldviewReactContext);
-  const {
-    dimension
-  } = context;
+  const { dimension } = context;
   const scaleInvariantFontSize = props.scaleInvariantFontSize || DEFAULT_SCALE_INVARIANT_SIZE;
   const scaleInvariantSize = scaleInvariantFontSize / dimension.height;
 
@@ -471,7 +467,7 @@ export default function GLText(props: Props) {
   // HACK: Worldview doesn't provide an easy way to pass a command-level prop into the regl commands,
   // so just attach it to the command object for now.
   command.autoBackgroundColor = props.autoBackgroundColor;
-  command.fontSize = (props.hiresFont ?? props.scaleInvariant) ? HIRES_FONT_SIZE : DEFAULT_FONT_SIZE;
+  command.fontSize = props.hiresFont ?? props.scaleInvariant ? HIRES_FONT_SIZE : DEFAULT_FONT_SIZE;
   command.scaleInvariant = props.scaleInvariant === true;
   command.scaleInvariantSize = scaleInvariantSize;
   return <Command reglCommand={command} {...props} />;

--- a/packages/regl-worldview/src/commands/GLText.js
+++ b/packages/regl-worldview/src/commands/GLText.js
@@ -42,7 +42,6 @@ type Props = {
   ...CommonCommandProps,
   children: $ReadOnlyArray<TextMarkerProps>,
   autoBackgroundColor?: boolean,
-  scaleInvariant?: boolean,
   scaleInvariantFontSize?: number,
 };
 
@@ -465,7 +464,7 @@ export default function GLText(props: Props) {
   // HACK: Worldview doesn't provide an easy way to pass a command-level prop into the regl commands,
   // so just attach it to the command object for now.
   command.autoBackgroundColor = props.autoBackgroundColor;
-  command.scaleInvariant = props.scaleInvariant === true;
+  command.scaleInvariant = !!scaleInvariantSize;
   command.scaleInvariantSize = scaleInvariantSize;
   return <Command reglCommand={command} {...props} />;
 }

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -103,7 +103,6 @@ storiesOf("Worldview/GLText", module)
   })
   .add("scaleInvariant", () => {
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
-    const target = markers[9].pose.position;
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
         <GLText hiresFont scaleInvariant>{markers}</GLText>
@@ -113,7 +112,6 @@ storiesOf("Worldview/GLText", module)
   })
   .add("scaleInvariant-20", () => {
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
-    const target = markers[9].pose.position;
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
         <GLText hiresFont scaleInvariant scaleInvariantFontSize="20">{markers}</GLText>
@@ -123,7 +121,6 @@ storiesOf("Worldview/GLText", module)
   })
   .add("scaleInvariant-40", () => {
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
-    const target = markers[9].pose.position;
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
         <GLText hiresFont scaleInvariant scaleInvariantFontSize="40">{markers}</GLText>
@@ -133,7 +130,6 @@ storiesOf("Worldview/GLText", module)
   })
   .add("scaleInvariant-html", () => {
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
-    const target = markers[9].pose.position;
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
         <Text>{markers}</Text>

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -133,12 +133,6 @@ storiesOf("Worldview/GLText", module)
       <Axes />
     </Container>
   ))
-  .add("non-billboard scaleInvariant", () => (
-    <Container cameraState={{ perspective: true, distance: 40 }}>
-      <GLText scaleInvariant>{textMarkers({ text: "Hello\nWorldview", billboard: false })}</GLText>
-      <Axes />
-    </Container>
-  ))
   .add("no background", () => (
     <Container cameraState={{ perspective: true, distance: 40 }}>
       <GLText>{textMarkers({ text: "Hello\nWorldview", billboard: false, background: false })}</GLText>

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -13,7 +13,7 @@ import { vec4ToOrientation } from "../utils/commandUtils";
 import Container from "./Container";
 import inScreenshotTests from "stories/inScreenshotTests";
 
-import { GLText } from "..";
+import { GLText, Text } from "..";
 
 function textMarkers({
   text,
@@ -59,6 +59,20 @@ storiesOf("Worldview/GLText", module)
       </Container>
     );
   })
+  .add("no-smoothing-sdf", () => {
+    const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
+    const target = markers[9].pose.position;
+    return (
+      <Container cameraState={{
+        target: [target.x, target.y, target.z],
+        perspective: true,
+        distance: 3,
+      }}>
+        <GLText debugSDF>{markers}</GLText>
+        <Axes />
+      </Container>
+    );
+  })
   .add("hires-smoothing", () => {
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     const target = markers[9].pose.position;
@@ -73,6 +87,40 @@ storiesOf("Worldview/GLText", module)
       </Container>
     );
   })
+  .add("hires-smoothing-sdf", () => {
+    const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
+    const target = markers[9].pose.position;
+    return (
+      <Container cameraState={{
+        target: [target.x, target.y, target.z],
+        perspective: true,
+        distance: 3,
+      }}>
+        <GLText hiresFont debugSDF>{markers}</GLText>
+        <Axes />
+      </Container>
+    );
+  })
+  .add("scaleInvariant", () => {
+    const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
+    const target = markers[9].pose.position;
+    return (
+      <Container cameraState={{ perspective: true, distance: 25 }}>
+        <GLText hiresFont scaleInvariant>{markers}</GLText>
+        <Axes />
+      </Container>
+    );
+  })
+  .add("scaleInvariant-gt", () => {
+    const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
+    const target = markers[9].pose.position;
+    return (
+      <Container cameraState={{ perspective: true, distance: 25 }}>
+        <Text>{markers}</Text>
+        <Axes />
+      </Container>
+    );
+  })
   .add("billboard", () => (
     <Container cameraState={{ perspective: true, distance: 40 }}>
       <GLText>{textMarkers({ text: "Hello\nWorldview", billboard: true })}</GLText>
@@ -82,6 +130,12 @@ storiesOf("Worldview/GLText", module)
   .add("non-billboard", () => (
     <Container cameraState={{ perspective: true, distance: 40 }}>
       <GLText>{textMarkers({ text: "Hello\nWorldview", billboard: false })}</GLText>
+      <Axes />
+    </Container>
+  ))
+  .add("non-billboard scaleInvariant", () => (
+    <Container cameraState={{ perspective: true, distance: 40 }}>
+      <GLText scaleInvariant>{textMarkers({ text: "Hello\nWorldview", billboard: false })}</GLText>
       <Axes />
     </Container>
   ))

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -129,17 +129,13 @@ storiesOf("Worldview/GLText", module)
     function Example() {
       const [text, setText] = useState("Hello\nWorldview");
       useLayoutEffect(() => {
-        let i = 0;
-        const id = setInterval(() => {
-          setText(`New text! ${++i}`);
-          if (inScreenshotTests()) {
-            clearInterval(id);
-          }
-        }, 100);
-        return () => clearInterval(id);
+        setText(`New text!`);
       }, []);
       return (
         <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
+          <div style={{ position: "absolute", top: 30, left: 30 }}>
+            <button onClick={() => setText(`Value: ${Math.floor(100 * Math.random())}`)}>Change Text</button>
+          </div>
           <GLText autoBackgroundColor>{textMarkers({ text })}</GLText>
           <Axes />
         </Container>

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -64,7 +64,7 @@ storiesOf("Worldview/GLText", module)
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
-        <GLText scaleInvariant>
+        <GLText scaleInvariantFontSize={10}>
           {markers}
         </GLText>
         <Axes />
@@ -75,7 +75,7 @@ storiesOf("Worldview/GLText", module)
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
-        <GLText scaleInvariant scaleInvariantFontSize={20}>
+        <GLText scaleInvariantFontSize={20}>
           {markers}
         </GLText>
         <Axes />
@@ -86,7 +86,7 @@ storiesOf("Worldview/GLText", module)
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
-        <GLText scaleInvariant scaleInvariantFontSize={40}>
+        <GLText scaleInvariantFontSize={40}>
           {markers}
         </GLText>
         <Axes />
@@ -119,7 +119,7 @@ storiesOf("Worldview/GLText", module)
   ))
   .add("autoBackgroundColor scaleInvariant", () => (
     <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
-      <GLText autoBackgroundColor scaleInvariant>
+      <GLText autoBackgroundColor scaleInvariantFontSize={10}>
         {textMarkers({ text: "Hello\nWorldview", billboard: true })}
       </GLText>
       <Axes />

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -161,6 +161,18 @@ storiesOf("Worldview/GLText", module)
       <Axes />
     </Container>
   ))
+  .add("autoBackgroundColor hires", () => (
+    <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
+      <GLText autoBackgroundColor hiresFont>{textMarkers({ text: "Hello\nWorldview" })}</GLText>
+      <Axes />
+    </Container>
+  ))
+  .add("autoBackgroundColor scaleInvariant", () => (
+    <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
+      <GLText autoBackgroundColor scaleInvariant>{textMarkers({ text: "Hello\nWorldview" })}</GLText>
+      <Axes />
+    </Container>
+  ))
   .add("changing text", () => {
     function Example() {
       const [text, setText] = useState("Hello\nWorldview");
@@ -177,6 +189,28 @@ storiesOf("Worldview/GLText", module)
       return (
         <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
           <GLText autoBackgroundColor>{textMarkers({ text })}</GLText>
+          <Axes />
+        </Container>
+      );
+    }
+    return <Example />;
+  })
+  .add("changing text hires", () => {
+    function Example() {
+      const [text, setText] = useState("Hello\nWorldview");
+      useLayoutEffect(() => {
+        let i = 0;
+        const id = setInterval(() => {
+          setText(`New text! ${++i}`);
+          if (inScreenshotTests()) {
+            clearInterval(id);
+          }
+        }, 100);
+        return () => clearInterval(id);
+      }, []);
+      return (
+        <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
+          <GLText autoBackgroundColor hiresFont>{textMarkers({ text })}</GLText>
           <Axes />
         </Container>
       );
@@ -213,6 +247,55 @@ storiesOf("Worldview/GLText", module)
           <div style={{ width: "100%", height: "100%" }}>
             <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
               <GLText autoBackgroundColor>{markers}</GLText>
+              <Axes />
+            </Container>
+          </div>
+          <div style={{ position: "absolute", top: "10px", right: "10px" }}>
+            <label htmlFor="search">Search: </label>
+            <input
+              type="text"
+              name="search"
+              placeholder="search text"
+              value={searchText}
+              onChange={(e) => setSearchText(e.target.value)}
+            />
+          </div>
+        </div>
+      );
+    };
+
+    return <Example />;
+  })
+  .add("highlighted text hires", () => {
+    const Example = () => {
+      const [searchText, setSearchText] = useState("ello\nW");
+      const markers = textMarkers({ text: "Hello\nWorldview" }).map((marker) => {
+        if (!searchText) {
+          return marker;
+        }
+        const highlightedIndices = new Set();
+        let match;
+        let regex;
+        try {
+          regex = new RegExp(searchText, "ig");
+        } catch (e) {
+          return marker;
+        }
+        while ((match = regex.exec(marker.text)) !== null) {
+          // $FlowFixMe - Flow doesn't understand the while loop terminating condition.
+          range(0, match[0].length).forEach((i) => {
+            // $FlowFixMe - Flow doesn't understand the while loop terminating condition.
+            highlightedIndices.add(match.index + i);
+          });
+        }
+        return { ...marker, highlightedIndices: Array.from(highlightedIndices) };
+      });
+
+      return (
+        <div style={{ width: "100%", height: "100%" }}>
+          <div style={{ width: "100%", height: "100%" }}>
+            <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
+              <GLText autoBackgroundColor hiresFont>{markers}</GLText>
               <Axes />
             </Container>
           </div>

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -45,6 +45,34 @@ function textMarkers({
 
 storiesOf("Worldview/GLText", module)
   .addDecorator(withScreenshot({ delay: 200 }))
+  .add("no-smoothing", () => {
+    const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
+    const target = markers[9].pose.position;
+    return (
+      <Container cameraState={{
+        target: [target.x, target.y, target.z],
+        perspective: true,
+        distance: 3,
+      }}>
+        <GLText>{markers}</GLText>
+        <Axes />
+      </Container>
+    );
+  })
+  .add("hires-smoothing", () => {
+    const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
+    const target = markers[9].pose.position;
+    return (
+      <Container cameraState={{
+        target: [target.x, target.y, target.z],
+        perspective: true,
+        distance: 3,
+      }}>
+        <GLText hiresFont>{markers}</GLText>
+        <Axes />
+      </Container>
+    );
+  })
   .add("billboard", () => (
     <Container cameraState={{ perspective: true, distance: 40 }}>
       <GLText>{textMarkers({ text: "Hello\nWorldview", billboard: true })}</GLText>

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -11,7 +11,6 @@ import { Axes } from "../commands";
 import type { Color } from "../types";
 import { vec4ToOrientation } from "../utils/commandUtils";
 import Container from "./Container";
-import inScreenshotTests from "stories/inScreenshotTests";
 
 import { GLText } from "..";
 
@@ -64,9 +63,7 @@ storiesOf("Worldview/GLText", module)
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
-        <GLText scaleInvariantFontSize={10}>
-          {markers}
-        </GLText>
+        <GLText scaleInvariantFontSize={10}>{markers}</GLText>
         <Axes />
       </Container>
     );
@@ -75,9 +72,7 @@ storiesOf("Worldview/GLText", module)
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
-        <GLText scaleInvariantFontSize={20}>
-          {markers}
-        </GLText>
+        <GLText scaleInvariantFontSize={20}>{markers}</GLText>
         <Axes />
       </Container>
     );
@@ -86,9 +81,7 @@ storiesOf("Worldview/GLText", module)
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
-        <GLText scaleInvariantFontSize={40}>
-          {markers}
-        </GLText>
+        <GLText scaleInvariantFontSize={40}>{markers}</GLText>
         <Axes />
       </Container>
     );
@@ -133,7 +126,7 @@ storiesOf("Worldview/GLText", module)
       }, []);
       return (
         <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
-          <div style={{ position: "absolute", top: 30, left: 30 }}>
+          <div style={{ position: "absolute", top: 30, right: 30 }}>
             <button onClick={() => setText(`Value: ${Math.floor(100 * Math.random())}`)}>Change Text</button>
           </div>
           <GLText autoBackgroundColor>{textMarkers({ text })}</GLText>

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -3,7 +3,7 @@
 import { storiesOf } from "@storybook/react";
 import { quat } from "gl-matrix";
 import { range } from "lodash";
-import React, { useState, useLayoutEffect } from "react";
+import React, { useState, useLayoutEffect, useCallback } from "react";
 import { withScreenshot } from "storybook-chrome-screenshot";
 import tinyColor from "tinycolor2";
 
@@ -85,6 +85,28 @@ storiesOf("Worldview/GLText", module)
         <Axes />
       </Container>
     );
+  })
+  .add("scaleInvariant resize", () => {
+    function Example() {
+      const [hasRenderedOnce, setHasRenderedOnce] = useState<boolean>(false);
+      const refFn = useCallback(() => {
+        setTimeout(() => {
+          setHasRenderedOnce(true);
+        }, 100);
+      }, []);
+      const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
+      return (
+        <div
+          style={{ width: hasRenderedOnce ? 500 : 250, height: hasRenderedOnce ? 500 : 250, background: "black" }}
+          ref={refFn}>
+          <Container cameraState={{ perspective: true, distance: 40 }}>
+            <GLText scaleInvariantFontSize={20}>{markers}</GLText>
+            <Axes />
+          </Container>
+        </div>
+      );
+    }
+    return <Example />;
   })
   .add("billboard", () => (
     <Container cameraState={{ perspective: true, distance: 40 }}>

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -59,20 +59,6 @@ storiesOf("Worldview/GLText", module)
       </Container>
     );
   })
-  .add("no-smoothing-sdf", () => {
-    const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
-    const target = markers[9].pose.position;
-    return (
-      <Container cameraState={{
-        target: [target.x, target.y, target.z],
-        perspective: true,
-        distance: 3,
-      }}>
-        <GLText debugSDF>{markers}</GLText>
-        <Axes />
-      </Container>
-    );
-  })
   .add("hires-smoothing", () => {
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     const target = markers[9].pose.position;
@@ -83,20 +69,6 @@ storiesOf("Worldview/GLText", module)
         distance: 3,
       }}>
         <GLText hiresFont>{markers}</GLText>
-        <Axes />
-      </Container>
-    );
-  })
-  .add("hires-smoothing-sdf", () => {
-    const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
-    const target = markers[9].pose.position;
-    return (
-      <Container cameraState={{
-        target: [target.x, target.y, target.z],
-        perspective: true,
-        distance: 3,
-      }}>
-        <GLText hiresFont debugSDF>{markers}</GLText>
         <Axes />
       </Container>
     );

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -49,11 +49,12 @@ storiesOf("Worldview/GLText", module)
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     const target = markers[9].pose.position;
     return (
-      <Container cameraState={{
-        target: [target.x, target.y, target.z],
-        perspective: true,
-        distance: 3,
-      }}>
+      <Container
+        cameraState={{
+          target: [target.x, target.y, target.z],
+          perspective: true,
+          distance: 3,
+        }}>
         <GLText>{markers}</GLText>
         <Axes />
       </Container>
@@ -63,11 +64,12 @@ storiesOf("Worldview/GLText", module)
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     const target = markers[9].pose.position;
     return (
-      <Container cameraState={{
-        target: [target.x, target.y, target.z],
-        perspective: true,
-        distance: 3,
-      }}>
+      <Container
+        cameraState={{
+          target: [target.x, target.y, target.z],
+          perspective: true,
+          distance: 3,
+        }}>
         <GLText hiresFont>{markers}</GLText>
         <Axes />
       </Container>
@@ -77,7 +79,9 @@ storiesOf("Worldview/GLText", module)
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
-        <GLText hiresFont scaleInvariant>{markers}</GLText>
+        <GLText hiresFont scaleInvariant>
+          {markers}
+        </GLText>
         <Axes />
       </Container>
     );
@@ -86,7 +90,9 @@ storiesOf("Worldview/GLText", module)
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
-        <GLText hiresFont scaleInvariant scaleInvariantFontSize="20">{markers}</GLText>
+        <GLText hiresFont scaleInvariant scaleInvariantFontSize="20">
+          {markers}
+        </GLText>
         <Axes />
       </Container>
     );
@@ -95,7 +101,9 @@ storiesOf("Worldview/GLText", module)
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
-        <GLText hiresFont scaleInvariant scaleInvariantFontSize="40">{markers}</GLText>
+        <GLText hiresFont scaleInvariant scaleInvariantFontSize="40">
+          {markers}
+        </GLText>
         <Axes />
       </Container>
     );
@@ -126,13 +134,17 @@ storiesOf("Worldview/GLText", module)
   ))
   .add("autoBackgroundColor hires", () => (
     <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
-      <GLText autoBackgroundColor hiresFont>{textMarkers({ text: "Hello\nWorldview" })}</GLText>
+      <GLText autoBackgroundColor hiresFont>
+        {textMarkers({ text: "Hello\nWorldview" })}
+      </GLText>
       <Axes />
     </Container>
   ))
   .add("autoBackgroundColor scaleInvariant", () => (
     <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
-      <GLText autoBackgroundColor scaleInvariant>{textMarkers({ text: "Hello\nWorldview" })}</GLText>
+      <GLText autoBackgroundColor scaleInvariant>
+        {textMarkers({ text: "Hello\nWorldview" })}
+      </GLText>
       <Axes />
     </Container>
   ))
@@ -173,7 +185,9 @@ storiesOf("Worldview/GLText", module)
       }, []);
       return (
         <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
-          <GLText autoBackgroundColor hiresFont>{textMarkers({ text })}</GLText>
+          <GLText autoBackgroundColor hiresFont>
+            {textMarkers({ text })}
+          </GLText>
           <Axes />
         </Container>
       );
@@ -258,7 +272,9 @@ storiesOf("Worldview/GLText", module)
         <div style={{ width: "100%", height: "100%" }}>
           <div style={{ width: "100%", height: "100%" }}>
             <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
-              <GLText autoBackgroundColor hiresFont>{markers}</GLText>
+              <GLText autoBackgroundColor hiresFont>
+                {markers}
+              </GLText>
               <Axes />
             </Container>
           </div>

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -90,7 +90,7 @@ storiesOf("Worldview/GLText", module)
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
-        <GLText hiresFont scaleInvariant scaleInvariantFontSize="20">
+        <GLText hiresFont scaleInvariant scaleInvariantFontSize={20}>
           {markers}
         </GLText>
         <Axes />
@@ -101,7 +101,7 @@ storiesOf("Worldview/GLText", module)
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
-        <GLText hiresFont scaleInvariant scaleInvariantFontSize="40">
+        <GLText hiresFont scaleInvariant scaleInvariantFontSize={40}>
           {markers}
         </GLText>
         <Axes />

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -13,7 +13,7 @@ import { vec4ToOrientation } from "../utils/commandUtils";
 import Container from "./Container";
 import inScreenshotTests from "stories/inScreenshotTests";
 
-import { GLText, Text } from "..";
+import { GLText } from "..";
 
 function textMarkers({
   text,
@@ -124,15 +124,6 @@ storiesOf("Worldview/GLText", module)
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
         <GLText hiresFont scaleInvariant scaleInvariantFontSize="40">{markers}</GLText>
-        <Axes />
-      </Container>
-    );
-  })
-  .add("scaleInvariant-html", () => {
-    const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
-    return (
-      <Container cameraState={{ perspective: true, distance: 25 }}>
-        <Text>{markers}</Text>
         <Axes />
       </Container>
     );

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -45,7 +45,7 @@ function textMarkers({
 
 storiesOf("Worldview/GLText", module)
   .addDecorator(withScreenshot({ delay: 200 }))
-  .add("no-smoothing", () => {
+  .add("high resolution text", () => {
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     const target = markers[9].pose.position;
     return (
@@ -60,26 +60,11 @@ storiesOf("Worldview/GLText", module)
       </Container>
     );
   })
-  .add("high-resolution-smoothing", () => {
-    const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
-    const target = markers[9].pose.position;
-    return (
-      <Container
-        cameraState={{
-          target: [target.x, target.y, target.z],
-          perspective: true,
-          distance: 3,
-        }}>
-        <GLText highResolutionFont>{markers}</GLText>
-        <Axes />
-      </Container>
-    );
-  })
   .add("scaleInvariant", () => {
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
-        <GLText highResolutionFont scaleInvariant>
+        <GLText scaleInvariant>
           {markers}
         </GLText>
         <Axes />
@@ -90,7 +75,7 @@ storiesOf("Worldview/GLText", module)
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
-        <GLText highResolutionFont scaleInvariant scaleInvariantFontSize={20}>
+        <GLText scaleInvariant scaleInvariantFontSize={20}>
           {markers}
         </GLText>
         <Axes />
@@ -101,7 +86,7 @@ storiesOf("Worldview/GLText", module)
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
-        <GLText highResolutionFont scaleInvariant scaleInvariantFontSize={40}>
+        <GLText scaleInvariant scaleInvariantFontSize={40}>
           {markers}
         </GLText>
         <Axes />
@@ -132,14 +117,6 @@ storiesOf("Worldview/GLText", module)
       <Axes />
     </Container>
   ))
-  .add("autoBackgroundColor highResolutionFont", () => (
-    <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
-      <GLText autoBackgroundColor highResolutionFont>
-        {textMarkers({ text: "Hello\nWorldview" })}
-      </GLText>
-      <Axes />
-    </Container>
-  ))
   .add("autoBackgroundColor scaleInvariant", () => (
     <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
       <GLText autoBackgroundColor scaleInvariant>
@@ -164,30 +141,6 @@ storiesOf("Worldview/GLText", module)
       return (
         <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
           <GLText autoBackgroundColor>{textMarkers({ text })}</GLText>
-          <Axes />
-        </Container>
-      );
-    }
-    return <Example />;
-  })
-  .add("changing text highResolutionFont", () => {
-    function Example() {
-      const [text, setText] = useState("Hello\nWorldview");
-      useLayoutEffect(() => {
-        let i = 0;
-        const id = setInterval(() => {
-          setText(`New text! ${++i}`);
-          if (inScreenshotTests()) {
-            clearInterval(id);
-          }
-        }, 100);
-        return () => clearInterval(id);
-      }, []);
-      return (
-        <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
-          <GLText autoBackgroundColor highResolutionFont>
-            {textMarkers({ text })}
-          </GLText>
           <Axes />
         </Container>
       );
@@ -224,57 +177,6 @@ storiesOf("Worldview/GLText", module)
           <div style={{ width: "100%", height: "100%" }}>
             <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
               <GLText autoBackgroundColor>{markers}</GLText>
-              <Axes />
-            </Container>
-          </div>
-          <div style={{ position: "absolute", top: "10px", right: "10px" }}>
-            <label htmlFor="search">Search: </label>
-            <input
-              type="text"
-              name="search"
-              placeholder="search text"
-              value={searchText}
-              onChange={(e) => setSearchText(e.target.value)}
-            />
-          </div>
-        </div>
-      );
-    };
-
-    return <Example />;
-  })
-  .add("highlighted text highResolutionFont", () => {
-    const Example = () => {
-      const [searchText, setSearchText] = useState("ello\nW");
-      const markers = textMarkers({ text: "Hello\nWorldview" }).map((marker) => {
-        if (!searchText) {
-          return marker;
-        }
-        const highlightedIndices = new Set();
-        let match;
-        let regex;
-        try {
-          regex = new RegExp(searchText, "ig");
-        } catch (e) {
-          return marker;
-        }
-        while ((match = regex.exec(marker.text)) !== null) {
-          // $FlowFixMe - Flow doesn't understand the while loop terminating condition.
-          range(0, match[0].length).forEach((i) => {
-            // $FlowFixMe - Flow doesn't understand the while loop terminating condition.
-            highlightedIndices.add(match.index + i);
-          });
-        }
-        return { ...marker, highlightedIndices: Array.from(highlightedIndices) };
-      });
-
-      return (
-        <div style={{ width: "100%", height: "100%" }}>
-          <div style={{ width: "100%", height: "100%" }}>
-            <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
-              <GLText autoBackgroundColor highResolutionFont>
-                {markers}
-              </GLText>
               <Axes />
             </Container>
           </div>

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -111,7 +111,7 @@ storiesOf("Worldview/GLText", module)
       </Container>
     );
   })
-  .add("scaleInvariant-gt", () => {
+  .add("scaleInvariant-html", () => {
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     const target = markers[9].pose.position;
     return (

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -111,6 +111,26 @@ storiesOf("Worldview/GLText", module)
       </Container>
     );
   })
+  .add("scaleInvariant-20", () => {
+    const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
+    const target = markers[9].pose.position;
+    return (
+      <Container cameraState={{ perspective: true, distance: 25 }}>
+        <GLText hiresFont scaleInvariant scaleInvariantFontSize="20">{markers}</GLText>
+        <Axes />
+      </Container>
+    );
+  })
+  .add("scaleInvariant-40", () => {
+    const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
+    const target = markers[9].pose.position;
+    return (
+      <Container cameraState={{ perspective: true, distance: 25 }}>
+        <GLText hiresFont scaleInvariant scaleInvariantFontSize="40">{markers}</GLText>
+        <Axes />
+      </Container>
+    );
+  })
   .add("scaleInvariant-html", () => {
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     const target = markers[9].pose.position;

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -60,7 +60,7 @@ storiesOf("Worldview/GLText", module)
       </Container>
     );
   })
-  .add("hires-smoothing", () => {
+  .add("high-resolution-smoothing", () => {
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     const target = markers[9].pose.position;
     return (
@@ -70,7 +70,7 @@ storiesOf("Worldview/GLText", module)
           perspective: true,
           distance: 3,
         }}>
-        <GLText hiresFont>{markers}</GLText>
+        <GLText highResolutionFont>{markers}</GLText>
         <Axes />
       </Container>
     );
@@ -79,7 +79,7 @@ storiesOf("Worldview/GLText", module)
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
-        <GLText hiresFont scaleInvariant>
+        <GLText highResolutionFont scaleInvariant>
           {markers}
         </GLText>
         <Axes />
@@ -90,7 +90,7 @@ storiesOf("Worldview/GLText", module)
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
-        <GLText hiresFont scaleInvariant scaleInvariantFontSize={20}>
+        <GLText highResolutionFont scaleInvariant scaleInvariantFontSize={20}>
           {markers}
         </GLText>
         <Axes />
@@ -101,7 +101,7 @@ storiesOf("Worldview/GLText", module)
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (
       <Container cameraState={{ perspective: true, distance: 25 }}>
-        <GLText hiresFont scaleInvariant scaleInvariantFontSize={40}>
+        <GLText highResolutionFont scaleInvariant scaleInvariantFontSize={40}>
           {markers}
         </GLText>
         <Axes />
@@ -132,9 +132,9 @@ storiesOf("Worldview/GLText", module)
       <Axes />
     </Container>
   ))
-  .add("autoBackgroundColor hires", () => (
+  .add("autoBackgroundColor highResolutionFont", () => (
     <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
-      <GLText autoBackgroundColor hiresFont>
+      <GLText autoBackgroundColor highResolutionFont>
         {textMarkers({ text: "Hello\nWorldview" })}
       </GLText>
       <Axes />
@@ -143,7 +143,7 @@ storiesOf("Worldview/GLText", module)
   .add("autoBackgroundColor scaleInvariant", () => (
     <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
       <GLText autoBackgroundColor scaleInvariant>
-        {textMarkers({ text: "Hello\nWorldview" })}
+        {textMarkers({ text: "Hello\nWorldview", billboard: true })}
       </GLText>
       <Axes />
     </Container>
@@ -170,7 +170,7 @@ storiesOf("Worldview/GLText", module)
     }
     return <Example />;
   })
-  .add("changing text hires", () => {
+  .add("changing text highResolutionFont", () => {
     function Example() {
       const [text, setText] = useState("Hello\nWorldview");
       useLayoutEffect(() => {
@@ -185,7 +185,7 @@ storiesOf("Worldview/GLText", module)
       }, []);
       return (
         <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
-          <GLText autoBackgroundColor hiresFont>
+          <GLText autoBackgroundColor highResolutionFont>
             {textMarkers({ text })}
           </GLText>
           <Axes />
@@ -243,7 +243,7 @@ storiesOf("Worldview/GLText", module)
 
     return <Example />;
   })
-  .add("highlighted text hires", () => {
+  .add("highlighted text highResolutionFont", () => {
     const Example = () => {
       const [searchText, setSearchText] = useState("ello\nW");
       const markers = textMarkers({ text: "Hello\nWorldview" }).map((marker) => {
@@ -272,7 +272,7 @@ storiesOf("Worldview/GLText", module)
         <div style={{ width: "100%", height: "100%" }}>
           <div style={{ width: "100%", height: "100%" }}>
             <Container cameraState={{ perspective: true, distance: 40 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
-              <GLText autoBackgroundColor hiresFont>
+              <GLText autoBackgroundColor highResolutionFont>
                 {markers}
               </GLText>
               <Axes />


### PR DESCRIPTION
## Summary

**Note: This PR is no longer valid. It has been replaced by #360**

This PR improves Worldview's existing GLText command, adding new functionalities for enhanced font rendering and scale invariance. 

### Higher resolution font
GLText now uses a higher resolution font atlas, which increases the resolution of the SDF texture, avoiding visual artifacts when zooming in/out the text:

**Before:**
<image src="https://user-images.githubusercontent.com/1727802/76123182-d3c2e400-5fac-11ea-9788-47758d12f919.png" height="300px" />

**Now:**
<image src="https://user-images.githubusercontent.com/1727802/76123180-d32a4d80-5fac-11ea-89c6-bfc634bf5809.png" height="300px" />

### Scale Invariance
Keeps the text at the same size (relative to the screen resolution) regardless of the zoom level in the 3D world. It produces a final result similar as when using the <Text> command (which renders text using HTML elements on top of the 3D video).

**Note:** scaleInvariant does not work when the billboard option is false for a marker.

Usage: 
`<GLText scaleInvariantFontSize="40">{markers}</GLText>`

The scaleInvariantFontSize option allows you to change the font size for the text when scale invariant is active. 

Because of how the SDF approach works, visual artifacts may appear when the text size is too small. In such cases, I'm skipping smoothing the distance value from the SDF texture which produce better results. This is handled by fragment shader.

I also updated the documentation with the new *scaleInvariantFontSize* option

## Test plan
Added several stories to showcase the new options and compare their output with the default implementation:

* *high resolution text*: Renders GLText at a higher zoom level to showcase the higher resolution font. 
* *scaleInvariant*: Shows how GLText renders text using the scaleInvariantFontSize. Three tests are provided: 
  * *scaleInvariant*: Font size is 10px. Does not use smooth interpolation.
  * *scaleInvariant-20*: Font size is 20px. Does not use smooth interpolation.
  * *scaleInvariant-40*: Font size is 40px. Since this is a bigger font, it will use smooth interpolation in the fragment shader.
* *autoBackgroundColor scaleInvariant*: Same as *autoBackgroundColor* story, but using the scaleInvariant option
* *changing text*: Updated version that avoid unpredictable results and allows you to change the text manually.


## Versioning impact
Minor
