### PR TITLE
Evict cached blocks from end of ranges sometimes

### DIFF
--- a/packages/webviz-core/src/dataProviders/MemoryCacheDataProvider.test.js
+++ b/packages/webviz-core/src/dataProviders/MemoryCacheDataProvider.test.js
@@ -218,6 +218,7 @@ describe("MemoryCacheDataProvider", () => {
           recentBlockRanges: [{ start: 0, end: 5 }],
           blockSizesInBytes: [1, 2, undefined, undefined, undefined],
           maxCacheSizeInBytes: 5,
+          badEvictionLocation: undefined,
         })
       ).toEqual({ blockIndexesToKeep: new Set([1, 0]), newRecentRanges: [{ start: 0, end: 5 }] });
     });
@@ -228,6 +229,7 @@ describe("MemoryCacheDataProvider", () => {
           recentBlockRanges: [{ start: 0, end: 5 }],
           blockSizesInBytes: [1, 0, 2, undefined, undefined],
           maxCacheSizeInBytes: 5,
+          badEvictionLocation: undefined,
         })
       ).toEqual({ blockIndexesToKeep: new Set([2, 1, 0]), newRecentRanges: [{ start: 0, end: 5 }] });
     });
@@ -238,6 +240,7 @@ describe("MemoryCacheDataProvider", () => {
           recentBlockRanges: [{ start: 0, end: 5 }],
           blockSizesInBytes: [1, 2, 3, undefined, undefined],
           maxCacheSizeInBytes: 5,
+          badEvictionLocation: undefined,
         })
       ).toEqual({ blockIndexesToKeep: new Set([2, 1, 0]), newRecentRanges: [{ start: 0, end: 5 }] });
     });
@@ -248,8 +251,31 @@ describe("MemoryCacheDataProvider", () => {
           recentBlockRanges: [{ start: 0, end: 5 }],
           blockSizesInBytes: [1, 2, 3, 4, undefined],
           maxCacheSizeInBytes: 5,
+          badEvictionLocation: undefined,
         })
       ).toEqual({ blockIndexesToKeep: new Set([3, 2]), newRecentRanges: [{ start: 2, end: 5 }] });
+    });
+
+    it("removes blocks from the left when the playback cursor is on the right", () => {
+      expect(
+        getBlocksToKeep({
+          recentBlockRanges: [{ start: 0, end: 5 }],
+          blockSizesInBytes: [1, 1, 1, 1, 1],
+          maxCacheSizeInBytes: 2,
+          badEvictionLocation: 5,
+        })
+      ).toEqual({ blockIndexesToKeep: new Set([2, 3, 4]), newRecentRanges: [{ start: 2, end: 5 }] });
+    });
+
+    it("removes blocks from the right when the playback cursor is on the left", () => {
+      expect(
+        getBlocksToKeep({
+          recentBlockRanges: [{ start: 0, end: 5 }],
+          blockSizesInBytes: [1, 1, 1, 1, 1],
+          maxCacheSizeInBytes: 2,
+          badEvictionLocation: 0,
+        })
+      ).toEqual({ blockIndexesToKeep: new Set([0, 1, 2]), newRecentRanges: [{ start: 0, end: 3 }] });
     });
   });
 


### PR DESCRIPTION
## Summary

Fix existing bug: Seeking to a soon-to-be-evicted block during playback
results in an infinite loop in which a block is requested, immediately
evicted, and then requested again etc.

This change fixes the bug by trying to not evict blocks in those
circumstances: When there are open read requests, we avoid evicting from
the edge of blocks closest to the first ("highest priority") request.

If there are no open read requests, perhaps because we've just resolved
the last one, try not to evict blocks near the last resolved request too
-- odds are fair we'll request another block nearby soon.

Also adds the small benefit that when there are two "close" ranges with a
gap in between, and the user is playing at the end of the first (earlier)
region, as the buffer of the first region extends, the cached blocks of the
second region are evicted _from the end_, and the two regions eventually
meet.

## Test plan

I've added a couple of unit tests to cover explicitly passing locations to the right- and left- edges of a block range, and existing unit tests cover the (unusual) case where we _don't_ pass a hint to `getBlocksToKeep`.

## Versioning impact

Just a bugfix. `getBlocksToKeep` is "exported for tests", I don't think anyone else depends on its signature.