### PR TITLE
Avoid duplicating position buffer during line rendering

### DIFF
--- a/packages/regl-worldview/src/stories/lines.stories.js
+++ b/packages/regl-worldview/src/stories/lines.stories.js
@@ -55,4 +55,97 @@ storiesOf("Worldview/Lines", module)
         <Lines>{emptyLine}</Lines>
       </Worldview>
     );
+  })
+  .add("<Lines> line strip (open)", () => {
+    const lines = [
+      {
+        closed: false,
+        pose: {
+          position: { x: 0, y: 0, z: 0 },
+          orientation: { x: 0, y: 0, z: 0, w: 0 },
+        },
+        scale: { x: 0.1, y: 0.1, z: 0.1 },
+        color: { r: 0, g: 1, b: 0, a: 1 },
+        points: [{ x: 0, y: -3, z: 0 }, { x: 1, y: -3, z: 0 }, { x: 1, y: -2, z: 0 }, { x: 0, y: -2, z: 0 }],
+        colors: [],
+        primitive: "line strip",
+      },
+    ];
+    return (
+      <Worldview defaultCameraState={{ distance: 10 }}>
+        <Lines>{lines}</Lines>
+      </Worldview>
+    );
+  })
+  .add("<Lines> line strip (closed)", () => {
+    const lines = [
+      {
+        closed: true,
+        pose: {
+          position: { x: 0, y: 0, z: 0 },
+          orientation: { x: 0, y: 0, z: 0, w: 0 },
+        },
+        scale: { x: 0.1, y: 0.1, z: 0.1 },
+        color: { r: 0, g: 1, b: 0, a: 1 },
+        points: [{ x: 0, y: -3, z: 0 }, { x: 1, y: -3, z: 0 }, { x: 1, y: -2, z: 0 }, { x: 0, y: -2, z: 0 }],
+        colors: [],
+        primitive: "line strip",
+      },
+    ];
+    return (
+      <Worldview defaultCameraState={{ distance: 10 }}>
+        <Lines>{lines}</Lines>
+      </Worldview>
+    );
+  })
+  .add("<Lines> wireframe", () => {
+    const lines = [
+      {
+        pose: {
+          position: { x: 0, y: 0, z: 0 },
+          orientation: { x: 0, y: 0, z: 0, w: 0 },
+        },
+        scale: { x: 0.1, y: 0.1, z: 0.1 },
+        color: { r: 0, g: 1, b: 0, a: 1 },
+        points: [
+          { x: 0, y: -3, z: 1 },
+          { x: 1, y: -2, z: 1 },
+          { x: 0, y: -3, z: 0 },
+          { x: 1, y: -2, z: 0 },
+
+          { x: 0, y: -3, z: 1 },
+          { x: 0, y: -3, z: 0 },
+
+          { x: 1, y: -2, z: 1 },
+          { x: 0.5, y: 0, z: 1 },
+          { x: 1, y: -2, z: 0 },
+          { x: 0.5, y: 0, z: 0 },
+
+          { x: 1, y: -2, z: 1 },
+          { x: 1, y: -2, z: 0 },
+
+          { x: 0.5, y: 0, z: 1 },
+          { x: -1, y: -1, z: 1 },
+          { x: 0.5, y: 0, z: 0 },
+          { x: -1, y: -1, z: 0 },
+
+          { x: 0.5, y: 0, z: 1 },
+          { x: 0.5, y: 0, z: 0 },
+
+          { x: -1, y: -1, z: 1 },
+          { x: 0, y: -3, z: 1 },
+          { x: -1, y: -1, z: 0 },
+          { x: 0, y: -3, z: 0 },
+
+          { x: -1, y: -1, z: 1 },
+          { x: -1, y: -1, z: 0 },
+        ],
+        colors: [],
+      },
+    ];
+    return (
+      <Worldview defaultCameraState={{ distance: 10 }}>
+        <Lines>{lines}</Lines>
+      </Worldview>
+    );
   });


### PR DESCRIPTION
## Summary

We're currently duplicating position data when rendering lines in order to fix an issue on some specific hardware (see #24). 

In this PR I'm implementing an alternative approach, which is to use 4-component vectors for positions. Based on previous experience, we might be causing alignment issues when using `vec3` and different stride/offset values for positions and that could be the reason behind the original problem. 

## Test plan

* All existing tests and stores must pass
* Added new stories for line strip rendering
* I need help in order to test this implementation since I don't have access to the specific hardware. Even when this implementation doesn't duplicate data, this solution won't be good enough if the original problem persists. See #24 for more details and a simple way to reproduce the problem.

## Versioning impact
* Patch