### PR TITLE
Fix gltext recreating draw command every tick

### DIFF
--- a/packages/regl-worldview/src/utils/commandUtils.js
+++ b/packages/regl-worldview/src/utils/commandUtils.js
@@ -110,11 +110,6 @@ export const defaultDepth = {
   mask: (context: any, props: any) => (props.depth && props.depth.mask) || defaultReglDepth.mask,
 };
 
-export const disabledDepth = {
-  enable: (context: any, props: any) => false,
-  mask: (context: any, props: any) => false,
-};
-
 export const defaultBlend = {
   ...defaultReglBlend,
   enable: (context: any, props: any) => (props.blend && props.blend.enable) || defaultReglBlend.enable,


### PR DESCRIPTION
When looking at performance tools in Webviz, I could see that the
`makeDrawText` command was being recompiled every tick. Fix this
command so that we never recompile it, saving ~8-15ms per tick (!).

Test plan: this should have no screenshot test changes.
