### PR TITLE
MemoryCacheDataProvider prefetches more data for "large" files

### DIFF
--- a/packages/webviz-core/src/dataProviders/MemoryCacheDataProvider.js
+++ b/packages/webviz-core/src/dataProviders/MemoryCacheDataProvider.js
@@ -280,6 +280,10 @@ export default class MemoryCacheDataProvider implements DataProvider {
     }
 
     // Then see if we need to set a new connection based on the new connection and read requests state.
+    this._maybeRunNewConnections();
+  }
+
+  _maybeRunNewConnections() {
     const newConnection = getNewConnection({
       currentRemainingRange: this._currentConnection ? this._currentConnection.remainingBlockRange : undefined,
       readRequestRange: this._readRequests[0] ? this._readRequests[0].blockRange : undefined,

--- a/packages/webviz-core/src/dataProviders/MemoryCacheDataProvider.js
+++ b/packages/webviz-core/src/dataProviders/MemoryCacheDataProvider.js
@@ -221,9 +221,7 @@ export default class MemoryCacheDataProvider implements DataProvider {
     return this._preloadTopics;
   }
 
-  // Gets called any time our "connection", read requests, or topics change.
-  _updateState() {
-    // First, see if there are any read requests that we can resolve now.
+  _resolveFinishedReadRequests() {
     this._readRequests = this._readRequests.filter(({ timeRange, blockRange, topics, resolve }) => {
       if (topics.length === 0) {
         resolve([]);
@@ -269,6 +267,12 @@ export default class MemoryCacheDataProvider implements DataProvider {
 
       return false;
     });
+  }
+
+  // Gets called any time our "connection", read requests, or topics change.
+  _updateState() {
+    // First, see if there are any read requests that we can resolve now.
+    this._resolveFinishedReadRequests();
 
     if (this._currentConnection && !isEqual(this._currentConnection.topics, this._getCurrentTopics())) {
       // If we have a different set of topics, stop the current "connection", and refresh everything.

--- a/packages/webviz-core/src/dataProviders/MemoryCacheDataProvider.js
+++ b/packages/webviz-core/src/dataProviders/MemoryCacheDataProvider.js
@@ -436,8 +436,9 @@ export default class MemoryCacheDataProvider implements DataProvider {
         );
       }
 
-      // Now `this._recentBlockRanges` and `this._blocks` have been updated, so we can purge the
-      // cache and report progress.
+      // Now `this._recentBlockRanges` and `this._blocks` have been updated, so we can resolve
+      // requests, purge the cache and report progress.
+      this._resolveFinishedReadRequests();
       this._purgeOldBlocks();
       this._updateProgress();
 
@@ -456,11 +457,9 @@ export default class MemoryCacheDataProvider implements DataProvider {
         ...this._currentConnection,
         remainingBlockRange: { start: currentBlockIndex + 1, end: blockRange.end },
       };
-      this._resolveFinishedReadRequests();
     }
     // Connection successfully completed.
     delete this._currentConnection;
-    this._resolveFinishedReadRequests();
     return true;
   }
 


### PR DESCRIPTION
##  Summary

While there is space left in the cache and there are no read requests currently in flight, the `MemoryCacheDataProvider` should intelligently fill up its cache.

This is currently already done for files shorter than 35 seconds long, but
 - We'd rather just have one threshold (size) rather than two (size and length), and
 - The technique currently used for short files ("request the whole thing") is not appropriate for files that won't fit in the cache.

The first couple of commits reorder some of the logic in the class to make the call graph simpler, replacing some mutual recursion with explicit iteration. Most of the changes are in the final commit.

## Test plan

A test has been added to demonstrate some new behaviour -- loading data *before* a read-request when there's enough space in the cache. Other behaviour is currently untested, including
* Fetching data close to the right of the cursor preferentially,
* Stopping once the cache is full.

It looks ok when verifying manually with large and small files (for small files the behaviour seems unchanged), but I could use some guidance on adding appropriate unit tests.

In manual testing I saw a couple of errors (one tab-crash and one in-product red bubble saying something about the provider) but I haven't been able to reproduce them. I'll keep trying to reproduce them, but code review might help -- I suspect the problem is in the fourth commit, if anywhere. I haven't seen it in a long time, though, so maybe it doesn't exist?

## Versioning impact

None?