### PR TITLE
Fix marker array scaling with small scale

### DIFF
--- a/packages/regl-worldview/src/stories/Points.stories.js
+++ b/packages/regl-worldview/src/stories/Points.stories.js
@@ -122,6 +122,82 @@ storiesOf("Worldview/Points", module)
       </Worldview>
     );
   })
+  .add("<Points> - World size matches non-unit cube (orthographic)", () => {
+    const scaleX = 0.5;
+    return (
+      <Worldview
+        defaultCameraState={{
+          distance: 3,
+          phi: 0.5 * Math.PI,
+          targetOffset: [0, 0, 0],
+          perspective: false,
+        }}>
+        <Points useWorldSpaceSize={true}>
+          {[
+            {
+              points: [{ x: 0, y: 0, z: 0 }],
+              scale: { x: scaleX, y: scaleX, z: scaleX },
+              color: { r: 1, g: 1, b: 0, a: 0.5 },
+              pose: {
+                position: { x: 0, y: 0, z: 0 },
+                orientation: { x: 0, y: 0, z: 0, w: 1 },
+              },
+            },
+          ]}
+        </Points>
+        <Cubes>
+          {[
+            {
+              pose: {
+                orientation: { x: 0, y: 0, z: 0, w: 1 },
+                position: { x: 0, y: 0, z: 0 },
+              },
+              scale: { x: scaleX, y: scaleX, z: scaleX },
+              color: { r: 1, g: 0, b: 1, a: 0.5 },
+            },
+          ]}
+        </Cubes>
+      </Worldview>
+    );
+  })
+  .add("<Points> - World size matches non-unit cube (perspective)", () => {
+    const scaleX = 0.5;
+    return (
+      <Worldview
+        defaultCameraState={{
+          distance: 3,
+          phi: 0.5 * Math.PI,
+          targetOffset: [0, 0, 0],
+          perspective: true,
+        }}>
+        <Points useWorldSpaceSize={true}>
+          {[
+            {
+              points: [{ x: 0, y: 0, z: 0 }],
+              scale: { x: scaleX, y: scaleX, z: scaleX },
+              color: { r: 1, g: 1, b: 0, a: 0.5 },
+              pose: {
+                position: { x: 0, y: 0, z: 0 },
+                orientation: { x: 0, y: 0, z: 0, w: 1 },
+              },
+            },
+          ]}
+        </Points>
+        <Cubes>
+          {[
+            {
+              pose: {
+                orientation: { x: 0, y: 0, z: 0, w: 1 },
+                position: { x: 0, y: 0, z: 0 },
+              },
+              scale: { x: scaleX, y: scaleX, z: scaleX },
+              color: { r: 1, g: 0, b: 1, a: 0.5 },
+            },
+          ]}
+        </Cubes>
+      </Worldview>
+    );
+  })
   .add("<Points> - Many points in world space, with cubes for reference", () => {
     const x = 5;
     const y = x;


### PR DESCRIPTION
## Summary

This PR resolves the last issue of #491. The current marker scale calculation is broken for any marker scale less than 1. This was caused by [this line](https://github.com/cruise-automation/webviz/blob/master/packages/regl-worldview/src/commands/Points.js#L89), where the marker scale was being bounded by `regl.limits.pointSizeDims`, which is `[1, 2047]`. No markers could be below one meter in size. Instead this limiting needs to happen after the new calculation that was added in #513. So [here](https://github.com/cruise-automation/webviz/blob/master/packages/regl-worldview/src/commands/Points.js#L67) is where the limiting should be applied. To achieve that I added `uniform` entries to the `Point`, to hold the value for the the point limits, then after we've done the calculation for the point size we can min/max appropriately. This ensures that when zooming out completely points are always shown as at least one pixel (checked this manually).

## Test plan

I first identified and fixed the issue. Then I reverted that change, added two unit tests where the points drawn with `useWorldSpaceSize=true` resulted in different sizes:
![before_non_unit_cube_orthographic](https://user-images.githubusercontent.com/1732289/96627763-551e7b00-12df-11eb-991b-66bb0a0062d3.png)

![before_non_unit_perspective](https://user-images.githubusercontent.com/1732289/96627816-68c9e180-12df-11eb-9c64-c0250413ca74.png)


Then I reapplied my proposed fix (second commit) and confirmed that the sizes were now identical, as one would expect:
![after_non_unit_orthographic](https://user-images.githubusercontent.com/1732289/96627865-77b09400-12df-11eb-97b4-ac87df4ddce2.png)

![after_non_unit_perspective](https://user-images.githubusercontent.com/1732289/96627877-7b441b00-12df-11eb-9ff7-08dae32d1a2d.png)

I tried to grab proper screenshots with `npm run screenshot-local-debug`, but that crashed with an error about an invalid array length.

## Versioning impact

This is a bugfix in the current version of `master`, currently marker arrays with points always show up as a size of 1 meters.