### PR TITLE
Changing onDirty & paint to be more performance friendly

### DIFF
--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -153,24 +153,7 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     if (this.props.cameraState) {
       worldviewContext.cameraStore.setCameraState(this.props.cameraState);
     }
-
-    // queue up a paint operation on the next frame, if we haven't already
-    if (!this._tick) {
-      this._tick = requestAnimationFrame(() => {
-        this._tick = undefined;
-        try {
-          worldviewContext.paint();
-        } catch (error) {
-          // Regl automatically tries to reconnect when losing the canvas 3d context.
-          // We should log this error, but it's not important to throw it.
-          if (error.message === "(regl) context lost") {
-            console.warn(error);
-          } else {
-            throw error;
-          }
-        }
-      });
-    }
+    worldviewContext.onDirty();
   }
 
   _onDoubleClick = (e: SyntheticMouseEvent<HTMLCanvasElement>) => {

--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -212,6 +212,8 @@ export class WorldviewContext {
     try {
       this._paint();
     } catch (error) {
+      // Regl automatically tries to reconnect when losing the canvas 3d context.
+      // We should log this error, but it's not important to throw it.
       if (error.message === "(regl) context lost") {
         console.warn(error);
       } else {

--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -82,7 +82,7 @@ export class WorldviewContext {
   _commands: Set<RawCommand<any>> = new Set();
   _compiled: Map<Function, CompiledReglCommand<any>> = new Map();
   _drawCalls: Map<React.Component<any>, DrawInput> = new Map();
-  _frame: AnimationFrameID | null;
+  _frame: ?AnimationFrameID;
   _paintCalls: Map<PaintFn, PaintFn> = new Map();
   _hitmapObjectIdManager: HitmapObjectIdManager = new HitmapObjectIdManager();
   _cachedReadHitmapCall: ?{
@@ -155,7 +155,9 @@ export class WorldviewContext {
     if (this.initializedData) {
       this.initializedData.regl.destroy();
     }
-    cancelAnimationFrame(this._frame);
+    if (this._frame) {
+      cancelAnimationFrame(this._frame);
+    }
   }
 
   // compile a command when it is first mounted, and try to register in _commands and _compiled maps

--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -245,7 +245,7 @@ export class WorldviewContext {
   }
 
   onDirty = () => {
-    if (undefined !== this._frame) {
+    if (undefined === this._frame) {
       this._frame = requestAnimationFrame(() => this.paint());
     }
   };

--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -239,11 +239,11 @@ export class WorldviewContext {
       paintCall();
     });
     this.counters.render = Date.now() - start;
-    this._frame = null;
+    this._frame = undefined;
   }
 
   onDirty = () => {
-    if (!this._frame) {
+    if (undefined !== this._frame) {
       this._frame = requestAnimationFrame(() => this.paint());
     }
   };

--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -6,7 +6,6 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 
-import debounce from "lodash/debounce";
 import * as React from "react";
 import createREGL from "regl";
 import shallowequal from "shallowequal";
@@ -83,6 +82,7 @@ export class WorldviewContext {
   _commands: Set<RawCommand<any>> = new Set();
   _compiled: Map<Function, CompiledReglCommand<any>> = new Map();
   _drawCalls: Map<React.Component<any>, DrawInput> = new Map();
+  _frame: AnimationFrameID | null;
   _paintCalls: Map<PaintFn, PaintFn> = new Map();
   _hitmapObjectIdManager: HitmapObjectIdManager = new HitmapObjectIdManager();
   _cachedReadHitmapCall: ?{
@@ -101,7 +101,6 @@ export class WorldviewContext {
 
   constructor({ dimension, canvasBackgroundColor, cameraState, onCameraStateChange }: ConstructorArgs) {
     // used for children to call paint() directly
-    this.onDirty = this._debouncedPaint;
     this.dimension = dimension;
     this.canvasBackgroundColor = canvasBackgroundColor;
     this.cameraStore = new CameraStore((cameraState: CameraState) => {
@@ -156,6 +155,7 @@ export class WorldviewContext {
     if (this.initializedData) {
       this.initializedData.regl.destroy();
     }
+    cancelAnimationFrame(this._frame);
   }
 
   // compile a command when it is first mounted, and try to register in _commands and _compiled maps
@@ -207,6 +207,18 @@ export class WorldviewContext {
   };
 
   paint() {
+    try {
+      this._paint();
+    } catch (error) {
+      if (error.message === "(regl) context lost") {
+        console.warn(error);
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  _paint() {
     const start = Date.now();
     this.reglCommandObjects.forEach((cmd) => (cmd.stats.count = 0));
     if (!this.initializedData) {
@@ -225,9 +237,14 @@ export class WorldviewContext {
       paintCall();
     });
     this.counters.render = Date.now() - start;
+    this._frame = null;
   }
 
-  _debouncedPaint = debounce(this.paint, 10);
+  onDirty = () => {
+    if (!this._frame) {
+      this._frame = requestAnimationFrame(() => this.paint());
+    }
+  };
 
   readHitmap = queuePromise(
     (


### PR DESCRIPTION
This is a continuation of https://github.com/cruise-automation/webviz/pull/383

## Summary

As a consumer of Worldview, I was debugging performance. I found something I think is a performance anti-pattern & should be changed. I see we use a Lodash debounce on our `onDirty` which calls paint, I think this should change.

Issue # 1 - There were frames that would take so long to render that their durations would sometimes exceed a whole second (FPS dropping below 1 FPS). 

![Screen Shot 2020-03-25 at 4 33 02 PM](https://user-images.githubusercontent.com/4021306/79589930-0e7b6a00-808b-11ea-8b40-2e4aa6e3f0f2.png)


Issue # 2 - I also noticed there was a lot of work happening on the main thread, which seemed animation related, but was not running in an animation frame event, but instead was happening in a timer event. This would mean we delay painting & miss the animation frame events, which would extend painting until the next frame, delaying the frame duration. It would also paint sometimes multiple times per animation event.


![Screen Shot 2020-03-25 at 4 26 42 PM](https://user-images.githubusercontent.com/4021306/79589953-15a27800-808b-11ea-95da-cdbe4596d409.png)


Issue # 3 - I also noticed, if you apply CPU throttling or give Worldview a complex enough scene such that painting takes longer than 10ms, Worldview will try to paint every 10ms & creates back pressure, which is where the main thread is being force fed work to do faster than it can do it - as a result real time updates can lag behind, and the app can feel sluggish.

This PR gets rid of the debounced paint method bound to the `onDirty` callback. It instead makes the `onDirty` callback schedule an animation frame to paint if there is not already one scheduled.

If you call `onDirty` very rapidly like in issue # 1 - it will paint on every animation frame event the browser fires, painting will now no longer be delayed up to indefinitely.

If you call `onDirty` less often than the RAF events fire, you should still see benefits because the browser is better able to synchronize the frame rate, and work isn't being done after the animation event, delaying the frame/painting, so issue # 2 should be solved.

Issue # 3 should also be solved because if the painting takes longer, the browser will not fire any animation frame events until it is ready for more work, so we will no longer force feed the main thread causing back pressure.

This also solves some other issues by consolidating the multiple places we control painting within Worldview, to prevent other scenarios where Worldview can paint multiple times per frame.

## Test plan

_How was this change tested & verified?_

## Versioning impact

minor