### PR TITLE
Allow custom render states for <Triangles /> and <FilledPolygons />

### DIFF
--- a/packages/regl-worldview/src/commands/Triangles.js
+++ b/packages/regl-worldview/src/commands/Triangles.js
@@ -18,6 +18,7 @@ import {
   withPose,
 } from "../utils/commandUtils";
 import { createInstancedGetChildrenForHitmap } from "../utils/getChildrenForHitmapDefaults";
+import withRenderStateOverrides from "../utils/withRenderStateOverrides";
 import Command, { type CommonCommandProps } from "./Command";
 
 // TODO(Audrey): default to the actual regl defaults before 1.x release
@@ -144,8 +145,8 @@ const vertexColors = (regl) =>
 
 // command to render triangle lists optionally supporting vertex colors for each triangle
 const triangles = (regl: Regl) => {
-  const single = regl(singleColor(regl));
-  const vertex = regl(vertexColors(regl));
+  const single = withRenderStateOverrides(singleColor)(regl);
+  const vertex = withRenderStateOverrides(vertexColors)(regl);
   return (props: any, isHitmap: boolean) => {
     const items: TriangleList[] = Array.isArray(props) ? props : [props];
     const singleColorItems = [];

--- a/packages/regl-worldview/src/stories/FilledPolygons.stories.js
+++ b/packages/regl-worldview/src/stories/FilledPolygons.stories.js
@@ -1,0 +1,52 @@
+//  Copyright (c) 2018-present, GM Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+import { withKnobs } from "@storybook/addon-knobs";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+import { FilledPolygons } from "../index";
+import Container from "./Container";
+import { withCustomRenderStates } from "./util";
+
+storiesOf("Worldview/FilledPolygons", module)
+  .addDecorator(withKnobs)
+  .add("<FilledPolygons> with points and color", () => {
+    return (
+      <Container cameraState={{ perspective: true, phi: 1.83, thetaOffset: -1.1 }}>
+        <FilledPolygons>
+          {[
+            {
+              points: [{ x: 0, y: 10, z: 0 }, { x: 10, y: 10, z: 0 }, { x: 10, y: 0, z: 10 }, { x: 0, y: 0, z: 10 }],
+              color: { r: 0, g: 1, b: 0, a: 1 },
+            },
+          ]}
+        </FilledPolygons>
+      </Container>
+    );
+  })
+  .add("<FilledPolygons> with custom depth and blend values", () => {
+    return (
+      <Container cameraState={{ perspective: true, phi: 1.83, thetaOffset: -1.1 }}>
+        <FilledPolygons>
+          {withCustomRenderStates(
+            [
+              {
+                points: [{ x: 0, y: 10, z: 0 }, { x: 10, y: 10, z: 0 }, { x: 10, y: 0, z: 10 }, { x: 0, y: 0, z: 10 }],
+                color: { r: 0, g: 1, b: 0, a: 1 },
+              },
+            ],
+            [
+              {
+                points: [{ x: -5, y: 10, z: 0 }, { x: 5, y: 10, z: 0 }, { x: 5, y: 0, z: 10 }, { x: -5, y: 0, z: 10 }],
+                color: { r: 0, g: 1, b: 0, a: 1 },
+              },
+            ]
+          )}
+        </FilledPolygons>
+      </Container>
+    );
+  });

--- a/packages/regl-worldview/src/stories/Triangles.stories.js
+++ b/packages/regl-worldview/src/stories/Triangles.stories.js
@@ -1,0 +1,62 @@
+//  Copyright (c) 2018-present, GM Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+import { withKnobs } from "@storybook/addon-knobs";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+import { Triangles } from "../index";
+import Container from "./Container";
+import { withCustomRenderStates } from "./util";
+
+const singleTriangle = (x, y, z) => {
+  return {
+    pose: {
+      orientation: { x: 0, y: 0, z: 0, w: 1 },
+      position: { x, y, z },
+    },
+    scale: { x: 20, y: 20, z: 20 },
+    colors: [{ r: 1, g: 1, b: 0, a: 1 }, { r: 1, g: 1, b: 0, a: 1 }, { r: 1, g: 1, b: 0, a: 1 }],
+    points: [[-10, 0, 0], [0, 0, 10], [10, 0, -10]],
+  };
+};
+
+const instancedTriangles = (x, y, z) => {
+  return {
+    pose: {
+      orientation: { x: 0, y: 0, z: 0, w: 1 },
+      position: { x, y, z },
+    },
+    scale: { x: 20, y: 20, z: 20 },
+    color: { r: 1, g: 0, b: 1, a: 0.5 },
+    colors: [
+      { r: 1, g: 1, b: 0, a: 1 },
+      { r: 1, g: 1, b: 0, a: 1 },
+      { r: 1, g: 1, b: 0, a: 1 },
+      { r: 1, g: 0, b: 0, a: 1 },
+      { r: 1, g: 0, b: 0, a: 1 },
+      { r: 1, g: 0, b: 0, a: 1 },
+    ],
+    points: [[-10, 0, 0], [0, 0, 10], [10, 0, -10], [-10, -20, 0], [0, -20, 10], [10, -20, -10]],
+  };
+};
+
+const Example = ({ triangles }) => (
+  <Container cameraState={{ perspective: true, phi: 1.83, thetaOffset: -1.1 }}>
+    <Triangles>{triangles}</Triangles>
+  </Container>
+);
+
+storiesOf("Worldview/Triangles", module)
+  .addDecorator(withKnobs)
+  .add("<Triangles> with points and color", () => <Example triangles={[singleTriangle(0, 0, 0)]} />)
+  .add("<Triangles> with instancing", () => <Example triangles={[instancedTriangles(0, 0, 0)]} />)
+  .add("<Triangles> with custom depth and blend values", () => (
+    <Example triangles={withCustomRenderStates([singleTriangle(0, 0, 0)], [singleTriangle(5, 0, 0.1)])} />
+  ))
+  .add("<Triangles> with instancing and custom render states", () => (
+    <Example triangles={withCustomRenderStates([instancedTriangles(0, 0, 0)], [instancedTriangles(5, 0, 0.1)])} />
+  ));


### PR DESCRIPTION
## Summary

This PR uses `withRenderStateOverrides` to set custom depth and blend values in both `<Triangles />` and `<FilledPolygons />`. This is required for advanced rendering modes in Webviz, life `Diff Mode`. 

## Test plan

New stories were created for both commands, with and without render state overrides. 

## Versioning impact

Minor. This is a bug fix and it's backward compatible. 
