### PR TITLE
Add support for custom render states on geometry-based commands

### DIFF
--- a/docs/src/4.1.Arrows.mdx
+++ b/docs/src/4.1.Arrows.mdx
@@ -9,6 +9,8 @@ import { Arrows, ArrowsInteractive } from './jsx/allLiveEditors'
 | Name       | Type                         | Default | Description                      |
 | ---------- | ---------------------------- | ------- | -------------------------------- |
 | `children` | `(PoseArrow | PointArrow)[]` | `[]`    | array of Arrow markers to render |
+| `depth`    | `DepthState` | `undefined` | optional depth state settings   |
+| `blend`    | `BlendState` | `undefined` | optional blend state settings   |
 
 ### PoseArrow
 

--- a/docs/src/4.2.Cones.mdx
+++ b/docs/src/4.2.Cones.mdx
@@ -9,6 +9,8 @@ import { Cones } from './jsx/allLiveEditors'
 | Name       | Type     | Default | Description                     |
 | ---------- | -------- | ------- | ------------------------------- |
 | `children` | `Cone[]` | `[]`    | array of Cone markers to render |
+| `depth`    | `DepthState` | `undefined` | optional depth state settings   |
+| `blend`    | `BlendState` | `undefined` | optional blend state settings   |
 
 ### Cone
 

--- a/docs/src/4.3.Cubes.mdx
+++ b/docs/src/4.3.Cubes.mdx
@@ -9,6 +9,8 @@ import { Cubes } from './jsx/allLiveEditors'
 | Name       | Type     | Default | Description                     |
 | ---------- | -------- | ------- | ------------------------------- |
 | `children` | `Cube[]` | `[]`    | array of cube markers to render |
+| `depth`    | `DepthState` | `undefined` | optional depth state settings   |
+| `blend`    | `BlendState` | `undefined` | optional blend state settings   |
 
 ### Cube
 

--- a/docs/src/4.4.Cylinders.mdx
+++ b/docs/src/4.4.Cylinders.mdx
@@ -9,6 +9,8 @@ import { Cylinders } from './jsx/allLiveEditors'
 | Name       | Type         | Default | Description                         |
 | ---------- | ------------ | ------- | ----------------------------------- |
 | `children` | `Cylinder[]` | `[]`    | array of Cylinder markers to render |
+| `depth`    | `DepthState` | `undefined` | optional depth state settings   |
+| `blend`    | `BlendState` | `undefined` | optional blend state settings   |
 
 ### Cylinder
 

--- a/docs/src/4.9.Spheres.mdx
+++ b/docs/src/4.9.Spheres.mdx
@@ -9,6 +9,8 @@ import {SpheresSingle, SpheresInstanced, SpheresInstancedColor} from './jsx/allL
 | Name       | Type       | Default | Description                       |
 | ---------- | ---------- | ------- | --------------------------------- |
 | `children` | `Sphere[]` | `[]`    | array of Sphere markers to render |
+| `depth`    | `DepthState` | `undefined` | optional depth state settings   |
+| `blend`    | `BlendState` | `undefined` | optional blend state settings   |
 
 ### Sphere
 

--- a/packages/regl-worldview/src/commands/Cones.js
+++ b/packages/regl-worldview/src/commands/Cones.js
@@ -11,12 +11,13 @@ import * as React from "react";
 import type { Cone } from "../types";
 import fromGeometry from "../utils/fromGeometry";
 import { createInstancedGetChildrenForHitmap } from "../utils/getChildrenForHitmapDefaults";
+import withRenderStateOverrides from "../utils/withRenderStateOverrides";
 import Command, { type CommonCommandProps } from "./Command";
 import { createCylinderGeometry } from "./Cylinders";
 
 const { points, sideFaces, endCapFaces } = createCylinderGeometry(30, true);
 
-const cones = fromGeometry(points, sideFaces.concat(endCapFaces));
+const cones = withRenderStateOverrides(fromGeometry(points, sideFaces.concat(endCapFaces)));
 
 const getChildrenForHitmap = createInstancedGetChildrenForHitmap(1);
 export default function Cones(props: { ...CommonCommandProps, children: Cone[] }) {

--- a/packages/regl-worldview/src/commands/Cubes.js
+++ b/packages/regl-worldview/src/commands/Cubes.js
@@ -11,41 +11,44 @@ import * as React from "react";
 import type { Cube } from "../types";
 import fromGeometry from "../utils/fromGeometry";
 import { createInstancedGetChildrenForHitmap } from "../utils/getChildrenForHitmapDefaults";
+import withRenderStateOverrides from "../utils/withRenderStateOverrides";
 import Command, { type CommonCommandProps } from "./Command";
 
-const cubes = fromGeometry(
-  [
-    // bottom face corners
-    [-0.5, -0.5, -0.5],
-    [-0.5, 0.5, -0.5],
-    [0.5, -0.5, -0.5],
-    [0.5, 0.5, -0.5],
-    // top face corners
-    [-0.5, -0.5, 0.5],
-    [-0.5, 0.5, 0.5],
-    [0.5, -0.5, 0.5],
-    [0.5, 0.5, 0.5],
-  ],
-  [
-    // bottom
-    [0, 1, 2],
-    [1, 2, 3],
-    // top
-    [4, 5, 6],
-    [5, 6, 7],
-    // left
-    [0, 2, 4],
-    [2, 4, 6],
-    // right
-    [1, 3, 5],
-    [3, 5, 7],
-    //front
-    [2, 3, 6],
-    [3, 6, 7],
-    //back
-    [0, 1, 4],
-    [1, 4, 5],
-  ]
+const cubes = withRenderStateOverrides(
+  fromGeometry(
+    [
+      // bottom face corners
+      [-0.5, -0.5, -0.5],
+      [-0.5, 0.5, -0.5],
+      [0.5, -0.5, -0.5],
+      [0.5, 0.5, -0.5],
+      // top face corners
+      [-0.5, -0.5, 0.5],
+      [-0.5, 0.5, 0.5],
+      [0.5, -0.5, 0.5],
+      [0.5, 0.5, 0.5],
+    ],
+    [
+      // bottom
+      [0, 1, 2],
+      [1, 2, 3],
+      // top
+      [4, 5, 6],
+      [5, 6, 7],
+      // left
+      [0, 2, 4],
+      [2, 4, 6],
+      // right
+      [1, 3, 5],
+      [3, 5, 7],
+      //front
+      [2, 3, 6],
+      [3, 6, 7],
+      //back
+      [0, 1, 4],
+      [1, 4, 5],
+    ]
+  )
 );
 
 const getChildrenForHitmap = createInstancedGetChildrenForHitmap(1);

--- a/packages/regl-worldview/src/commands/Cylinders.js
+++ b/packages/regl-worldview/src/commands/Cylinders.js
@@ -11,6 +11,7 @@ import * as React from "react";
 import type { Cylinder } from "../types";
 import fromGeometry from "../utils/fromGeometry";
 import { createInstancedGetChildrenForHitmap } from "../utils/getChildrenForHitmapDefaults";
+import withRenderStateOverrides from "../utils/withRenderStateOverrides";
 import Command, { type CommonCommandProps } from "./Command";
 
 export function createCylinderGeometry(numSegments: number, cone: boolean) {
@@ -47,7 +48,7 @@ export function createCylinderGeometry(numSegments: number, cone: boolean) {
 
 const { points, sideFaces, endCapFaces } = createCylinderGeometry(30, false);
 
-const cylinders = fromGeometry(points, sideFaces.concat(endCapFaces));
+const cylinders = withRenderStateOverrides(fromGeometry(points, sideFaces.concat(endCapFaces)));
 
 const getChildrenForHitmap = createInstancedGetChildrenForHitmap(1);
 export default function Cylinders(props: { ...CommonCommandProps, children: Cylinder[] }) {

--- a/packages/regl-worldview/src/commands/Spheres.js
+++ b/packages/regl-worldview/src/commands/Spheres.js
@@ -11,6 +11,7 @@ import * as React from "react";
 import type { SphereList } from "../types";
 import fromGeometry from "../utils/fromGeometry";
 import { createInstancedGetChildrenForHitmap } from "../utils/getChildrenForHitmapDefaults";
+import withRenderStateOverrides from "../utils/withRenderStateOverrides";
 import Command, { type CommonCommandProps } from "./Command";
 
 const NUM_PARALLELS = 15;
@@ -54,7 +55,7 @@ for (let j = 0; j < NUM_MERIDIANS; j++) {
   faces.push([pt, prevPt, 1]);
 }
 
-const spheres = fromGeometry(points, faces);
+const spheres = withRenderStateOverrides(fromGeometry(points, faces));
 
 const getChildrenForHitmap = createInstancedGetChildrenForHitmap(1);
 export default function Spheres(props: { ...CommonCommandProps, children: SphereList[] }) {

--- a/packages/regl-worldview/src/stories/Arrows.stories.js
+++ b/packages/regl-worldview/src/stories/Arrows.stories.js
@@ -1,0 +1,52 @@
+//  Copyright (c) 2018-present, GM Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+import { withKnobs } from "@storybook/addon-knobs";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+import Worldview, { Arrows, Axes } from "../index";
+import { withCustomRenderStates } from "./util";
+
+storiesOf("Worldview/Arrows", module)
+  .addDecorator(withKnobs)
+  .add("<Arrows> with pose and custom depth and blend values", () => {
+    const poseArrow = (shift) => ({
+      pose: {
+        orientation: { x: 0, y: 0, z: -1, w: 0.5 },
+        position: { x: shift, y: 0, z: 0 },
+      },
+      scale: { x: 20, y: 3, z: 3 },
+      color: { r: 1, g: 0, b: 0, a: 1 },
+    });
+
+    const arrows1 = [poseArrow(-3), poseArrow(0)];
+    const arrows2 = [poseArrow(3), poseArrow(0)];
+
+    return (
+      <Worldview>
+        <Arrows>{withCustomRenderStates(arrows1, arrows2)}</Arrows>
+        <Axes />
+      </Worldview>
+    );
+  })
+  .add("<Arrows> with points and custom depth and blend values", () => {
+    const pointArrow = (shift) => ({
+      color: { r: 0, g: 0, b: 1, a: 1 },
+      points: [{ x: 0 + shift, y: 0, z: 0 }, { x: 10 + shift, y: 10, z: 10 }],
+      scale: { x: 2, y: 2, z: 3 },
+    });
+
+    const arrows1 = [pointArrow(-3), pointArrow(0)];
+    const arrows2 = [pointArrow(3), pointArrow(0)];
+
+    return (
+      <Worldview>
+        <Arrows>{withCustomRenderStates(arrows1, arrows2)}</Arrows>
+        <Axes />
+      </Worldview>
+    );
+  });

--- a/packages/regl-worldview/src/stories/Cones.stories.js
+++ b/packages/regl-worldview/src/stories/Cones.stories.js
@@ -1,0 +1,47 @@
+//  Copyright (c) 2018-present, GM Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+import { withKnobs } from "@storybook/addon-knobs";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+import { Cones } from "../index";
+import Container from "./Container";
+import { withCustomRenderStates } from "./util";
+
+storiesOf("Worldview/Cones", module)
+  .addDecorator(withKnobs)
+  .add("<Cones> with custom depth and blend values", () => {
+    return (
+      <Container cameraState={{ perspective: true, phi: 1.83, thetaOffset: -1.1 }}>
+        <Cones>
+          {withCustomRenderStates(
+            [
+              {
+                pose: {
+                  orientation: { x: 0, y: 0, z: 0, w: 1 },
+                  position: { x: 0, y: 0, z: 0 },
+                },
+                scale: { x: 10, y: 10, z: 10 },
+                color: { r: 1, g: 0, b: 1, a: 0.5 },
+              },
+            ],
+            [
+              {
+                pose: {
+                  orientation: { x: 0, y: 0, z: 0, w: 1 },
+                  position: { x: 0, y: 0, z: 0 },
+                },
+                scale: { x: 10, y: 10, z: 10 },
+                color: { r: 1, g: 1, b: 0, a: 0.5 },
+                points: [{ x: -10, y: 10, z: 10 }, { x: -20, y: 5, z: 10 }],
+              },
+            ]
+          )}
+        </Cones>
+      </Container>
+    );
+  });

--- a/packages/regl-worldview/src/stories/Cubes.stories.js
+++ b/packages/regl-worldview/src/stories/Cubes.stories.js
@@ -5,7 +5,7 @@ import React from "react";
 
 import type { MouseHandler } from "../types";
 import Container from "./Container";
-import { cube, p, UNIT_QUATERNION, buildMatrix, rng } from "./util";
+import { cube, p, UNIT_QUATERNION, buildMatrix, rng, withCustomRenderStates } from "./util";
 import withRange from "./withRange";
 
 import { Cubes, DEFAULT_CAMERA_STATE } from "..";
@@ -140,4 +140,12 @@ storiesOf("Worldview/Cubes", module)
         </Container>
       );
     })
-  );
+  )
+  .add("<Cubes> - with custom depth and blend values", () => {
+    const cubes = withCustomRenderStates([cube(0)], [cube(1)]);
+    return (
+      <Container cameraState={{ perspective: true }}>
+        <Wrapper cubes={cubes} />
+      </Container>
+    );
+  });

--- a/packages/regl-worldview/src/stories/Cylinders.stories.js
+++ b/packages/regl-worldview/src/stories/Cylinders.stories.js
@@ -1,0 +1,47 @@
+//  Copyright (c) 2018-present, GM Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+import { withKnobs } from "@storybook/addon-knobs";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+import { Cylinders } from "../index";
+import Container from "./Container";
+import { withCustomRenderStates } from "./util";
+
+storiesOf("Worldview/Cylinders", module)
+  .addDecorator(withKnobs)
+  .add("<Cylinders> with custom depth and blend values", () => {
+    return (
+      <Container cameraState={{ perspective: true, phi: 1.83, thetaOffset: -1.1 }}>
+        <Cylinders>
+          {withCustomRenderStates(
+            [
+              {
+                pose: {
+                  orientation: { x: 0, y: 0, z: 0, w: 1 },
+                  position: { x: 0, y: 0, z: 0 },
+                },
+                scale: { x: 10, y: 10, z: 10 },
+                color: { r: 1, g: 0, b: 1, a: 0.5 },
+              },
+            ],
+            [
+              {
+                pose: {
+                  orientation: { x: 0, y: 0, z: 0, w: 1 },
+                  position: { x: 0, y: 0, z: 0 },
+                },
+                scale: { x: 10, y: 10, z: 10 },
+                color: { r: 1, g: 1, b: 0, a: 0.5 },
+                points: [{ x: -10, y: 10, z: 10 }, { x: -20, y: 5, z: 10 }],
+              },
+            ]
+          )}
+        </Cylinders>
+      </Container>
+    );
+  });

--- a/packages/regl-worldview/src/stories/Spheres.stories.js
+++ b/packages/regl-worldview/src/stories/Spheres.stories.js
@@ -1,0 +1,46 @@
+//  Copyright (c) 2018-present, GM Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+import { withKnobs } from "@storybook/addon-knobs";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+import { Spheres } from "../index";
+import Container from "./Container";
+import { withCustomRenderStates } from "./util";
+
+storiesOf("Worldview/Spheres", module)
+  .addDecorator(withKnobs)
+  .add("<Spheres> with custom depth and blend values", () => {
+    return (
+      <Container cameraState={{ perspective: true, phi: 1.83, thetaOffset: -1.1 }}>
+        <Spheres>
+          {withCustomRenderStates(
+            [
+              {
+                pose: {
+                  orientation: { x: 0, y: 0, z: 0, w: 1 },
+                  position: { x: 3, y: 0, z: 0 },
+                },
+                scale: { x: 10, y: 10, z: 10 },
+                color: { r: 1, g: 0, b: 1, a: 0.5 },
+              },
+            ],
+            [
+              {
+                pose: {
+                  orientation: { x: 0, y: 0, z: 0, w: 1 },
+                  position: { x: 0, y: 0, z: 0 },
+                },
+                scale: { x: 10, y: 10, z: 10 },
+                color: { r: 1, g: 0, b: 1, a: 0.5 },
+              },
+            ]
+          )}
+        </Spheres>
+      </Container>
+    );
+  });

--- a/packages/regl-worldview/src/stories/util.js
+++ b/packages/regl-worldview/src/stories/util.js
@@ -35,3 +35,56 @@ export const cube = (range: number, id: number = 1) => {
   };
   return marker;
 };
+
+export const withCustomRenderStates = (markers1: any, markers2: any) => {
+  const magenta = markers1.map((marker) => ({
+    ...marker,
+    colors: [],
+    color: { r: 1, g: 0, b: 1, a: 1 },
+    depth: {
+      enable: true,
+      mask: true,
+    },
+    blend: {
+      enable: true,
+      func: {
+        src: "constant color",
+        dst: "src alpha",
+      },
+      color: [1, 0, 1, 1],
+    },
+  }));
+  const gray = markers2.map((marker) => ({
+    ...marker,
+    colors: [],
+    color: { r: 0.5, g: 0.5, b: 0.5, a: 1 },
+    depth: {
+      enable: false,
+    },
+    blend: {
+      enable: true,
+      func: {
+        src: "constant color",
+        dst: "zero",
+      },
+      color: [0.5, 0.5, 0.5, 1.0],
+    },
+  }));
+  const cyan = markers2.map((marker) => ({
+    ...marker,
+    colors: [],
+    color: { r: 0, g: 1, b: 1, a: 1 },
+    depth: {
+      enable: true,
+    },
+    blend: {
+      enable: true,
+      func: {
+        src: "constant color",
+        dst: "one",
+      },
+      color: [0, 1, 1, 1],
+    },
+  }));
+  return [...magenta, ...gray, ...cyan];
+};

--- a/packages/regl-worldview/src/utils/withRenderStateOverrides.js
+++ b/packages/regl-worldview/src/utils/withRenderStateOverrides.js
@@ -12,6 +12,9 @@ import type { DepthState, BlendState } from "../types";
 import { defaultReglDepth, defaultReglBlend } from "./commandUtils";
 
 const withRenderStateOverrides = (command: any) => (regl: any) => {
+  // Generate the render command once
+  const reglCommand = command(regl);
+
   const renderElement = (props) => {
     // Get curstom render states from the given marker. Some commands, like <Arrows />
     // will use the originalMarker property instead. If no custom render states
@@ -23,8 +26,7 @@ const withRenderStateOverrides = (command: any) => (regl: any) => {
     // for the same render states
     const memoizedRender = memoize(
       (props: { depth: DepthState, blend: BlendState }) => {
-        const cmd = { ...command(regl), depth, blend };
-        return regl(cmd);
+        return regl({ ...reglCommand, depth, blend });
       },
       (...args) => JSON.stringify(args)
     );

--- a/packages/regl-worldview/src/utils/withRenderStateOverrides.js
+++ b/packages/regl-worldview/src/utils/withRenderStateOverrides.js
@@ -1,0 +1,43 @@
+// @flow
+
+//  Copyright (c) 2018-present, GM Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+import memoize from "lodash/memoize";
+
+import type { DepthState, BlendState } from "../types";
+import { defaultReglDepth, defaultReglBlend } from "./commandUtils";
+
+const withRenderStateOverrides = (command: any) => (regl: any) => {
+  const renderElement = (props) => {
+    // Get curstom render states from the given marker. Some commands, like <Arrows />
+    // will use the originalMarker property instead. If no custom render states
+    // are present, use the default ones to make sure the hitmap works correctly.
+    const depth = props.depth || props.originalMarker?.depth || defaultReglDepth;
+    const blend = props.blend || props.originalMarker?.blend || defaultReglBlend;
+
+    // Use memoization to prevent generating too multiple render commands
+    // for the same render states
+    const memoizedRender = memoize(
+      (props: { depth: DepthState, blend: BlendState }) => {
+        const cmd = { ...command(regl), depth, blend };
+        return regl(cmd);
+      },
+      (...args) => JSON.stringify(args)
+    );
+    memoizedRender({ depth, blend })(props);
+  };
+
+  return (props: any) => {
+    if (Array.isArray(props)) {
+      props.forEach(renderElement);
+    } else {
+      renderElement(props);
+    }
+  };
+};
+
+export default withRenderStateOverrides;


### PR DESCRIPTION
## Summary

In order to support advanced rendering techniques, geometry-based commands like `<Cubes />`, `<Cylinders />` or `<Arrows />` need to allow to set custom `depth` and `blend` states (in a similar way as `<Lines />` currently does). Those custom settings are directly forwarded to Regl during rendering. 

Memoization is used to prevent creating too many commands instances for the same params.

## Test plan

New screenshot tests have been added for the related commands

## Versioning impact

Minor. Changes are backward compatible. 
