### PR TITLE
Fix scale invariance for both perspective and orthographic projections

### DIFF
--- a/packages/regl-worldview/src/camera/camera.js
+++ b/packages/regl-worldview/src/camera/camera.js
@@ -78,6 +78,14 @@ export default (regl: any) => {
         billboardRotation(context, props) {
           return selectors.billboardRotation(this.cameraState);
         },
+
+        isPerspective(context, props) {
+          return this.cameraState.perspective;
+        },
+
+        fovy(context, props) {
+          return this.cameraState.fovy;
+        },
       },
 
       // adds view and projection as uniforms to every command

--- a/packages/regl-worldview/src/commands/GLText.js
+++ b/packages/regl-worldview/src/commands/GLText.js
@@ -134,7 +134,6 @@ const vert = `
   uniform float scaleInvariantSize;
   uniform float viewportHeight;
   uniform float viewportWidth;
-  uniform float pixelRatio;
   uniform bool isPerspective;
   uniform float cameraFovY;
 
@@ -207,17 +206,17 @@ const vert = `
         gl_Position = computeVertexPosition(markerSpacePos);
         scaleInvariantFactor *= gl_Position.w;
         // We also need to take into account the camera's half vertical FOV
-        scaleInvariantFactor *= 0.5 * cameraFovY;
+        scaleInvariantFactor *= cameraFovY;
       } else {
         // Compute inverse aspect ratio
         float invAspect = viewportHeight / viewportWidth;
         // When using orthographic projection, the scaling factor is obtain from
         // the camera projection itself.
         // We also need applied the inverse aspect ratio
-        scaleInvariantFactor *= invAspect / length(projection[0].xyz);
+        scaleInvariantFactor *= 2.0 * invAspect / length(projection[0].xyz);
       }
-      // Apply scale invariant factor and pixel ratio to get the correct height in pixels
-      markerSpacePos *= pixelRatio * scaleInvariantFactor;
+      // Apply scale invariant factor
+      markerSpacePos *= scaleInvariantFactor;
     }
 
     // Compute final vertex position
@@ -305,7 +304,6 @@ function makeTextCommand(alphabet?: string[]) {
         scaleInvariantSize: command.scaleInvariantSize,
         viewportHeight: regl.context("viewportHeight"),
         viewportWidth: regl.context("viewportWidth"),
-        pixelRatio: regl.context("pixelRatio"),
         isPerspective: regl.context("isPerspective"),
         cameraFovY: regl.context("fovy"),
       },

--- a/packages/regl-worldview/src/commands/GLText.js
+++ b/packages/regl-worldview/src/commands/GLText.js
@@ -2,11 +2,10 @@
 
 import TinySDF from "@mapbox/tiny-sdf";
 import memoizeOne from "memoize-one";
-import React, { useState, useContext } from "react";
+import React, { useState } from "react";
 
 import type { Color } from "../types";
 import { defaultBlend, defaultDepth } from "../utils/commandUtils";
-import WorldviewReactContext from "../WorldviewReactContext";
 import Command, { type CommonCommandProps } from "./Command";
 import { isColorDark, type TextMarker } from "./Text";
 
@@ -133,6 +132,11 @@ const vert = `
   uniform vec2 atlasSize;
   uniform bool scaleInvariant;
   uniform float scaleInvariantSize;
+  uniform float viewportHeight;
+  uniform float viewportWidth;
+  uniform float pixelRatio;
+  uniform bool isPerspective;
+  uniform float cameraFovY;
 
   // per-vertex attributes
   attribute vec2 texCoord;
@@ -181,17 +185,43 @@ const vert = `
   }
 
   void main () {
-    vec2 srcSize = vec2(srcWidth, fontSize);
-    vec3 markerSpacePos = scale * vec3((destOffset + position * srcSize + alignmentOffset) / fontSize, 0);
-    gl_Position = computeVertexPosition(markerSpacePos);
+    // Scale invariance only works for billboards
+    bool scaleInvariantEnabled = scaleInvariant && billboard == 1.0;
 
-    if (scaleInvariant && billboard == 1.0) {
-      // Scale invariance only works for billboards
-      float w = gl_Position.w;
-      w *= scaleInvariantSize;
-      markerSpacePos *= w;
-      gl_Position = computeVertexPosition(markerSpacePos);
+    vec2 srcSize = vec2(srcWidth, fontSize);
+    vec3 markerSpacePos = vec3((destOffset + position * srcSize + alignmentOffset) / fontSize, 0);
+
+    if (!scaleInvariantEnabled) {
+      // Apply marker scale only when scale invariance is disabled
+      markerSpacePos *= scale;
+    } else {
+      // If scale invariance is enabled, the text will be rendered at a constant
+      // scale regardless of the zoom level.
+      // The given scaleInvariantSize is in pixels. We need to scale it based on
+      // the current canvas resolution to get the proper dimensions later in NDC
+      float scaleInvariantFactor = scaleInvariantSize / viewportHeight;
+      if (isPerspective) {
+        // When using a perspective projection, the effect is achieved by using
+        // the w-component for scaling, which is obtained by first projecting
+        // the marker position into clip space.
+        gl_Position = computeVertexPosition(markerSpacePos);
+        scaleInvariantFactor *= gl_Position.w;
+        // We also need to take into account the camera's half vertical FOV
+        scaleInvariantFactor *= 0.5 * cameraFovY;
+      } else {
+        // Compute inverse aspect ratio
+        float invAspect = viewportHeight / viewportWidth;
+        // When using orthographic projection, the scaling factor is obtain from
+        // the camera projection itself.
+        // We also need applied the inverse aspect ratio
+        scaleInvariantFactor *= invAspect / length(projection[0].xyz);
+      }
+      // Apply scale invariant factor and pixel ratio to get the correct height in pixels
+      markerSpacePos *= pixelRatio * scaleInvariantFactor;
     }
+
+    // Compute final vertex position
+    gl_Position = computeVertexPosition(markerSpacePos);
 
     vTexCoord = (srcOffset + texCoord * srcSize) / atlasSize;
     vEnableBackground = enableBackground;
@@ -228,12 +258,12 @@ const frag = `
     // depth test don't work together nicely for partially-transparent pixels.
     float edgeStep = smoothstep(1.0 - cutoff - fwidth(dist), 1.0 - cutoff, dist);
 
-    if (scaleInvariant && vBillboard == 1.0 && scaleInvariantSize < 0.03) {
-      // If scale invariant is enabled and scaleInvariantSize is "too small", do not interpolate 
-      // the raw distance value since at such small scale, the SDF approach causes some 
+    if (scaleInvariant && vBillboard == 1.0 && scaleInvariantSize <= 20.0) {
+      // If scale invariant is enabled and scaleInvariantSize is "too small", do not interpolate
+      // the raw distance value since at such small scale, the SDF approach causes some
       // visual artifacts.
-      // The value used for checking if scaleInvariantSize is "too small" is arbitrary and 
-      // was defined after some experimentation. 
+      // The value used for checking if scaleInvariantSize is "too small" is arbitrary and
+      // was defined after some experimentation.
       edgeStep = dist;
     }
 
@@ -273,6 +303,11 @@ function makeTextCommand(alphabet?: string[]) {
         cutoff: CUTOFF,
         scaleInvariant: command.scaleInvariant,
         scaleInvariantSize: command.scaleInvariantSize,
+        viewportHeight: regl.context("viewportHeight"),
+        viewportWidth: regl.context("viewportWidth"),
+        pixelRatio: regl.context("pixelRatio"),
+        isPerspective: regl.context("isPerspective"),
+        cameraFovY: regl.context("fovy"),
       },
       instances: regl.prop("instances"),
       count: 4,
@@ -456,23 +491,12 @@ function makeTextCommand(alphabet?: string[]) {
 }
 
 export default function GLText(props: Props) {
-  const context = useContext(WorldviewReactContext);
-  const { dimension } = context;
-
   const [command] = useState(() => makeTextCommand(props.alphabet));
   // HACK: Worldview doesn't provide an easy way to pass a command-level prop into the regl commands,
   // so just attach it to the command object for now.
   command.autoBackgroundColor = props.autoBackgroundColor;
-
   command.resolution = Math.max(MIN_RESOLUTION, props.resolution || DEFAULT_RESOLUTION);
-
   command.scaleInvariant = props.scaleInvariantFontSize != null;
-  // Compute the actual size for the text object in NDC coordinates (from -1 to 1)
-  // In order to make sure the text is always shown at the same size regardless of
-  // the canvas dimensions (as Text does), we need to scale it based on both the desired
-  // font size and the current worldview resolution. Otherwise, the text will be
-  // displayed at different sizes depending on the worlview canvas dimension.
-  command.scaleInvariantSize = (props.scaleInvariantFontSize ?? 0) / dimension.height;
-
+  command.scaleInvariantSize = props.scaleInvariantFontSize ?? 0;
   return <Command reglCommand={command} {...props} />;
 }

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -18,13 +18,22 @@ function textMarkers({
   text,
   billboard,
   background = true,
+  randomScale = false,
 }: {
   text: string,
   billboard?: ?boolean,
   background?: ?boolean,
+  randomScale?: ?boolean,
 }) {
   const radius = 10;
   const count = 10;
+  const scale = (i: number) => {
+    if (!randomScale) {
+      return { x: 1, y: 1, z: 1 };
+    }
+    // It's not really random. Otherwise, screenshot tests won't work correctly
+    return { x: 0.5 + (2 * i) / count, y: 0.5 + (2 * i) / count, z: 1 };
+  };
   return new Array(count).fill().map((_, i) => {
     const angle = (2 * Math.PI * i) / count;
     const color = { r: 0, g: i / count, b: i / count, a: 1 };
@@ -34,7 +43,7 @@ function textMarkers({
         position: { x: radius * Math.cos(angle), y: radius * Math.sin(angle), z: 0 },
         orientation: vec4ToOrientation(quat.rotateZ(quat.create(), quat.create(), Math.PI / 2 + angle)),
       },
-      scale: { x: 1, y: 1, z: 1 },
+      scale: scale(i),
       color,
       colors: background && i % 4 === 0 ? [color, { r: 1, g: 1, b: 0, a: 1 }] : undefined,
       billboard,
@@ -89,6 +98,15 @@ storiesOf("Worldview/GLText", module)
       </Container>
     );
   })
+  .add("random marker scale", () => {
+    const markers = textMarkers({ text: "Hello\nWorldview", billboard: true, randomScale: true });
+    return (
+      <Container cameraState={{ perspective: true, distance: 25 }}>
+        <GLText resolution={40}>{markers}</GLText>
+        <Axes />
+      </Container>
+    );
+  })
   .add("scaleInvariant", () => {
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (
@@ -110,7 +128,16 @@ storiesOf("Worldview/GLText", module)
   .add("scaleInvariant-40", () => {
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
     return (
-      <Container cameraState={{ perspective: true, distance: 25 }}>
+      <Container cameraState={{ perspective: true, distance: 25 }} backgroundColor={[0.2, 0.2, 0.4, 1]}>
+        <GLText scaleInvariantFontSize={40}>{markers}</GLText>
+        <Axes />
+      </Container>
+    );
+  })
+  .add("scaleInvariant - perspective: false", () => {
+    const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });
+    return (
+      <Container cameraState={{ perspective: false, distance: 25 }} backgroundColor={[0.4, 0.2, 0.2, 1]}>
         <GLText scaleInvariantFontSize={40}>{markers}</GLText>
         <Axes />
       </Container>
@@ -137,6 +164,15 @@ storiesOf("Worldview/GLText", module)
       );
     }
     return <Example />;
+  })
+  .add("scaleInvariant - ignore scale", () => {
+    const markers = textMarkers({ text: "Hello\nWorldview", billboard: true, randomScale: true });
+    return (
+      <Container cameraState={{ perspective: true, distance: 25 }}>
+        <GLText scaleInvariantFontSize={30}>{markers}</GLText>
+        <Axes />
+      </Container>
+    );
   })
   .add("with alphabet", () => {
     const markers = textMarkers({ text: "Hello\nWorldview", billboard: true });

--- a/packages/regl-worldview/src/stories/GLText.stories.js
+++ b/packages/regl-worldview/src/stories/GLText.stories.js
@@ -11,6 +11,7 @@ import { Axes } from "../commands";
 import type { Color } from "../types";
 import { vec4ToOrientation } from "../utils/commandUtils";
 import Container from "./Container";
+import { rng } from "./util";
 
 import { GLText } from "..";
 
@@ -31,8 +32,11 @@ function textMarkers({
     if (!randomScale) {
       return { x: 1, y: 1, z: 1 };
     }
-    // It's not really random. Otherwise, screenshot tests won't work correctly
-    return { x: 0.5 + (2 * i) / count, y: 0.5 + (2 * i) / count, z: 1 };
+    return {
+      x: 0.5 + 2.0 * rng(),
+      y: 0.5 + 2.0 * rng(),
+      z: 0.5 + 2.0 * rng(),
+    };
   };
   return new Array(count).fill().map((_, i) => {
     const angle = (2 * Math.PI * i) / count;


### PR DESCRIPTION
## Summary

This PR fixes several issues for `<GLText />` when scale invariance is enabled:

### Orthographic projection

Scale invariance is not working correctly when using orthographic projection (`perspective = false` in camera state) because we're using the w-component to compute the text scale. But that component is always 1 in orthographic mode. So, in that case we need a different approach. Check the comments in shaders for more information.

### Pixel size

Rendered text's size was not matching the pixel size specified in scaleInvariantFontSize. Now it does, although the calculations are different for orthographic and perspective projections.

### Marker's scale

After some discussion with the team, we decided to ignore the scale property of individual markers when scale invariance is enabled, since that resulted in text being too big or too small. It is taken into account when not using scale invariance, of course.

### Use Regl Context instead of WorldviewReactContext

I'm using Regl Context values for things like viewport dimensions and pixel sizes, which seem to be a more correct approach than using WorldviewReactContext. I also added a couple of properties for the camera.

## Test plan

Added new tests for orthographic projection and ignoring individual markers' scale when scale invariance is enabled.

## Versioning impact

Patch. No new functionality has been added.