### PR TITLE
Disable patching in open source for internal CI

### DIFF
--- a/packages/webviz-core/src/loadWebviz.js
+++ b/packages/webviz-core/src/loadWebviz.js
@@ -178,7 +178,6 @@ const defaultHooks = {
     const { REMOTE_BAG_URL_2_QUERY_KEY } = require("webviz-core/src/util/globalConstants");
     return [REMOTE_BAG_URL_2_QUERY_KEY];
   },
-  maybeUpdateURLToTrackLayout: () => {},
 };
 
 let hooks = defaultHooks;

--- a/packages/webviz-core/src/reducers/panels.js
+++ b/packages/webviz-core/src/reducers/panels.js
@@ -811,8 +811,8 @@ export default function panelsReducer(state: State, action: ActionTypes): State 
     const inScreenshot = inScreenshotTests();
     const params = new URLSearchParams(window.location.search);
     const enableShareableUrl = getExperimentalFeature("shareableUrl");
-    // TODO(Audrey): remove the screenshot env checking after release.
-    const shouldProcessPatch = enableShareableUrl || inScreenshot;
+    // TODO(Audrey): remove the screenshot env checking after release. Don't support patch in open source yet.
+    const shouldProcessPatch = getGlobalHooks().maybeUpdateURLToTrackLayout && (enableShareableUrl || inScreenshot);
     if (shouldProcessPatch) {
       getGlobalHooks().maybeUpdateURLToTrackLayout(oldState, newState);
     } else {


### PR DESCRIPTION
Supporting layout URL patching in open source version causes complexity in managing internal CI right now.  Will add it back later. 