### PR TITLE
Use world units for point sizes

### DIFF
--- a/docs/src/4.8.Points.mdx
+++ b/docs/src/4.8.Points.mdx
@@ -11,6 +11,10 @@ import { Points } from './jsx/allLiveEditors'
 | `children`          | `Point[]` | `[]`           | array of Point markers to render      |
 | `useWorldSpaceSize` | `boolean` | `undefined`    | use world space units for point sizes |
 
+### Using World Space sizes
+
+By default, points are rendered in `view space`, meaninig that their size (in pixels) is constant and not affected by the point's position in the world. In contrast, when the `useWorldSpaceSize` flag is set to `true`, points will be rendered in `world space`, meaning that their size (indicated in world units, i.e. meters) will be calculated based on their distance to the camera.
+
 ### Point
 
 ```js

--- a/docs/src/4.8.Points.mdx
+++ b/docs/src/4.8.Points.mdx
@@ -6,9 +6,10 @@ import { Points } from './jsx/allLiveEditors'
 
 ## Props
 
-| Name       | Type      | Default | Description                      |
-| ---------- | --------- | ------- | -------------------------------- |
-| `children` | `Point[]` | `[]`    | array of Point markers to render |
+| Name                | Type      | Default        | Description                           |
+| ------------------- | --------- | -------------- | ------------------------------------- |
+| `children`          | `Point[]` | `[]`           | array of Point markers to render      |
+| `useWorldSpaceSize` | `boolean` | `undefined`    | use world space units for point sizes |
 
 ### Point
 

--- a/packages/regl-worldview/src/commands/Points.js
+++ b/packages/regl-worldview/src/commands/Points.js
@@ -15,11 +15,11 @@ import Command, { type CommonCommandProps } from "./Command";
 
 type Props = {
   ...CommonCommandProps,
-  children: $ReadOnlyArray<PointType>,
   useWorldSpaceSize?: boolean,
+  children: $ReadOnlyArray<PointType>,
 };
 
-const makePointsCommand = (useWorldSpacePointSize: boolean) => {
+const makePointsCommand = (useWorldSpaceSize: boolean) => {
   return (regl: Regl) => {
     const [min, max] = regl.limits.pointSizeDims;
     return withPose({
@@ -88,7 +88,7 @@ const makePointsCommand = (useWorldSpacePointSize: boolean) => {
           const size = props.scale.x || 1;
           return Math.min(max, Math.max(min, size));
         },
-        useWorldSpacePointSize,
+        useWorldSpaceSize,
         viewportWidth: regl.context("viewportWidth"),
         viewportHeight: regl.context("viewportHeight"),
       },

--- a/packages/regl-worldview/src/commands/Points.js
+++ b/packages/regl-worldview/src/commands/Points.js
@@ -6,64 +6,100 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 
-import * as React from "react";
+import React, { useState } from "react";
 
 import type { PointType, Regl } from "../types";
 import { getVertexColors, pointToVec3, withPose } from "../utils/commandUtils";
 import { createInstancedGetChildrenForHitmap } from "../utils/getChildrenForHitmapDefaults";
 import Command, { type CommonCommandProps } from "./Command";
 
-const points = (regl: Regl) => {
-  const [min, max] = regl.limits.pointSizeDims;
-  return withPose({
-    primitive: "points",
-    vert: `
+type Props = {
+  ...CommonCommandProps,
+  children: $ReadOnlyArray<PointType>,
+  useWorldSpaceSize?: boolean,
+};
+
+const makePointsCommand = (useWorldSpacePointSize: boolean) => {
+  return (regl: Regl) => {
+    const [min, max] = regl.limits.pointSizeDims;
+    return withPose({
+      primitive: "points",
+      vert: `
     precision mediump float;
 
     #WITH_POSE
 
     uniform mat4 projection, view;
     uniform float pointSize;
+    uniform bool useWorldSpaceSize;
+    uniform float viewportWidth;
+    uniform float viewportHeight;
 
     attribute vec3 point;
     attribute vec4 color;
     varying vec4 fragColor;
     void main () {
-      gl_PointSize = pointSize;
       vec3 pos = applyPose(point);
       gl_Position = projection * view * vec4(pos, 1);
       fragColor = color;
+
+      if (useWorldSpaceSize) {
+        // Calculate the point size based on world dimensions:
+        // First, we need to compute a new point that is one unit away from
+        // the center of the current point being rendered. We do it in view space
+        // in order to make sure the new point is always one unit up and it's not
+        // affected by view rotation.
+        vec4 up = projection * (view * vec4(pos, 1.0) + vec4(0.0, 1.0, 0.0, 0.0));
+
+        // Then, we compute the distance between both points in clip space, dividing
+        // by the w-component to account for distance in perspective projection.
+        float d = length(up.xyz / up.w - gl_Position.xyz / gl_Position.w);
+
+        // Finally, the point size is calculated using the size of the render target
+        // and it's aspect ratio. We multiply it by 0.5 since distance in clip space
+        // is in range [0, 2] (because clip space's range is [-1, 1]) and
+        // we need it to be [0, 1].
+        float invAspect = viewportHeight / viewportWidth;
+        gl_PointSize = pointSize * 0.5 * d * viewportWidth * invAspect;
+      } else {
+        gl_PointSize = pointSize;
+      }
     }
     `,
-    frag: `
+      frag: `
     precision mediump float;
     varying vec4 fragColor;
     void main () {
       gl_FragColor = vec4(fragColor.x, fragColor.y, fragColor.z, 1);
     }
     `,
-    attributes: {
-      point: (context, props) => {
-        return props.points.map((point) => (Array.isArray(point) ? point : pointToVec3(point)));
+      attributes: {
+        point: (context, props) => {
+          return props.points.map((point) => (Array.isArray(point) ? point : pointToVec3(point)));
+        },
+        color: (context, props) => {
+          const colors = getVertexColors(props);
+          return colors;
+        },
       },
-      color: (context, props) => {
-        const colors = getVertexColors(props);
-        return colors;
-      },
-    },
 
-    uniforms: {
-      pointSize: (context, props) => {
-        const size = props.scale.x || 1;
-        return Math.min(max, Math.max(min, size));
+      uniforms: {
+        pointSize: (context, props) => {
+          const size = props.scale.x || 1;
+          return Math.min(max, Math.max(min, size));
+        },
+        useWorldSpacePointSize,
+        viewportWidth: regl.context("viewportWidth"),
+        viewportHeight: regl.context("viewportHeight"),
       },
-    },
 
-    count: regl.prop("points.length"),
-  });
+      count: regl.prop("points.length"),
+    });
+  };
 };
 
 const getChildrenForHitmap = createInstancedGetChildrenForHitmap(1);
-export default function Points(props: { ...CommonCommandProps, children: PointType[] }) {
-  return <Command getChildrenForHitmap={getChildrenForHitmap} {...props} reglCommand={points} />;
+export default function Points(props: Props) {
+  const [command] = useState(() => makePointsCommand(!!props.useWorldSpaceSize));
+  return <Command getChildrenForHitmap={getChildrenForHitmap} {...props} reglCommand={command} />;
 }

--- a/packages/regl-worldview/src/stories/Points.stories.js
+++ b/packages/regl-worldview/src/stories/Points.stories.js
@@ -1,0 +1,172 @@
+//  Copyright (c) 2018-present, GM Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+import Worldview, { Points, Cubes } from "../index";
+
+storiesOf("Worldview/Points", module)
+  .add("<Points> - Many points in screen space", () => {
+    const x = 5;
+    const y = x;
+    const z = x;
+    const step = 10;
+    const points = [];
+    const colors = [];
+    for (let i = 0; i < x; i++) {
+      for (let j = 0; j < y; j++) {
+        for (let k = 0; k < z; k++) {
+          points.push({ x: i * step, y: j * step, z: k * step });
+          colors.push({ r: 1 - (1 + i) / x, g: 1 - (1 + j) / y, b: (1 + k) / z, a: 1 });
+        }
+      }
+    }
+
+    const scaleX = 10;
+    const marker = {
+      points,
+      colors,
+      scale: { x: scaleX, y: scaleX, z: scaleX },
+      color: { r: 1, g: 1, b: 1, a: 1 },
+      pose: { position: { x: 0, y: 0, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+    };
+
+    return (
+      <Worldview
+        defaultCameraState={{
+          distance: 100,
+          phi: 1,
+          thetaOffset: 0.7071,
+          targetOffset: [0, 0, 30],
+          perspective: true,
+        }}>
+        <Points>{[marker]}</Points>
+      </Worldview>
+    );
+  })
+  .add("<Points> - World size matches unit cube (orthographic)", () => {
+    return (
+      <Worldview
+        defaultCameraState={{
+          distance: 3,
+          phi: 0.5 * Math.PI,
+          targetOffset: [0, 0, 0],
+          perspective: false,
+        }}>
+        <Points useWorldSpaceSize={true}>
+          {[
+            {
+              points: [{ x: 0, y: 0, z: 0 }],
+              scale: { x: 1, y: 1, z: 1 },
+              color: { r: 1, g: 1, b: 0, a: 0.5 },
+              pose: {
+                position: { x: 0, y: 0, z: 0 },
+                orientation: { x: 0, y: 0, z: 0, w: 1 },
+              },
+            },
+          ]}
+        </Points>
+        <Cubes>
+          {[
+            {
+              pose: {
+                orientation: { x: 0, y: 0, z: 0, w: 1 },
+                position: { x: 0, y: 0, z: 0 },
+              },
+              scale: { x: 1, y: 1, z: 1 },
+              color: { r: 1, g: 0, b: 1, a: 0.5 },
+            },
+          ]}
+        </Cubes>
+      </Worldview>
+    );
+  })
+  .add("<Points> - World size matches unit cube (perspective)", () => {
+    return (
+      <Worldview
+        defaultCameraState={{
+          distance: 3,
+          phi: 0.5 * Math.PI,
+          targetOffset: [0, 0, 0],
+          perspective: true,
+        }}>
+        <Points useWorldSpaceSize={true}>
+          {[
+            {
+              points: [{ x: 0, y: 0, z: 0 }],
+              scale: { x: 1, y: 1, z: 1 },
+              color: { r: 1, g: 1, b: 0, a: 0.5 },
+              pose: {
+                position: { x: 0, y: 0, z: 0 },
+                orientation: { x: 0, y: 0, z: 0, w: 1 },
+              },
+            },
+          ]}
+        </Points>
+        <Cubes>
+          {[
+            {
+              pose: {
+                orientation: { x: 0, y: 0, z: 0, w: 1 },
+                position: { x: 0, y: 0, z: 0 },
+              },
+              scale: { x: 1, y: 1, z: 1 },
+              color: { r: 1, g: 0, b: 1, a: 0.5 },
+            },
+          ]}
+        </Cubes>
+      </Worldview>
+    );
+  })
+  .add("<Points> - Many points in world space, with cubes for reference", () => {
+    const x = 5;
+    const y = x;
+    const z = x;
+    const step = 10;
+    const points = [];
+    const colors = [];
+    for (let i = 0; i < x; i++) {
+      for (let j = 0; j < y; j++) {
+        for (let k = 0; k < z; k++) {
+          points.push({ x: i * step, y: j * step, z: k * step });
+          colors.push({ r: 1 - (1 + i) / x, g: 1 - (1 + j) / y, b: (1 + k) / z, a: 1 });
+        }
+      }
+    }
+
+    const scaleX = 2;
+    const marker = {
+      points,
+      colors,
+      scale: { x: scaleX, y: scaleX, z: scaleX },
+      color: { r: 1, g: 1, b: 1, a: 1 },
+      pose: { position: { x: 0, y: 0, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+    };
+
+    return (
+      <Worldview
+        defaultCameraState={{
+          distance: 20,
+          phi: 1,
+          thetaOffset: 0.7071,
+          targetOffset: [0, 0, 30],
+          perspective: true,
+        }}>
+        <Points useWorldSpaceSize={true}>{[marker]}</Points>
+        <Cubes>
+          {points.map((p) => ({
+            pose: {
+              orientation: { x: 0, y: 0, z: 0, w: 1 },
+              position: p,
+            },
+            scale: { x: scaleX, y: scaleX, z: scaleX },
+            color: { r: 1, g: 0, b: 1, a: 0.2 },
+          }))}
+        </Cubes>
+      </Worldview>
+    );
+  });

--- a/packages/regl-worldview/src/stories/assertionStories/Points.stories.js
+++ b/packages/regl-worldview/src/stories/assertionStories/Points.stories.js
@@ -44,9 +44,13 @@ const instancedPoints = {
 };
 
 const stories = storiesOf("Integration/Points", module);
+
+// $FlowFixMe - Flow does not like that `<Points />` has optional properties
 generateNonInstancedClickAssertions<PointType>("Point", Points, twoPointsInARow).forEach(({ name, story }) =>
   stories.add(name, story)
 );
+
+// $FlowFixMe - Flow does not like that `<Points />` has optional properties
 generateInstancedClickAssertions<PointType>("Point", Points, instancedPoints).forEach(({ name, story }) =>
   stories.add(name, story)
 );

--- a/packages/regl-worldview/src/types/index.js
+++ b/packages/regl-worldview/src/types/index.js
@@ -41,6 +41,7 @@ export type Regl = {
     pointSizeDims: [number, number],
   },
   prop: (string) => any,
+  context: (string) => any,
 };
 
 export type CommandProps = {


### PR DESCRIPTION
By default, <Points /> uses the `scale` property to determine the size of all points. `gl_PointSize` expects values in pixels rather than in units in world space, though.

The changes in this commit introduce a new optional flag to use world space point sizes instead of pixels. In order to accomplish that goal, the vertex shader computes a scaled point size based on the current view transformation and render target size.

Test plan: Added new stories for `<Points />` command, using both screen and world space point sizes with unit cubes for reference.

## Versioning impact

Minor: the new flag is used to ensure backward compatibility
