### PR TITLE
Add option to build just Webviz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ __screenshots__/
 # build files
 dist/
 lib/
+__static_webviz__/
 
 # reg-suit generated files
 .reg/

--- a/Dockerfile-static-webviz
+++ b/Dockerfile-static-webviz
@@ -1,0 +1,36 @@
+# Copyright (c) 2020-present, GM Cruise LLC
+#
+# This source code is licensed under the Apache License, Version 2.0,
+# found in the LICENSE file in the root directory of this source tree.
+# You may not use this file except in compliance with the License.
+
+# This is a static build of just the Webviz application.
+# This container is published at https://hub.docker.com/r/cruise/webviz.
+
+FROM node:10.16-slim
+
+# Install some general dependencies for stuff below and for CircleCI;
+# https://circleci.com/docs/2.0/custom-images/#required-tools-for-primary-containers
+RUN apt-get update && apt-get install -yq gnupg libgconf-2-4 wget git ssh --no-install-recommends
+
+# Install dumb-init which helps with proper signal handling.
+RUN apt-get install -y dumb-init
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+# Copy in the files
+COPY . .
+
+# Delete .gitignore files, so we don't accidentally pollute our image.
+RUN git clean -Xf
+
+# Bumped up from the default old_space size (512mb) as it was being exceeded during builds.
+ENV NODE_OPTIONS="--max_old_space_size=4096"
+
+# Build the static webviz.
+RUN npm run install-ci
+RUN npm run build
+RUN npm run build-static-webviz
+
+# Start the server.
+EXPOSE 8080
+CMD ["npm", "run", "serve-static-webviz"]

--- a/Dockerfile-webviz-ci
+++ b/Dockerfile-webviz-ci
@@ -4,6 +4,7 @@
 # found in the LICENSE file in the root directory of this source tree.
 # You may not use this file except in compliance with the License.
 
+# This is just for use in CI, as well as the base image for our proprietary version.
 # This container is published at https://hub.docker.com/r/cruise/webviz-ci.
 
 FROM node:10.16-slim

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # [Webviz](https://webviz.io/) [![CircleCI](https://circleci.com/gh/cruise-automation/webviz.svg?style=svg)](https://circleci.com/gh/cruise-automation/webviz)
 
-**Drag and drop your own bag files into [Webviz](https://webviz.io/app/) to explore your robotics data, or connect to a live robot or simulation using the [rosbridge_server](http://wiki.ros.org/rosbridge_suite/Tutorials/RunningRosbridge).**
-
-**View a demo of Webviz in action [here](https://webviz.io/app/?demo).**
+**Drag and drop your own bag files into [Webviz](https://webviz.io/app/?demo) to explore your robotics data, or connect to a live robot or simulation using the [rosbridge_server](http://wiki.ros.org/rosbridge_suite/Tutorials/RunningRosbridge).**
 
 **Webviz** is a web-based application for playback and visualization of [ROS](http://www.ros.org/) [bag files](http://wiki.ros.org/Bags). This repository also contains some libraries that can be used independently to build web-based visualization tools.
 
@@ -15,6 +13,19 @@
 
 Please see the individual package READMEs for details on how to install and use them.
 
+## Running the static Webviz application
+
+We recommend using the [hosted version of Webviz](https://webviz.io/app/?demo), which can connect to your [rosbridge_server](http://wiki.ros.org/rosbridge_suite/Tutorials/RunningRosbridge) or stream in bag data from your S3/GCS bucket. This way you'll always use the latest version of Webviz.
+
+However, sometimes the hosted version is inconvenient, when streaming data from robots on the field where there is poor internet connectivity. For this it is useful to use a static build of webviz.
+
+```sh
+npm run bootstrap # install dependencies
+npm run build # build all packages
+npm run build-static-webviz # generate static build in __static_webviz__
+npm run serve-static-webviz # serve static build on localhost:8080
+```
+
 ## Developing
 
 - `npm run bootstrap` in the root directory to install dependencies.
@@ -26,6 +37,8 @@ Please see the individual package READMEs for details on how to install and use 
 - `npm run flow` to run Flow.
 - `npm run flow-typed-rebuild` to update the flow-typed definitions (any time when changing packages).
 - `npm test` to run tests.
+- `npm run build-static-webviz` to make a special build of just the Webviz application in the `__static_webviz__` directory.
+- `npm run serve-static-webviz` to host the contents of the `__static_webviz__` directory on `localhost:8080`.
 
 If you have the right permissions, you can publish:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4976,6 +4976,12 @@
       "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
       "dev": true
     },
+    "basic-auth": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
+      "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
+      "dev": true
+    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -6600,6 +6606,12 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
+      "dev": true
+    },
     "cosmiconfig": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.7.tgz",
@@ -7738,6 +7750,32 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecstatic": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
+      "integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
+      "dev": true,
+      "requires": {
+        "he": "^1.1.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.1.0",
+        "url-join": "^2.0.5"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
       }
     },
     "ee-first": {
@@ -11436,6 +11474,96 @@
         "is-glob": "^4.0.0",
         "lodash": "^4.17.11",
         "micromatch": "^3.1.10"
+      }
+    },
+    "http-server": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.12.3.tgz",
+      "integrity": "sha512-be0dKG6pni92bRjq0kvExtj/NrrAd28/8fCXkaI/4piTwQMSDSLMhWyW0NI1V+DBI3aa1HMlQu46/HjVLfmugA==",
+      "dev": true,
+      "requires": {
+        "basic-auth": "^1.0.3",
+        "colors": "^1.4.0",
+        "corser": "^2.0.1",
+        "ecstatic": "^3.3.2",
+        "http-proxy": "^1.18.0",
+        "minimist": "^1.2.5",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.25",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "eventemitter3": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+          "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
+          "dev": true
+        },
+        "http-proxy": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+          "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "^4.0.0",
+            "follow-redirects": "^1.0.0",
+            "requires-port": "^1.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "portfinder": {
+          "version": "1.0.26",
+          "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.26.tgz",
+          "integrity": "sha512-Xi7mKxJHHMI3rIUrnm/jjUgwhbYMkp/XKEcZX3aG4BrumLpq3nmoQMX+ClYnDZnZ/New7IatC1no5RX0zo1vXQ==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.2",
+            "debug": "^3.1.1",
+            "mkdirp": "^0.5.1"
+          }
+        }
       }
     },
     "http-signature": {
@@ -16179,6 +16307,12 @@
       "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw=",
       "dev": true
     },
+    "opener": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
+      "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+      "dev": true
+    },
     "opn": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
@@ -20052,6 +20186,12 @@
         }
       }
     },
+    "secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=",
+      "dev": true
+    },
     "seedrandom": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.4.tgz",
@@ -22044,6 +22184,15 @@
         "x-is-string": "^0.1.0"
       }
     },
+    "union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "requires": {
+        "qs": "^6.4.0"
+      }
+    },
     "union-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
@@ -22332,6 +22481,12 @@
           "dev": true
         }
       }
+    },
+    "url-join": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
+      "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
+      "dev": true
     },
     "url-loader": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "gh-pages": "^2.0.1",
     "gl-matrix": "^2.8.1",
     "history": "^4.7.2",
+    "http-server": "^0.12.3",
     "jest": "^23.6.0",
     "jest-canvas-mock": "^2.0.0-beta.1",
     "jest-diff": "24.9.0",
@@ -113,7 +114,6 @@
     "webpack-dev-server": "^3.7.1",
     "worker-loader": "^2.0.0"
   },
-  "dependencies": {},
   "scripts": {
     "bootstrap": "npm install && lerna bootstrap --hoist \"{react,react-dom}\"",
     "install-ci": "npm ci && lerna bootstrap --hoist \"{react,react-dom}\"",
@@ -131,9 +131,10 @@
     "flow": "flow",
     "flow-typed-rebuild": "rm -rf flow-typed/ && flow-typed install && flow-typed install --rootDir packages/@cruise-automation/hooks && flow-typed install --rootDir packages/@cruise-automation/button && flow-typed install --rootDir packages/@cruise-automation/tooltip && flow-typed install --rootDir packages/react-key-listener && flow-typed install --rootDir packages/regl-worldview",
     "docs": "DEV_SERVER=true webpack-dev-server",
-    "docs-deploy": "cp -r docs/public __temp_deploy__ && cp --remove-destination packages/webviz-core/public/index.html __temp_deploy__/app/index.html && echo 'webviz.io' > __temp_deploy__/CNAME && gh-pages -d __temp_deploy__ && rm -rf __temp_deploy__",
+    "docs-deploy": "cp -r docs/public __temp_deploy__ && rm __temp_deploy__/app/index.html && cp packages/webviz-core/public/index.html __temp_deploy__/app/index.html && echo 'webviz.io' > __temp_deploy__/CNAME && gh-pages -d __temp_deploy__ && rm -rf __temp_deploy__",
     "publish": "lerna run clean && lerna run build && lerna publish",
-    "serve-dist": "cd docs/public && npx http-server .",
+    "build-static-webviz": "rm -rf __static_webviz__ && cp -r docs/public/app __static_webviz__ && rm __static_webviz__/index.html && cp packages/webviz-core/public/index.html __static_webviz__/index.html && sed -i -- 's/\\/dist\\/webvizCoreBundle.js/webvizCoreBundle.js/' __static_webviz__/index.html && NODE_ENV=production STATIC_WEBVIZ=true webpack",
+    "serve-static-webviz": "node_modules/http-server/bin/http-server __static_webviz__",
     "screenshot": "NODE_ENV=development storybook-chrome-screenshot -c stories --parallel 1 --inject-files stories/injected.js --browser-timeout 1200000",
     "screenshot-ci": "npm run screenshot -- --puppeteer-launch-config '{\"executablePath\": \"/usr/bin/google-chrome\", \"headless\": false, \"args\":[\"--use-gl=swiftshader\", \"--no-sandbox\",\"--disable-setuid-sandbox\", \"--disable-dev-shm-usage\", \"--headless\", \"--mute-audio\", \"--user-agent=PuppeteerTestingChrome/80.\"]}'",
     "screenshot-proprietary-ci": "npm run screenshot-ci -- --parallel 8",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,8 @@ const TerserPlugin = require("terser-webpack-plugin");
 const visit = require("unist-util-visit");
 const webpack = require("webpack");
 
+const STATIC_WEBVIZ = process.env.STATIC_WEBVIZ === "true";
+
 // Enable smart quotes:
 // https://github.com/mdx-js/mdx/blob/ad58be384c07672dc415b3d9d9f45dcebbfd2eb8/docs/advanced/retext-plugins.md
 const smartypantsProcessor = retext().use(retextSmartypants);
@@ -51,13 +53,19 @@ const gitInfo = (() => {
 
 module.exports = {
   devtool: "cheap-module-eval-source-map",
-  entry: {
-    docs: "./docs/src/index.js",
-    webvizCoreBundle: "./packages/webviz-core/src/index.js",
-  },
+  entry: STATIC_WEBVIZ
+    ? {
+        webvizCoreBundle: "./packages/webviz-core/src/index.js",
+      }
+    : {
+        docs: "./docs/src/index.js",
+        webvizCoreBundle: "./packages/webviz-core/src/index.js",
+      },
   output: {
-    path: path.resolve(`${__dirname}/docs/public/dist`),
-    publicPath: "/dist/",
+    path: STATIC_WEBVIZ
+      ? path.resolve(`${__dirname}/__static_webviz__`)
+      : path.resolve(`${__dirname}/docs/public/dist`),
+    publicPath: STATIC_WEBVIZ ? "" : "/dist/",
     pathinfo: true,
     filename: "[name].js",
     devtoolModuleFilenameTemplate: (info) => path.resolve(info.absoluteResourcePath),
@@ -198,6 +206,9 @@ if (process.env.NODE_ENV === "production") {
   module.exports.mode = "production";
   module.exports.devtool = "source-map";
 } else {
+  if (STATIC_WEBVIZ) {
+    throw new Error("If STATIC_WEBVIZ=true is set the NODE_ENV=production must be set!");
+  }
   module.exports.mode = "development";
   module.exports.entry.docs = [module.exports.entry.docs, "webpack-hot-middleware/client"];
   module.exports.plugins.push(new webpack.HotModuleReplacementPlugin());


### PR DESCRIPTION
Plus a Dockerfile that just installs Webviz.

There have been multiple requests for something like this, especially
from people who want to use Webviz in situations with limited internet
connectivity. See e.g. #120, #267, and #406.

I’ve also renamed the existing Dockerfile.

I’ll follow up with another PR that updates the README to explain how to
use the new Docker image once I’ve figured out how to set up automated
Docker builds.

Test plan: tested this locally. There’s some risk of this getting out of
sync since we don’t run this in CI, but hopefully with the automated
Docker build which I’ll set up later we’ll at least get some coverage on
this flow.