### PR TITLE
Do not require a scene in GLTF

### DIFF
--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "license": "Apache-2.0",
   "repository": "cruise-automation/webviz/tree/master/packages/regl-worldview",

--- a/packages/regl-worldview/src/commands/GLTFScene.js
+++ b/packages/regl-worldview/src/commands/GLTFScene.js
@@ -38,6 +38,14 @@ function glConstantToRegl(value: ?number): ?string {
   throw new Error(`unhandled constant value ${JSON.stringify(value)}`);
 }
 
+const getSceneToDraw = ({ json }) => {
+  if (json.scene != null) {
+    return json.scene;
+  }
+  // Draw the first scene if the scene key is missing.
+  return Object.keys(json.scenes)[0];
+};
+
 const drawModel = (regl) => {
   const command = regl({
     primitive: "triangles",
@@ -179,8 +187,9 @@ const drawModel = (regl) => {
       }
     }
 
-    // finally, draw each of the main scene's nodes
-    for (const nodeIdx of model.json.scenes[model.json.scene].nodes) {
+    // finally, draw each of the main scene's nodes. Use the first scene if one isn't specified
+    // explicitly.
+    for (const nodeIdx of model.json.scenes[getSceneToDraw(model)].nodes) {
       const rootTransform = mat4.create();
       mat4.rotateX(rootTransform, rootTransform, Math.PI / 2);
       mat4.rotateY(rootTransform, rootTransform, Math.PI / 2);

--- a/packages/regl-worldview/src/commands/GLTFScene.js
+++ b/packages/regl-worldview/src/commands/GLTFScene.js
@@ -43,7 +43,11 @@ const getSceneToDraw = ({ json }) => {
     return json.scene;
   }
   // Draw the first scene if the scene key is missing.
-  return Object.keys(json.scenes)[0];
+  const keys = Object.keys(json.scenes ?? {});
+  if (keys.length === 0) {
+    throw new Error("No scenes to render");
+  }
+  return keys[0];
 };
 
 const drawModel = (regl) => {


### PR DESCRIPTION
The `scene` property is optional. If it's not specified, use "the first"
scene.

In a .glb file I opened that didn't have a specified scene, there was
one key in the `scenes` object: `"0"`. In GLTF 2 `scenes` is an array, so
we might be able to get away with just `scenes[0]`, but this seems
slightly more robust.

I don't think we need to be super careful about files without scenes.
Maybe we want some controls for the scene to draw to be specified in the
command if there could be more than one, but let's not worry about that
until we come across it.

Tested by loading a file up in the worldview docs site locally. I don't have
a publicly available .glb example.