### PR TITLE
Less buffer copying in <Lines>

### DIFF
--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "license": "Apache-2.0",
   "repository": "cruise-automation/webviz/tree/master/packages/regl-worldview",


### PR DESCRIPTION
Whenever we render a line we copy over the whole buffer, which is as
long as the longest line we've ever seen. This can be very inefficient
if there are a small number of very long lines and a large number of
short lines.

Test plan: No functional changes. Screenshots should stay unchanged.

Bumped minor version.