### PR TITLE
Increase canvas resolution by using device's pixel ratio

### DIFF
--- a/docs/src/3.1.Worldview.mdx
+++ b/docs/src/3.1.Worldview.mdx
@@ -21,7 +21,7 @@
 | `onMouseMove`         | `MouseHandler`                                  |                        |                                                                                                         |
 | `onClick`             | `MouseHandler`                                  |                        |                                                                                                         |
 | `hitmapOnMouseMove`   | `boolean`                                       |                        | (DEPRECATED: see `disableHitmapForEvents`) if enabled, the clicked object will be returned from the mouse event handler. Disabled by default for performance reasons. |
-| `resolutionScale`     | `number`                                        |                        | if present, the `canvas` element will be scaled by the given amount, improving the final render quality.
+| `resolutionScale`     | `number`                                        | `1`                    | if present, the `canvas` element will be scaled by the given amount, improving the final render quality.
 
 _All props are optional._
 

--- a/docs/src/3.1.Worldview.mdx
+++ b/docs/src/3.1.Worldview.mdx
@@ -21,6 +21,7 @@
 | `onMouseMove`         | `MouseHandler`                                  |                        |                                                                                                         |
 | `onClick`             | `MouseHandler`                                  |                        |                                                                                                         |
 | `hitmapOnMouseMove`   | `boolean`                                       |                        | (DEPRECATED: see `disableHitmapForEvents`) if enabled, the clicked object will be returned from the mouse event handler. Disabled by default for performance reasons. |
+| `resolutionScale`     | `number`                                        |                        | if present, the `canvas` element will be scaled by the given amount, improving the final render quality.
 
 _All props are optional._
 

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -58,6 +58,9 @@ export type BaseProps = {|
   onMouseUp?: MouseHandler,
   onMouseMove?: MouseHandler,
   onClick?: MouseHandler,
+
+  // Used to scale the canvas resolution and provide a higher image quality
+  resolutionScale?: number,
   ...Dimensions,
 |};
 
@@ -314,18 +317,28 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
   }
 
   render() {
-    const { width, height, showDebug, keyMap, shiftKeys, style, cameraState, onCameraStateChange } = this.props;
+    const {
+      width,
+      height,
+      showDebug,
+      keyMap,
+      shiftKeys,
+      style,
+      cameraState,
+      onCameraStateChange,
+      resolutionScale,
+    } = this.props;
     const { worldviewContext } = this.state;
     // If we are supplied controlled camera state and no onCameraStateChange callback
     // then there is a 'fixed' camera from outside of worldview itself.
     const isFixedCamera = cameraState && !onCameraStateChange;
-    const devicePixelRatio = window.devicePixelRatio || 1;
+    const canvasScale = resolutionScale || 1;
     const canvasHtml = (
       <React.Fragment>
         <canvas
           style={{ width, height, maxWidth: "100%", maxHeight: "100%" }}
-          width={width * devicePixelRatio}
-          height={height * devicePixelRatio}
+          width={width * canvasScale}
+          height={height * canvasScale}
           ref={this._canvas}
           onMouseUp={this._onMouseUp}
           onMouseDown={this._onMouseDown}

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -333,12 +333,13 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     // If we are supplied controlled camera state and no onCameraStateChange callback
     // then there is a 'fixed' camera from outside of worldview itself.
     const isFixedCamera = cameraState && !onCameraStateChange;
+    const canvasScale = resolutionScale || 1;
     const canvasHtml = (
       <React.Fragment>
         <canvas
           style={{ width, height, maxWidth: "100%", maxHeight: "100%" }}
-          width={width * resolutionScale}
-          height={height * resolutionScale}
+          width={width * canvasScale}
+          height={height * canvasScale}
           ref={this._canvas}
           onMouseUp={this._onMouseUp}
           onMouseDown={this._onMouseDown}

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -96,6 +96,7 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     backgroundColor: DEFAULT_BACKGROUND_COLOR,
     shiftKeys: true,
     style: {},
+    resolutionScale: 1,
   };
 
   constructor(props: BaseProps) {
@@ -332,13 +333,12 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     // If we are supplied controlled camera state and no onCameraStateChange callback
     // then there is a 'fixed' camera from outside of worldview itself.
     const isFixedCamera = cameraState && !onCameraStateChange;
-    const canvasScale = resolutionScale || 1;
     const canvasHtml = (
       <React.Fragment>
         <canvas
           style={{ width, height, maxWidth: "100%", maxHeight: "100%" }}
-          width={width * canvasScale}
-          height={height * canvasScale}
+          width={width * resolutionScale}
+          height={height * resolutionScale}
           ref={this._canvas}
           onMouseUp={this._onMouseUp}
           onMouseDown={this._onMouseDown}

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -319,12 +319,13 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     // If we are supplied controlled camera state and no onCameraStateChange callback
     // then there is a 'fixed' camera from outside of worldview itself.
     const isFixedCamera = cameraState && !onCameraStateChange;
+    const devicePixelRatio = window.devicePixelRatio || 1;
     const canvasHtml = (
       <React.Fragment>
         <canvas
           style={{ width, height, maxWidth: "100%", maxHeight: "100%" }}
-          width={width}
-          height={height}
+          width={width * devicePixelRatio}
+          height={height * devicePixelRatio}
           ref={this._canvas}
           onMouseUp={this._onMouseUp}
           onMouseDown={this._onMouseDown}


### PR DESCRIPTION
Worldview is not using the `devicePixelRatio` property to resize the `canvas`, which does not take advantage of high resolution screens (like Retina). 

![with_antialiasing](https://user-images.githubusercontent.com/1727802/93506675-fa19f280-f8f2-11ea-9464-6d8046b5ae5c.png)

In this PR, I'm adding a new property to `Worldview` named `resolutionScale`. If present, the `canvas` element will be scaled accordingly, which will let us have better control over the final image quality. The following image shows `resolutionScale` set to `devicePixelRatio`:

![with_antialiasing_and_device_pixel_ratio](https://user-images.githubusercontent.com/1727802/93506662-f5edd500-f8f2-11ea-832c-2d8a95cf5962.png)

## Test plan

There should be no differences in stories.

## Versioning impact

Minor
