### PR TITLE
Fix glyph size when rendering text

### DIFF
--- a/packages/regl-worldview/src/commands/GLText.js
+++ b/packages/regl-worldview/src/commands/GLText.js
@@ -272,7 +272,7 @@ function makeTextCommand(alphabet?: string[]) {
         // For the font size, make sure there's enough room to handle
         // both ascent and descent for each glyph. Otherwise, some characters
         // might get cropped when rendering
-        fontSize: command.resolution + BUFFER,
+        fontSize: command.resolution,
         cutoff: CUTOFF,
         scaleInvariant: command.scaleInvariant,
         scaleInvariantSize: command.scaleInvariantSize,
@@ -377,7 +377,7 @@ function makeTextCommand(alphabet?: string[]) {
           destOffsets[2 * index + 0] = x;
           destOffsets[2 * index + 1] = -y;
           srcOffsets[2 * index + 0] = info.x + BUFFER;
-          srcOffsets[2 * index + 1] = info.y + BUFFER;
+          srcOffsets[2 * index + 1] = info.y + 2 * BUFFER;
           srcWidths[index] = info.width;
 
           x += info.width;

--- a/packages/regl-worldview/src/commands/GLText.js
+++ b/packages/regl-worldview/src/commands/GLText.js
@@ -269,9 +269,6 @@ function makeTextCommand(alphabet?: string[]) {
       uniforms: {
         atlas: atlasTexture,
         atlasSize: () => [atlasTexture.width, atlasTexture.height],
-        // For the font size, make sure there's enough room to handle
-        // both ascent and descent for each glyph. Otherwise, some characters
-        // might get cropped when rendering
         fontSize: command.resolution,
         cutoff: CUTOFF,
         scaleInvariant: command.scaleInvariant,
@@ -377,7 +374,10 @@ function makeTextCommand(alphabet?: string[]) {
           destOffsets[2 * index + 0] = x;
           destOffsets[2 * index + 1] = -y;
           srcOffsets[2 * index + 0] = info.x + BUFFER;
-          srcOffsets[2 * index + 1] = info.y + 2 * BUFFER;
+          // In order to make sure there's enough room for glyphs' descenders (i.e. 'g'),
+          // we need to apply an extra offset based on the font resolution.
+          // The value used to compute the offset is a result of experimentation.
+          srcOffsets[2 * index + 1] = info.y + BUFFER + 0.05 * command.resolution;
           srcWidths[index] = info.width;
 
           x += info.width;

--- a/packages/regl-worldview/src/commands/GLText.js
+++ b/packages/regl-worldview/src/commands/GLText.js
@@ -229,11 +229,11 @@ const frag = `
     float edgeStep = smoothstep(1.0 - cutoff - fwidth(dist), 1.0 - cutoff, dist);
 
     if (scaleInvariant && vBillboard == 1.0 && scaleInvariantSize < 0.03) {
-      // If scale invariant is enabled and scaleInvariantSize is "too small", do not interpolate 
-      // the raw distance value since at such small scale, the SDF approach causes some 
+      // If scale invariant is enabled and scaleInvariantSize is "too small", do not interpolate
+      // the raw distance value since at such small scale, the SDF approach causes some
       // visual artifacts.
-      // The value used for checking if scaleInvariantSize is "too small" is arbitrary and 
-      // was defined after some experimentation. 
+      // The value used for checking if scaleInvariantSize is "too small" is arbitrary and
+      // was defined after some experimentation.
       edgeStep = dist;
     }
 
@@ -269,6 +269,9 @@ function makeTextCommand(alphabet?: string[]) {
       uniforms: {
         atlas: atlasTexture,
         atlasSize: () => [atlasTexture.width, atlasTexture.height],
+        // For the font size, make sure there's enough room to handle
+        // both ascent and descent for each glyph. Otherwise, some characters
+        // might get cropped when rendering
         fontSize: command.resolution + BUFFER,
         cutoff: CUTOFF,
         scaleInvariant: command.scaleInvariant,

--- a/packages/regl-worldview/src/commands/GLText.js
+++ b/packages/regl-worldview/src/commands/GLText.js
@@ -269,7 +269,7 @@ function makeTextCommand(alphabet?: string[]) {
       uniforms: {
         atlas: atlasTexture,
         atlasSize: () => [atlasTexture.width, atlasTexture.height],
-        fontSize: command.resolution,
+        fontSize: command.resolution + BUFFER,
         cutoff: CUTOFF,
         scaleInvariant: command.scaleInvariant,
         scaleInvariantSize: command.scaleInvariantSize,

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -89,6 +89,21 @@ storiesOf("Worldview/GLText", module)
       </Container>
     );
   })
+  .add("glyph ascent and descent", () => {
+    const markers = textMarkers({ text: "BDFGHJKLPQTY\nbdfghjklpqty", billboard: true });
+    const target = markers[9].pose.position;
+    return (
+      <Container
+        cameraState={{
+          target: [target.x, target.y + 2, target.z],
+          perspective: true,
+          distance: 8,
+        }}>
+        <GLText>{markers}</GLText>
+        <Axes />
+      </Container>
+    );
+  })
   .add("scaleInvariant", () => {
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (


### PR DESCRIPTION
## Summary

There's a bug in `<GLText />` resulting in some characters being cropped when rendering:

![Screen Shot 2020-03-18 at 11 31 43 AM](https://user-images.githubusercontent.com/1727802/76999609-aa537200-6935-11ea-8e41-8750def592af.png)

The problem is that we're not taking into account the small margin (named `BUFFER` in the code) for each glyph that is used when computing the SDF for the font.

This is the result after my fix:

![Screen Shot 2020-03-18 at 11 31 04 AM](https://user-images.githubusercontent.com/1727802/76999601-a6275480-6935-11ea-97ff-9d8f2e897993.png)

I added a comment and a test as well 

## Test plan

Added a story to make sure each character is not cropped. It will help if we change the font in the future (I noticed a comment about that).

## Versioning impact

This should be a patch. No new functionality was added.
