### PR TITLE
Support changing the color of laserscans.

### DIFF
--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/LaserScanVert.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/LaserScanVert.js
@@ -18,11 +18,12 @@ export default `
   uniform float range_min;
   uniform float range_max;
   uniform bool isHitmap;
+  uniform vec4 hitmapColor;
+  uniform vec4 overrideColor;
 
   attribute float index;
   attribute float range;
   attribute float intensity;
-  attribute vec4 hitmapColor;
 
   varying vec4 vColor;
 
@@ -38,7 +39,7 @@ export default `
     } else if (isHitmap) {
       vColor = hitmapColor;
     } else {
-      vColor = vec4(0.5, 0.5, 1, 1);
+      vColor = overrideColor;
     }
   }
 `;

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/LaserScanSettingsEditor.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/LaserScanSettingsEditor.js
@@ -7,8 +7,11 @@
 //  You may not use this file except in compliance with the License.
 
 import React from "react";
+import { type Color } from "regl-worldview";
 
 import { CommonPointSettings, CommonDecaySettings, type TopicSettingsEditorProps } from ".";
+import ColorPickerForTopicSettings from "./ColorPickerForTopicSettings";
+import { SLabel } from "./common";
 import Flex from "webviz-core/src/components/Flex";
 import type { LaserScan } from "webviz-core/src/types/Messages";
 
@@ -16,7 +19,9 @@ type LaserScanSettings = {|
   pointSize?: ?number,
   pointShape?: ?string,
   decayTime?: ?number,
+  overrideColor: ?Color,
 |};
+
 export default function LaserScanSettingsEditor(props: TopicSettingsEditorProps<LaserScan, LaserScanSettings>) {
   const { settings, onFieldChange } = props;
 
@@ -29,6 +34,12 @@ export default function LaserScanSettingsEditor(props: TopicSettingsEditorProps<
         onFieldChange={onFieldChange}
       />
       <CommonDecaySettings settings={settings} onFieldChange={onFieldChange} />
+
+      <SLabel>Color</SLabel>
+      <ColorPickerForTopicSettings
+        color={settings.overrideColor}
+        onChange={(newColor) => onFieldChange("overrideColor", newColor)}
+      />
     </Flex>
   );
 }

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/commands/LaserScans.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/commands/LaserScans.js
@@ -11,6 +11,7 @@ import * as React from "react";
 import {
   Command,
   withPose,
+  toRGBA,
   type Regl,
   type CommonCommandProps,
   nonInstancedGetChildrenForHitmap,
@@ -18,6 +19,8 @@ import {
 
 import { getGlobalHooks } from "webviz-core/src/loadWebviz";
 import type { LaserScan } from "webviz-core/src/types/Messages";
+
+export const DEFAULT_FLAT_COLOR = { r: 0.5, g: 0.5, b: 1, a: 1 };
 
 const laserScan = (regl: Regl) =>
   withPose({
@@ -47,6 +50,9 @@ const laserScan = (regl: Regl) =>
       angle_increment: regl.prop("angle_increment"),
       range_min: regl.prop("range_min"),
       range_max: regl.prop("range_max"),
+
+      overrideColor: (context, props) => toRGBA(props.settings?.overrideColor || DEFAULT_FLAT_COLOR),
+      hitmapColor: (context, props) => props.color || [0, 0, 0, 1],
     },
 
     attributes: {
@@ -56,7 +62,6 @@ const laserScan = (regl: Regl) =>
         props.intensities.length === props.ranges.length
           ? props.intensities
           : new Float32Array(props.ranges.length).fill(1),
-      hitmapColor: (context, props) => new Array(props.ranges.length).fill(props.color || [0, 0, 0, 1]),
     },
 
     count: regl.prop("ranges.length"),


### PR DESCRIPTION
## Summary

This PR adds functionality to change the color of the points drawn for `LaserScan` messages in the 3D panel.

### What's the motivation for this change
One of the problems we (fyi @jasonimercer) were having is that the default color for laser scans was a tint of purple. This purple was hard to see on a standard `OccupancyGrid`, which defaults to grey for empty cells:

![not_really_visible](https://user-images.githubusercontent.com/1732289/96350838-b519e500-1085-11eb-9fb1-234dfb4f638a.png)


With the changes in this PR, the color of that laser scan can be changed to bright red, which makes the points stand out clearly:
![better](https://user-images.githubusercontent.com/1732289/96351191-d085ef80-1087-11eb-94af-2dea340c5c6a.png)

The LaserScan topic settings look like this:
![LaserScanTopicSettings](https://user-images.githubusercontent.com/1732289/96351622-b39eeb80-108a-11eb-85eb-4cbf6ace90c8.png)


The second benefit is that this allows us to distinguish which sensor the points are coming from, as we can make different topics different colors it provides us additional information about the source of the data.

### what approach did you take, and why?
I looked at how the `PointCloud` topic handles the color selection in [PointCloudSettingsEditor](https://github.com/cruise-automation/webviz/blob/master/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PointCloudSettingsEditor.js) and copied parts from there to modify the `LaserScanSettingsEditor` to add a color picker. After that I modified the `LaserScanVert.js` and `LaserScan.js` files to populate an extra attribute to hold the now configurable fallback color.

I briefly looked at setting the `isHitmap` attribute instead and using the `hitmapColor` attribute, because this [comment](https://github.com/cruise-automation/webviz/blob/master/packages/webviz-core/src/panels/ThreeDimensionalViz/commands/LaserScans.js#L42-L44) refers to that impacting the color, that way the `hitmapColor` could be reused. But I couldn't quite figure out how that all worked, and taking that approach would've required me to support a toggle or something in the topic settings, and a [toggle](https://github.com/cruise-automation/webviz/blob/master/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PointCloudSettingsEditor.js#L103-L237) seemed like more work than I was willing to do on a Saturday.

I have tried to keep the color handling identical to the PointCloudSettings, such that the code is already positioned to support the other functionality such as [gradient](https://github.com/cruise-automation/webviz/blob/master/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PointCloudSettingsEditor.js#L26-L33). I can see this being useful for a future addition where a gradient can selected to color map by intensity. RViz for example supports coloring by intensity.

## Test plan
I ran the development environment with `npm run docs` and tested by dragging a bag with two laserscan topics into the browser. On initialisation the color is the standard fallback color, but this can now be changed per topic in the settings. Exporting the layout does contain the topics' color information and importing it does apply the coloring settings. The alpha channel does not seem to work, I did not find an easy way to disable that in the color picker.

I have ran the linter with `npm run lint` and fixed things until it was happy. Node `v10.22.0` was used.

I'm not super familiar with Node / Modern Javascript, so I hope I haven't missed anything.

## Versioning impact
I believe this is a minor feature improvement that is fully backwards compatible, as such I would just mark it as a patch.