### PR TITLE
Worldview: Fix render state memoization to avoid performance issues

### DIFF
--- a/packages/regl-worldview/src/utils/withRenderStateOverrides.js
+++ b/packages/regl-worldview/src/utils/withRenderStateOverrides.js
@@ -15,7 +15,7 @@ const withRenderStateOverrides = (command: any) => (regl: any) => {
   // Generate the render command once
   const reglCommand = command(regl);
 
-  // Use memoization to prevent generating too multiple render commands
+  // Use memoization to avoid generating multiple render commands for the same render states
   // for the same render states
   const memoizedRender = memoize(
     (props: { depth: DepthState, blend: BlendState }) => {

--- a/packages/regl-worldview/src/utils/withRenderStateOverrides.js
+++ b/packages/regl-worldview/src/utils/withRenderStateOverrides.js
@@ -15,21 +15,22 @@ const withRenderStateOverrides = (command: any) => (regl: any) => {
   // Generate the render command once
   const reglCommand = command(regl);
 
+  // Use memoization to prevent generating too multiple render commands
+  // for the same render states
+  const memoizedRender = memoize(
+    (props: { depth: DepthState, blend: BlendState }) => {
+      const { depth, blend } = props;
+      return regl({ ...reglCommand, depth, blend });
+    },
+    (...args) => JSON.stringify(args)
+  );
+
   const renderElement = (props) => {
     // Get curstom render states from the given marker. Some commands, like <Arrows />
     // will use the originalMarker property instead. If no custom render states
     // are present, use the default ones to make sure the hitmap works correctly.
     const depth = props.depth || props.originalMarker?.depth || defaultReglDepth;
     const blend = props.blend || props.originalMarker?.blend || defaultReglBlend;
-
-    // Use memoization to prevent generating too multiple render commands
-    // for the same render states
-    const memoizedRender = memoize(
-      (props: { depth: DepthState, blend: BlendState }) => {
-        return regl({ ...reglCommand, depth, blend });
-      },
-      (...args) => JSON.stringify(args)
-    );
     memoizedRender({ depth, blend })(props);
   };
 


### PR DESCRIPTION
## Summary

The function `withRenderStateOverrides` does not handle memoization correctly, leading to performance issues on Worldview clients. Since `memoizedRender` is created and invoked in the same scope, the memoization does not really happens.

I'm moving the memoization so it is done outside of `renderElement`, which is the correct approach. After this change, performance is back to normal

## Test plan

Cover by existing screenshot tests.

## Versioning impact

Patch.