### PR TITLE
Remove `event.stopPropagation` from react keylistener

### DIFF
--- a/packages/react-key-listener/package-lock.json
+++ b/packages/react-key-listener/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-key-listener",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/react-key-listener/package-lock.json
+++ b/packages/react-key-listener/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-key-listener",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/react-key-listener/package.json
+++ b/packages/react-key-listener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-key-listener",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "lib/index.js",
   "description": "React component for handling keyboard events",
   "license": "Apache-2.0",

--- a/packages/react-key-listener/package.json
+++ b/packages/react-key-listener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-key-listener",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "main": "lib/index.js",
   "description": "React component for handling keyboard events",
   "license": "Apache-2.0",

--- a/packages/react-key-listener/src/index.js
+++ b/packages/react-key-listener/src/index.js
@@ -51,7 +51,6 @@ export default class KeyListener extends React.Component<Props> {
       return;
     }
     if (typeof handlers[event.key] === "function") {
-      event.stopPropagation();
       event.preventDefault();
       handlers[event.key](event);
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Webviz! To help us understand and review your PR, please fill out the following sections: -->

## Summary

The line in our key listener `stopPropagation` was causing an issue with the 3D panel. Since the Worldview implementation of `CameraListener` depends on propagated events, when we added a custom `ctrl + f` handler, it halted the Worldview `f` keydown event (tilt) from propagating to the Worldview way of handling keydown events (Worldview does not add event listeners).

It makes sense to me that the onus of propagating or not propagating events should be on the custom key handler itself, not on the library. I did a sanity check on some other react key handler packages to see if they stopped event propagation, and it seems like we're an outlier here.

Obviously I'm a bit worried about any unintended breakage here of other consumers, I figured I could manually go through all of our instances of it to double check. The other option here was to simply add a `stopPropagation` prop so we could limit the effect of this change to just our 3D panel usage of it, however I thought this was cleaner. 

## Test plan

Verified locally.

## Versioning impact

Minor update.