### PR TITLE
Fix worldview triangle hitmap bug

### DIFF
--- a/packages/regl-worldview/package-lock.json
+++ b/packages/regl-worldview/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "regl-worldview",
-	"version": "0.7.3",
+	"version": "0.7.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "license": "Apache-2.0",
   "repository": "cruise-automation/webviz/tree/master/packages/regl-worldview",

--- a/packages/regl-worldview/src/commands/Triangles.js
+++ b/packages/regl-worldview/src/commands/Triangles.js
@@ -59,12 +59,6 @@ const singleColor = (regl) =>
         }
         return props.points;
       },
-      color: (context, props) => {
-        if (shouldConvert(props.colors) || shouldConvert(props.color)) {
-          return getVertexColors(props);
-        }
-        return props.color || props.colors;
-      },
     },
     uniforms: {
       color: (context, props) => {
@@ -125,10 +119,13 @@ const vertexColors = (regl) =>
         return props.points;
       },
       color: (context, props) => {
-        if (shouldConvert(props.colors) || shouldConvert(props.color)) {
+        if (!props.colors || !props.colors.length) {
+          throw new Error(`Invalid empty or null prop "colors" when rendering triangles using vertex colors`);
+        }
+        if (shouldConvert(props.colors)) {
           return getVertexColors(props);
         }
-        return props.color || props.colors;
+        return props.colors;
       },
     },
 


### PR DESCRIPTION
Found when testing. In some cases, when there is an array color and
an array colors on a triangle, the rendering would fail becuase we
incorrectly use the single color instead of the array colors.
