### PR TITLE
Update docker CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,8 @@ jobs:
       - run: echo $REG_SUIT_EXPECTED_KEY
 
       - run:
-          command: docker run -v `pwd`:`pwd` -w `pwd` -it --rm -e CI -e CIRCLE_SHA1 -e REG_SUIT_EXPECTED_KEY -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION cruise/webviz-ci:0.0.8 npm run ci
+          # Use /root:/root to ensure that npm packages from git repos can be installed correctly.
+          command: docker run -v `pwd`:`pwd` -v /root:/root -w `pwd` -it --rm -e CI -e CIRCLE_SHA1 -e REG_SUIT_EXPECTED_KEY -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION cruise/webviz-ci:0.0.10 npm run ci
           no_output_timeout: 30m
 
       - save_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,18 +6,18 @@
 
 # This container is published at https://hub.docker.com/r/cruise/webviz-ci.
 
-FROM node:10.15.3-slim
+FROM node:10.16-slim
 
 # Install some general dependencies for stuff below and for CircleCI;
 # https://circleci.com/docs/2.0/custom-images/#required-tools-for-primary-containers
-RUN apt-get update && apt-get install -yq libgconf-2-4 wget git ssh --no-install-recommends
+RUN apt-get update && apt-get install -yq gnupg libgconf-2-4 wget git ssh --no-install-recommends
 
 # Install Google Chrome for Puppeteer.
 # https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+RUN wget --no-check-certificate -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
-    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont --no-install-recommends
+    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf --no-install-recommends
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 ENV WEBVIZ_IN_DOCKER=true


### PR DESCRIPTION
This is a fix for a long-winded attempt to get packages synced between
internal and open source versions. We use NPM aliasing internally, but
it doesn't seem to work in open-source - see #362, which keeps failing
the build in CI even though the build works locally. It turns out that the
version of NPM in CI (6.4.2) doesn't support package aliasing while
my local version of NPM does - support was only added in 6.9.0 
(https://npm.community/t/release-npm-6-9-0/5911).

The fix is simple: update the dockerfile version that we use to
be able to use package aliasing in CI.
