### PR TITLE
Allow adding context attributes in Worldview

### DIFF
--- a/docs/src/3.1.Worldview.mdx
+++ b/docs/src/3.1.Worldview.mdx
@@ -22,6 +22,7 @@
 | `onClick`             | `MouseHandler`                                  |                        |                                                                                                         |
 | `hitmapOnMouseMove`   | `boolean`                                       |                        | (DEPRECATED: see `disableHitmapForEvents`) if enabled, the clicked object will be returned from the mouse event handler. Disabled by default for performance reasons. |
 | `resolutionScale`     | `number`                                        | `1`                    | if present, the `canvas` element will be scaled by the given amount, improving the final render quality.
+| `contextAttributes`     | `Object`                                        |                     | If present, the WebGL context attributes that will be passed to `canvas.getContext` when creating the canvas for Worldview.
 
 _All props are optional._
 

--- a/packages/regl-worldview/package-lock.json
+++ b/packages/regl-worldview/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "regl-worldview",
-	"version": "0.13.5",
+	"version": "0.14.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.13.5",
+  "version": "0.14.0",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "license": "Apache-2.0",
   "repository": "cruise-automation/webviz/tree/master/packages/regl-worldview",

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -64,7 +64,7 @@ export type BaseProps = {|
   ...Dimensions,
 
   // Context attributes passed into canvas.getContext.
-  contextAttributes?: ?any,
+  contextAttributes?: ?{ [string]: any },
 |};
 
 type State = {|
@@ -152,7 +152,7 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
         // DEFAULT_CAMERA_STATE is applied if both `cameraState` and `defaultCameraState` are not present
         cameraState: props.cameraState || props.defaultCameraState || DEFAULT_CAMERA_STATE,
         onCameraStateChange: props.onCameraStateChange || undefined,
-        contextAttributes: props.contextAttributes || undefined,
+        contextAttributes: props.contextAttributes || {},
       }),
     };
   }

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -62,6 +62,9 @@ export type BaseProps = {|
   // Used to scale the canvas resolution and provide a higher image quality
   resolutionScale?: number,
   ...Dimensions,
+
+  // Context attributes passed into canvas.getContext.
+  contextAttributes?: ?any,
 |};
 
 type State = {|
@@ -149,6 +152,7 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
         // DEFAULT_CAMERA_STATE is applied if both `cameraState` and `defaultCameraState` are not present
         cameraState: props.cameraState || props.defaultCameraState || DEFAULT_CAMERA_STATE,
         onCameraStateChange: props.onCameraStateChange || undefined,
+        contextAttributes: props.contextAttributes || undefined,
       }),
     };
   }

--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -37,6 +37,7 @@ type ConstructorArgs = {
   cameraState: CameraState,
   defaultCameraState?: CameraState,
   onCameraStateChange: ?(CameraState) => void,
+  contextAttributes?: ?any,
 };
 
 type InitializedData = {
@@ -98,6 +99,7 @@ export class WorldviewContext {
   canvasBackgroundColor: Vec4 = [0, 0, 0, 1];
   // group all initialized data together so it can be checked for existence to verify initialization is complete
   initializedData: ?InitializedData;
+  contextAttributes: ?any;
 
   constructor({ dimension, canvasBackgroundColor, cameraState, onCameraStateChange }: ConstructorArgs) {
     // used for children to call paint() directly
@@ -121,6 +123,7 @@ export class WorldviewContext {
     const regl = this._instrumentCommands(
       createREGL({
         canvas,
+        attributes: this.contextAttributes || {},
         extensions: [
           "angle_instanced_arrays",
           "oes_texture_float",

--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -37,7 +37,7 @@ type ConstructorArgs = {
   cameraState: CameraState,
   defaultCameraState?: CameraState,
   onCameraStateChange: ?(CameraState) => void,
-  contextAttributes?: ?any,
+  contextAttributes?: ?{ [string]: any },
 };
 
 type InitializedData = {
@@ -99,7 +99,7 @@ export class WorldviewContext {
   canvasBackgroundColor: Vec4 = [0, 0, 0, 1];
   // group all initialized data together so it can be checked for existence to verify initialization is complete
   initializedData: ?InitializedData;
-  contextAttributes: ?any;
+  contextAttributes: ?{ [string]: any };
 
   constructor({ dimension, canvasBackgroundColor, cameraState, onCameraStateChange }: ConstructorArgs) {
     // used for children to call paint() directly


### PR DESCRIPTION
Allow passing in context attributes in Worldview that will be used
when creating the context from `getContext`.
