### PR TITLE
Jest module-mapper handles worker-loader options

### DIFF
--- a/jest/jest.config.js
+++ b/jest/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
   ],
   setupTestFrameworkScriptFile: "<rootDir>/packages/webviz-core/src/test/setupTestFramework.js",
   moduleNameMapper: {
-    "worker-loader!.*": "<rootDir>/packages/webviz-core/src/test/MockWorker.js",
+    "worker-loader.*!.*": "<rootDir>/packages/webviz-core/src/test/MockWorker.js",
     "\\.svg$": "<rootDir>/packages/webviz-core/src/test/MockSvg.js",
     "react-monaco-editor": "<rootDir>/packages/webviz-core/src/test/stubs/MonacoEditor.js",
     "\\.css$": "<rootDir>/jest/styleMock.js",


### PR DESCRIPTION
## Summary

Inline uses of worker-loaders con include options before the bang. They
look like URL params -- question marks and equals signs etc. We want to
make a change that requires an inline option, and don't want it to break
our tests.

## Test plan

Existing unit tests still pass. I've also made a similar change in a different
project, and it worked... Not currently tested in this project in this PR, though
it will be when the change that depends on this is made.

## Versioning impact

None.