### PR TITLE
Optimize Dockerfile for smaller container images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,43 @@
+.dockerignore
+.git
+.gitignore
+Dockerfile*
+
+# The following are defined in .gitignore; see that file for more information.
+#
+# To update this list, append the output of:
+#     sed 's/#.*//g' .gitignore | sed '/^$/d'
+
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pids
+*.pid
+*.seed
+*.pid.lock
+lib-cov
+coverage
+.nyc_output
+.grunt
+bower_components
+.lock-wscript
+build/Release
+node_modules/
+jspm_packages/
+typings/
+.npm
+.eslintcache
+.node_repl_history
+*.tgz
+.yarn-integrity
+.env
+.next
+.DS_Store
+.cache/
+__screenshots__/
+dist/
+lib/
+__static_webviz__/
+.reg/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Note: When updating this file, please also update .dockerignore
+
 # Logs
 logs
 *.log

--- a/Dockerfile-static-webviz
+++ b/Dockerfile-static-webviz
@@ -7,27 +7,45 @@
 # This is a static build of just the Webviz application.
 # This container is published at https://hub.docker.com/r/cruise/webviz.
 
-FROM node:10.22-slim
+FROM node:10.22 AS builder
 
-# Install some general dependencies for stuff below and for CircleCI;
-# https://circleci.com/docs/2.0/custom-images/#required-tools-for-primary-containers
-RUN apt-get update && apt-get install -yq gnupg libgconf-2-4 wget git ssh --no-install-recommends
+# Copy only the files necessary for installing our package dependencies. This
+# way, if the code is updated but the dependencies are the same, we can still
+# re-use the cache to avoid re-installing.
+WORKDIR /app
+COPY lerna.json package.json package-lock.json ./
+COPY packages/@cruise-automation/button/package.json \
+     packages/@cruise-automation/button/package-lock.json \
+     packages/@cruise-automation/button/
+COPY packages/@cruise-automation/hooks/package.json \
+     packages/@cruise-automation/hooks/package-lock.json \
+     packages/@cruise-automation/hooks/
+COPY packages/@cruise-automation/tooltip/package.json \
+     packages/@cruise-automation/tooltip/package-lock.json \
+     packages/@cruise-automation/tooltip/
+COPY packages/regl-worldview/package.json \
+     packages/regl-worldview/package-lock.json \
+     packages/regl-worldview/
+COPY packages/webviz-core/package.json \
+     packages/webviz-core/package-lock.json \
+     packages/webviz-core/
 
-# Install dumb-init which helps with proper signal handling.
-RUN apt-get install -y dumb-init
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-
-# Copy in the files
-COPY . .
-
-# Delete .gitignore files, so we don't accidentally pollute our image.
-RUN git clean -Xf
-
-# Build the static webviz.
+# Install dependencies
 RUN npm run install-ci
+
+# Copy the rest of the code
+COPY . /app
+
+# Build static webviz
 RUN npm run build
 RUN npm run build-static-webviz
 
-# Start the server.
+# Start again with a clean nginx container
+FROM nginx:1-alpine
+
+# For backwards compatibility, patch the server config to change the port
+RUN sed -i 's/listen  *80;/listen 8080;/g' /etc/nginx/conf.d/default.conf
 EXPOSE 8080
-CMD ["npm", "run", "serve-static-webviz"]
+
+# Copy the build products to the web root
+COPY --from=builder /app/__static_webviz__ /usr/share/nginx/html

--- a/Dockerfile-static-webviz
+++ b/Dockerfile-static-webviz
@@ -37,7 +37,6 @@ RUN npm run install-ci
 COPY . /app
 
 # Build static webviz
-RUN npm run build
 RUN npm run build-static-webviz
 
 # Start again with a clean nginx container

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ docker run -p 8080:8080 cruise/webviz
 
 ```sh
 npm run bootstrap # install dependencies
-npm run build # build all packages
 npm run build-static-webviz # generate static build in __static_webviz__
 npm run serve-static-webviz # serve static build on localhost:8080
 ```

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "docs": "DEV_SERVER=true webpack-dev-server",
     "docs-deploy": "cp -r docs/public __temp_deploy__ && rm __temp_deploy__/app/index.html && cp packages/webviz-core/public/index.html __temp_deploy__/app/index.html && echo 'webviz.io' > __temp_deploy__/CNAME && gh-pages -d __temp_deploy__ && rm -rf __temp_deploy__",
     "publish": "lerna run clean && lerna run build && lerna publish",
-    "build-static-webviz": "rm -rf __static_webviz__ && cp -r docs/public/app __static_webviz__ && rm __static_webviz__/index.html && cp packages/webviz-core/public/index.html __static_webviz__/index.html && sed -i -- 's/\\/dist\\/webvizCoreBundle.js/webvizCoreBundle.js/' __static_webviz__/index.html && NODE_ENV=production STATIC_WEBVIZ=true webpack",
+    "build-static-webviz": "lerna run build && rm -rf __static_webviz__ && cp -r docs/public/app __static_webviz__ && rm __static_webviz__/index.html && cp packages/webviz-core/public/index.html __static_webviz__/index.html && sed -i -- 's/\\/dist\\/webvizCoreBundle.js/webvizCoreBundle.js/' __static_webviz__/index.html && NODE_ENV=production STATIC_WEBVIZ=true webpack",
     "serve-static-webviz": "node_modules/http-server/bin/http-server __static_webviz__",
     "screenshot": "NODE_ENV=development storycap http://localhost:6006 --serverTimeout 120000 --captureTimeout 35000 --disableCssAnimation --serverCmd \"yarn run storybook\" --viewport \"1001x745\" --parallel 4",
     "screenshot-ci": "npm run screenshot -- --puppeteerLaunchConfig '{\"executablePath\": \"/usr/bin/google-chrome\", \"headless\": true, \"args\":[\"--use-gl=swiftshader\", \"--no-sandbox\",\"--disable-setuid-sandbox\", \"--disable-dev-shm-usage\", \"--headless\", \"--mute-audio\", \"--user-agent=PuppeteerTestingChrome/80.\"]}'",


### PR DESCRIPTION
## Summary

This change dramatically shrinks the static Webviz Docker image from 1005.44 MB to 74.14 MB, a reduction of 92.63%.

The Dockerfile now uses a multi-stage build to install build-time dependencies into a temporary container, while only the build products are copied into the final container image.

The final container image is based on nginx, a widely-deployed HTTP server and one of the most popular Docker containers. This may remove the need to keep the Node package `http-server` in the project's dependencies, but I'm not aware if it is used elsewhere.

The Dockerfile is now structured to take advantage of the Docker cache when re-building. Code changes that do not alter `package.json` etc. will not require a complete re-installation of dependencies.

The `git clean` stage was replaced with a `.dockerignore` file which prevents the files from being copied into the container in the first place. This file is generated from `.gitignore` and there are instructions provided for re-generating it in the future. This saves a lot of time by not copying `node_modules` and other large files into the Docker build context.

On advice of the official `node` Docker image, I switched from the `slim` variant to the vanilla `node` image. This doesn't have any significant effect. For a smaller final container image, I use the `alpine` variant of nginx.

After this is released, users can run `docker image prune` to reclaim disk space from previous versions of the container image. 

Closes #541 by moving the code from the root directory to the `/app` subdirectory inside the `builder` container.


## Test plan

I built the Docker image on an x86_64 macOS host using Docker Desktop 2.5.0.0 (49427) and briefly visited the built Webviz in Chrome.

I also successfully built it on an arm64 Ubuntu Bionic host.


## Versioning impact

This is not *likely* to affect versioning.

In the unlikely event that someone customized the built `cruise/webviz` image (e.g., used it as a base image for another container), their customizations would probably break. But it is doubtful anyone is customizing the image in this way because the JavaScript has been packed and is virtually immutable.

For backwards compatibility, the nginx configuration is patched to serve on port 8080 by default.

