### PR TITLE
Don't ignore keyboard events when the target is a Button or a Select

### DIFF
--- a/packages/@cruise-automation/button/package.json
+++ b/packages/@cruise-automation/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruise-automation/button",
-  "version": "0.0.7",
+  "version": "1.0.7",
   "main": "lib/index.js",
   "description": "Cruise button",
   "license": "Apache-2.0",

--- a/packages/react-key-listener/src/index.js
+++ b/packages/react-key-listener/src/index.js
@@ -60,15 +60,11 @@ export default class KeyListener extends React.Component<Props> {
   handleEvent = (event: KeyboardEvent) => {
     const { target, type } = event;
     if (
-      // escape key should still work when a button is focused
-      event.key !== "Escape" &&
-      (target instanceof HTMLButtonElement ||
-        target instanceof HTMLInputElement ||
-        target instanceof HTMLSelectElement ||
-        target instanceof HTMLTextAreaElement ||
-        (target instanceof HTMLElement && target.isContentEditable))
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      (target instanceof HTMLElement && target.isContentEditable)
     ) {
-      // the user is typing in an editable field; ignore the event.
+      // The user is typing in an editable field; ignore the event.
       return;
     }
 


### PR DESCRIPTION
Previously we'd ignore events if their target was a Button or a Select, but this breaks keyboard shortcuts once a Button has been focused. In order to keep keyboard shortcuts working all the time, we now allow events targeted at Button and Select elements.

## Test plan

Manually verified

## Versioning impact

It does impact the behavior so maybe minor/patch
