### PR TITLE
Update .flowconfig to support .wasm files (WebAssembly)

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -32,6 +32,7 @@ module.file_ext=.jsx
 module.file_ext=.json
 module.file_ext=.glb
 module.file_ext=.bag
+module.file_ext=.wasm
 
 [lints]
 # Suppress warnings about $Subtype / $Supertype in flow-typed libdefs


### PR DESCRIPTION
## Summary

This is a simple change in `.flowconfig` file to add support for WebAssembly files, which is required by some of the new features we are currently working on.

