### PR TITLE
Avoid running SDF calculations twice

### DIFF
--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "license": "Apache-2.0",
   "repository": "cruise-automation/webviz/tree/master/packages/regl-worldview",


### PR DESCRIPTION
We have been running SDF calculations twice when the set of characters
changes -- once when the change happens (using a temporary set of
characters whose identity is always unique) and again immediately after
(using the constant-identity original `charSet`.)

This change updates the code to only do the calculation when the change
happens, and simplifies the logic a little by grouping all of the
memoization/recomputation and cache-busting decisions into one place --
the `memoizeOne` around the atlas-building function.

Test plan: I've instrumented the function during webviz startup and
verified that the SDF calculations are only done once.

Versioning impact: This is a bugfix, but it wasn't a correctness issue. Bump
the version number so people downstream can get the benefit.