### PR TITLE
Make screenshot tests more verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Please see the individual package READMEs for details on how to install and use 
 - `npm run build` to run a single build or `npm run watch` to watch and build.
 - `npm run docs` to run the docs app (e.g. go to http://localhost:8080/app to open Webviz). Requires `build` to be run first.
 - `npm run storybook` to run storybook. Requires `build` to be run first.
-- `npm run screenshot-debug` to generate screenshots from stories.
+- `npm run screenshot-local` or `npm run screenshot-local-debug` to generate screenshots from stories.
 - `npm run lint` to run the linters (and `npm run lint:fix` to automatically fix issues).
 - `npm run flow` to run Flow.
 - `npm run flow-typed-rebuild` to update the flow-typed definitions (any time when changing packages).

--- a/package.json
+++ b/package.json
@@ -134,8 +134,9 @@
     "docs-deploy": "cp -r docs/public __temp_deploy__ && cp --remove-destination packages/webviz-core/public/index.html __temp_deploy__/app/index.html && echo 'webviz.io' > __temp_deploy__/CNAME && gh-pages -d __temp_deploy__ && rm -rf __temp_deploy__",
     "publish": "lerna run clean && lerna run build && lerna publish",
     "screenshot": "NODE_ENV=development storybook-chrome-screenshot -c stories --parallel 8 --inject-files stories/injected.js --browser-timeout 1200000",
-    "screenshot-ci": "npm run screenshot -- --parallel 1 --debug --puppeteer-launch-config '{\"executablePath\": \"/usr/bin/google-chrome\", \"headless\": false, \"args\":[\"--use-gl=swiftshader\", \"--no-sandbox\",\"--disable-setuid-sandbox\", \"--disable-dev-shm-usage\", \"--headless\", \"--mute-audio\", \"--user-agent=PuppeteerTestingChrome/80.\"]}'",
-    "screenshot-debug": "npm run screenshot -- --puppeteer-launch-config '{\"headless\": false, \"--args\":[\"--user-agent=PuppeteerTestingChrome/80.\"]}'",
+    "screenshot-ci": "npm run screenshot -- --debug --puppeteer-launch-config '{\"executablePath\": \"/usr/bin/google-chrome\", \"headless\": false, \"args\":[\"--use-gl=swiftshader\", \"--no-sandbox\",\"--disable-setuid-sandbox\", \"--disable-dev-shm-usage\", \"--headless\", \"--mute-audio\", \"--user-agent=PuppeteerTestingChrome/80.\"]}'",
+    "screenshot-local": "npm run screenshot -- --puppeteer-launch-config '{\"headless\": false, \"--args\":[\"--user-agent=PuppeteerTestingChrome/80.\"]}'",
+    "screenshot-local-debug": "npm run screenshot-local -- --parallel 1 --debug",
     "ci-commands-for-cruise-proprietary-repo": "npm run install-ci && NODE_ENV=production npm run build && npm run lint && npm run flow && npm test && NODE_ENV=production npm run screenshot-ci",
     "ci": "npm run ci-commands-for-cruise-proprietary-repo && reg-suit run --verbose"
   }

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "docs-deploy": "cp -r docs/public __temp_deploy__ && cp --remove-destination packages/webviz-core/public/index.html __temp_deploy__/app/index.html && echo 'webviz.io' > __temp_deploy__/CNAME && gh-pages -d __temp_deploy__ && rm -rf __temp_deploy__",
     "publish": "lerna run clean && lerna run build && lerna publish",
     "screenshot": "NODE_ENV=development storybook-chrome-screenshot -c stories --parallel 8 --inject-files stories/injected.js --browser-timeout 1200000",
-    "screenshot-ci": "npm run screenshot -- --debug --puppeteer-launch-config '{\"executablePath\": \"/usr/bin/google-chrome\", \"headless\": false, \"args\":[\"--use-gl=swiftshader\", \"--no-sandbox\",\"--disable-setuid-sandbox\", \"--disable-dev-shm-usage\", \"--headless\", \"--mute-audio\", \"--user-agent=PuppeteerTestingChrome/80.\"]}'",
+    "screenshot-ci": "npm run screenshot -- --parallel 1 --debug --puppeteer-launch-config '{\"executablePath\": \"/usr/bin/google-chrome\", \"headless\": false, \"args\":[\"--use-gl=swiftshader\", \"--no-sandbox\",\"--disable-setuid-sandbox\", \"--disable-dev-shm-usage\", \"--headless\", \"--mute-audio\", \"--user-agent=PuppeteerTestingChrome/80.\"]}'",
     "screenshot-local": "npm run screenshot -- --puppeteer-launch-config '{\"headless\": false, \"--args\":[\"--user-agent=PuppeteerTestingChrome/80.\"]}'",
     "screenshot-local-debug": "npm run screenshot-local -- --parallel 1 --debug",
     "ci-commands-for-cruise-proprietary-repo": "npm run install-ci && NODE_ENV=production npm run build && npm run lint && npm run flow && npm test && NODE_ENV=production npm run screenshot-ci",

--- a/package.json
+++ b/package.json
@@ -134,8 +134,8 @@
     "docs-deploy": "cp -r docs/public __temp_deploy__ && cp --remove-destination packages/webviz-core/public/index.html __temp_deploy__/app/index.html && echo 'webviz.io' > __temp_deploy__/CNAME && gh-pages -d __temp_deploy__ && rm -rf __temp_deploy__",
     "publish": "lerna run clean && lerna run build && lerna publish",
     "screenshot": "NODE_ENV=development storybook-chrome-screenshot -c stories --parallel 8 --inject-files stories/injected.js --browser-timeout 1200000",
-    "screenshot-ci": "npm run screenshot -- --puppeteer-launch-config '{\"executablePath\": \"/usr/bin/google-chrome\", \"headless\": false, \"args\":[\"--use-gl=swiftshader\", \"--no-sandbox\",\"--disable-setuid-sandbox\", \"--disable-dev-shm-usage\", \"--headless\", \"--mute-audio\", \"--user-agent=PuppeteerTestingChrome/72.\"]}'",
-    "screenshot-debug": "npm run screenshot -- --parallel 1 --debug --puppeteer-launch-config '{\"headless\": false, \"--args\":[\"--user-agent=PuppeteerTestingChrome/72.\"]}'",
+    "screenshot-ci": "npm run screenshot -- --parallel 1 --debug --puppeteer-launch-config '{\"executablePath\": \"/usr/bin/google-chrome\", \"headless\": false, \"args\":[\"--use-gl=swiftshader\", \"--no-sandbox\",\"--disable-setuid-sandbox\", \"--disable-dev-shm-usage\", \"--headless\", \"--mute-audio\", \"--user-agent=PuppeteerTestingChrome/80.\"]}'",
+    "screenshot-debug": "npm run screenshot -- --puppeteer-launch-config '{\"headless\": false, \"--args\":[\"--user-agent=PuppeteerTestingChrome/80.\"]}'",
     "ci-commands-for-cruise-proprietary-repo": "npm run install-ci && NODE_ENV=production npm run build && npm run lint && npm run flow && npm test && NODE_ENV=production npm run screenshot-ci",
     "ci": "npm run ci-commands-for-cruise-proprietary-repo && reg-suit run --verbose"
   }


### PR DESCRIPTION
And also only do one at a time.

This makes it so that screenshots are less likely to cause a timeout in CircleCI, and also gives us more information to debug if a screenshot hangs the system.