### PR TITLE
Replace react-container-dimensions with custom code in Dimensions

### DIFF
--- a/packages/regl-worldview/package-lock.json
+++ b/packages/regl-worldview/package-lock.json
@@ -24,11 +24,6 @@
 			"resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.1.1.tgz",
 			"integrity": "sha512-Ihn1nZcGIswJ5XGbgFAvVumOgWpvIjBX9jiRlIl46uQG9vJOF51ViBYHF95rEZupuyQbEmhLaDPLQlU7fUTsBg=="
 		},
-		"batch-processor": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
-			"integrity": "sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg="
-		},
 		"distance-to-line-segment": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/distance-to-line-segment/-/distance-to-line-segment-0.2.0.tgz",
@@ -38,14 +33,6 @@
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/earcut/-/earcut-2.1.5.tgz",
 			"integrity": "sha512-QFWC7ywTVLtvRAJTVp8ugsuuGQ5mVqNmJ1cRYeLrSHgP3nycr2RHTJob9OtM0v8ujuoKN0NY1a93J/omeTL1PA=="
-		},
-		"element-resize-detector": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/element-resize-detector/-/element-resize-detector-1.1.14.tgz",
-			"integrity": "sha1-rwZKCmGKggrVcKlcXuxbd74BKME=",
-			"requires": {
-				"batch-processor": "^1.0.0"
-			}
 		},
 		"flow-bin": {
 			"version": "0.80.0",
@@ -58,31 +45,10 @@
 			"resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-2.8.1.tgz",
 			"integrity": "sha512-0YCjVpE3pS5XWlN3J4X7AiAx65+nqAI54LndtVFnQZB6G/FVLkZH8y8V6R3cIoOQR4pUdfwQGd1iwyoXHJ4Qfw=="
 		},
-		"invariant": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"requires": {
-				"loose-envify": "^1.0.0"
-			}
-		},
-		"js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-		},
 		"lodash": {
 			"version": "4.17.11",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
 			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-		},
-		"loose-envify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"requires": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
-			}
 		},
 		"memoize-one": {
 			"version": "5.1.1",
@@ -98,30 +64,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
 			"integrity": "sha1-rsiGr/2wRQcNhWRH32Ls+GFG7EU="
-		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-		},
-		"prop-types": {
-			"version": "15.6.2",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-			"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
-			"requires": {
-				"loose-envify": "^1.3.1",
-				"object-assign": "^4.1.1"
-			}
-		},
-		"react-container-dimensions": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/react-container-dimensions/-/react-container-dimensions-1.3.3.tgz",
-			"integrity": "sha1-XaMB4w3stEn7DO8aKrIQ35cMpx4=",
-			"requires": {
-				"element-resize-detector": "^1.1.10",
-				"invariant": "^2.2.2",
-				"prop-types": "^15.5.8"
-			}
 		},
 		"regl": {
 			"version": "1.3.11",

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -34,7 +34,6 @@
     "memoize-one": "^5.1.1",
     "memoize-weak": "^1.0.2",
     "normalize-wheel": "1.0.1",
-    "react-container-dimensions": "1.3.3",
     "regl": "^1.3.1",
     "reselect": "^3.0.1",
     "shallowequal": "1.1.0"

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -9,7 +9,6 @@
 import mapValues from "lodash/mapValues";
 import pickBy from "lodash/pickBy";
 import * as React from "react";
-import ContainerDimensions from "react-container-dimensions";
 
 import { CameraListener, DEFAULT_CAMERA_STATE } from "./camera/index";
 import Command from "./commands/Command";
@@ -24,6 +23,7 @@ import type {
 } from "./types";
 import aggregate from "./utils/aggregate";
 import { getNodeEnv } from "./utils/common";
+import ContainerDimensions from "./utils/Dimensions";
 import { Ray } from "./utils/Raycast";
 import { WorldviewContext } from "./WorldviewContext";
 import WorldviewReactContext from "./WorldviewReactContext";

--- a/packages/regl-worldview/src/utils/Dimensions.js
+++ b/packages/regl-worldview/src/utils/Dimensions.js
@@ -1,0 +1,81 @@
+// @flow
+//
+//  Copyright (c) 2018-present, GM Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+import React, { useEffect, useState, useCallback, type Node } from "react";
+
+type DimensionsParams = {| height: number, width: number, left: number, top: number |};
+type Props = {|
+  children: (DimensionsParams) => Node,
+|};
+
+// Jest does not include ResizeObserver.
+class ResizeObserverMock {
+  _callback: (ResizeObserverEntry[]) => void;
+  constructor(callback) {
+    this._callback = callback;
+  }
+
+  observe() {
+    const entry: any = { contentRect: { width: 150, height: 150 } };
+    this._callback([entry]);
+  }
+  unobserve() {}
+}
+const ResizeObserverImpl = process.env.NODE_ENV === "test" ? (ResizeObserverMock: any) : ResizeObserver;
+
+// Calculates the dimensions of the parent element, and passes those dimensions to the child function.
+// Uses resizeObserver, which is very performant.
+// Works by rendering an empty div, getting the parent element, and then once we know the dimensions of the parent
+// element, rendering the children. After the initial render it just observes the parent element.
+// We expect the parent element to never change.
+export default function Dimensions({ children }: Props) {
+  const [parentElement, setParentElement] = useState(undefined);
+  const [dimensions, setDimensions] = useState<?DimensionsParams>();
+  // This resizeObserver should never change.
+  const [resizeObserver] = useState<ResizeObserver>(
+    () =>
+      new ResizeObserverImpl((entries) => {
+        if (!entries || !entries.length) {
+          return;
+        }
+
+        // We only observe a single element, so just use the first entry.
+        // We have to round because these could be sub-pixel values.
+        const newWidth = Math.round(entries[0].contentRect.width);
+        const newHeight = Math.round(entries[0].contentRect.height);
+        const newLeft = Math.round(entries[0].contentRect.left);
+        const newTop = Math.round(entries[0].contentRect.top);
+        setDimensions({ width: newWidth, height: newHeight, top: newTop, left: newLeft });
+      })
+  );
+
+  // This should only fire once, because `dimensions` should only be undefined at the beginning.
+  const setParentElementRef = useCallback((element) => {
+    if (element) {
+      setParentElement(element.parentElement);
+    }
+  }, []);
+
+  useEffect(
+    () => {
+      if (!parentElement) {
+        return;
+      }
+      resizeObserver.observe(parentElement);
+      // Make sure to unobserve when we unmount the component.
+      return () => resizeObserver.unobserve(parentElement);
+    },
+    [parentElement, resizeObserver]
+  );
+
+  // This only happens during the first render - we use it to grab the parentElement of this div.
+  if (dimensions == null) {
+    return <div ref={setParentElementRef} />;
+  }
+  return children(dimensions);
+}


### PR DESCRIPTION
Similar to what is coming to the rest of Webviz, but use this in the
Worldview. Replace the inefficient react-container-dimensions with
custom Dimensions.

Test plan: screenshot tests.
