### PR TITLE
Add an imperative `focus()` method to Worldview

### DIFF
--- a/docs/src/3.1.Worldview.mdx
+++ b/docs/src/3.1.Worldview.mdx
@@ -30,6 +30,8 @@ See [MouseEvents](#/docs/api/mouse-events).
 
 ## Keyboard Controls
 
+The keyboard controls are only active if the `<Worldview>` HTMLElement has focus. In order to focus `<Worldview>` programatically, `<Worldview>` exposes a imperative `focus()` method, similar to `HTMLElement.focus()`.
+
 `keyMap` allows you to customize the keyboard controls for Worldview's camera. The `keyMap` is an optional object whose keys are [KeyboardEvent.code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) values, and whose values specify the action to perform when the corresponding key is pressed. To disable a key from the keyboard controls, simply provide a `null`/`false` value for that key. For example, the following would reverse all actions and disable tilting and zooming:
 
     <Worldview keyMap={{

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "license": "Apache-2.0",
   "repository": "cruise-automation/webviz/tree/master/packages/regl-worldview",

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -84,6 +84,7 @@ function handleWorldviewMouseInteraction(
 // takes in children that declaritively define what should be rendered
 export class WorldviewBase extends React.Component<BaseProps, State> {
   _canvas: { current: HTMLCanvasElement | null } = React.createRef();
+  _cameraListener: { current: CameraListener | null } = React.createRef();
   _tick: AnimationFrameID | void;
   _dragStartPos: ?{ x: number, y: number } = null;
 
@@ -180,6 +181,12 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
       worldviewContext.cameraStore.setCameraState(this.props.cameraState);
     }
     worldviewContext.onDirty();
+  }
+
+  focus() {
+    if (this._cameraListener.current) {
+      this._cameraListener.current.focus();
+    }
   }
 
   _onDoubleClick = (e: SyntheticMouseEvent<HTMLCanvasElement>) => {
@@ -334,7 +341,11 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
         {isFixedCamera ? (
           canvasHtml
         ) : (
-          <CameraListener cameraStore={worldviewContext.cameraStore} keyMap={keyMap} shiftKeys={shiftKeys}>
+          <CameraListener
+            cameraStore={worldviewContext.cameraStore}
+            keyMap={keyMap}
+            shiftKeys={shiftKeys}
+            ref={(el) => (this._cameraListener.current = el)}>
             {canvasHtml}
           </CameraListener>
         )}
@@ -350,11 +361,13 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
 
 export type Props = $Diff<React.ElementConfig<typeof WorldviewBase>, Dimensions>;
 
-const Worldview = (props: Props) => (
+const Worldview = React.forwardRef<Props, _>((props: Props, ref) => (
   <ContainerDimensions>
-    {({ width, height, left, top }) => <WorldviewBase width={width} height={height} left={left} top={top} {...props} />}
+    {({ width, height, left, top }) => (
+      <WorldviewBase width={width} height={height} left={left} top={top} ref={ref} {...props} />
+    )}
   </ContainerDimensions>
-);
+));
 
 Worldview.displayName = "Worldview";
 

--- a/packages/regl-worldview/src/camera/CameraListener.js
+++ b/packages/regl-worldview/src/camera/CameraListener.js
@@ -83,6 +83,12 @@ export default class CameraListener extends React.Component<Props> {
     _el.removeEventListener("wheel", this._onWheel, { passive: false });
   }
 
+  focus() {
+    if (this._el) {
+      this._el.focus();
+    }
+  }
+
   _getMouseOnScreen = (mouse: MouseEvent) => {
     const { clientX, clientY } = mouse;
     const { top, left, width, height } = this._rect;

--- a/stories/config.js
+++ b/stories/config.js
@@ -11,6 +11,7 @@ import { withScreenshot } from "storycap";
 
 import "webviz-core/src/styles/global.scss";
 import prepareForScreenshots from "./prepareForScreenshots";
+import withStateReset from "./withStateReset";
 import storiesSetup from "webviz-core/src/stories/setup";
 import waitForFonts from "webviz-core/src/styles/waitForFonts";
 import installChartjs from "webviz-core/src/util/installChartjs";
@@ -29,6 +30,7 @@ addDecorator((storyFn) => {
   return React.createElement(storyFn);
 });
 
+addDecorator(withStateReset);
 addDecorator(withScreenshot);
 addParameters({
   screenshot: {

--- a/stories/withStateReset.js
+++ b/stories/withStateReset.js
@@ -10,7 +10,6 @@ const StoryWrapper = (props) => {
   useEffect(
     () => {
       // Remove leftover modals from the previous story
-      // TODO: [EP-26051] This can be removed when modals remove themselves
       document.querySelectorAll("[data-modalcontainer]").forEach((el) => el.remove());
       localStorage.clear();
 
@@ -25,9 +24,7 @@ const StoryWrapper = (props) => {
       const timer = setImmediate(() => {
         setShowStory(true);
       });
-      return () => {
-        clearTimeout(timer);
-      };
+      return () => clearTimeout(timer);
     },
     [props]
   );

--- a/stories/withStateReset.js
+++ b/stories/withStateReset.js
@@ -1,0 +1,40 @@
+import * as monacoApi from "monaco-editor/esm/vs/editor/editor.api";
+import React, { useEffect, useState } from "react";
+
+import { resetRenderCountsForTests } from "webviz-core/src/panels/NumberOfRenders";
+
+const StoryWrapper = (props) => {
+  const [showStory, setShowStory] = useState(false);
+
+  // Reset the state before rendering the next story
+  useEffect(
+    () => {
+      // Remove leftover modals from the previous story
+      // TODO: [EP-26051] This can be removed when modals remove themselves
+      document.querySelectorAll("[data-modalcontainer]").forEach((el) => el.remove());
+      localStorage.clear();
+
+      // Reset the renderCounts for the NumberOfRenders panel
+      resetRenderCountsForTests();
+
+      // Reset cached monacoApi state
+      monacoApi.editor.getModels().forEach((model) => model.dispose());
+
+      // Unmount the old story before rendering the next one to clear out any stored state
+      setShowStory(false);
+      const timer = setImmediate(() => {
+        setShowStory(true);
+      });
+      return () => {
+        clearTimeout(timer);
+      };
+    },
+    [props]
+  );
+
+  return (showStory && React.createElement(props.storyComponent)) || null;
+};
+
+export default function withStateReset(storyComponent) {
+  return <StoryWrapper storyComponent={storyComponent} />;
+}


### PR DESCRIPTION
In order to allow external code to focus the Worldview element in order to get keyboard
controls working again instead of forcing the user to click the worldview element.

Test plan: Manual