### PR TITLE
Teleop panel

### DIFF
--- a/packages/webviz-core/src/hooksImporter.js
+++ b/packages/webviz-core/src/hooksImporter.js
@@ -39,6 +39,7 @@ export function panelsByCategory() {
   const ThreeDimensionalViz = require("webviz-core/src/panels/ThreeDimensionalViz").default;
   const { ndash } = require("webviz-core/src/util/entities");
   const Table = require("webviz-core/src/panels/Table").default;
+  const Teleop = require("webviz-core/src/panels/Teleop").default;
 
   const ros = [
     { title: "2D Plot", component: TwoDimensionalPlot },
@@ -52,6 +53,7 @@ export function panelsByCategory() {
     { title: "rosout", component: Rosout },
     { title: "State Transitions", component: StateTransitions },
     { title: "Table", component: Table },
+    { title: "Teleop", component: Teleop }
   ];
 
   const utilities = [

--- a/packages/webviz-core/src/panels/Teleop/index.js
+++ b/packages/webviz-core/src/panels/Teleop/index.js
@@ -28,6 +28,7 @@ import { string } from "prop-types";
 
 type Config = {|
   buttonColor: string,
+  topicName: string,
 |};
 
 type Props = {
@@ -105,6 +106,7 @@ class Teleop extends React.PureComponent<Props, PanelState> {
   static panelType = "Teleop";
   static defaultConfig = {
     buttonColor: "#00A871",
+    topicName: "/cmd_vel",
   };
 
   _publisher = React.createRef<Publisher>();
@@ -212,6 +214,17 @@ class Teleop extends React.PureComponent<Props, PanelState> {
             placeholder="rgba(1,1,1,1) or #FFFFFF"
           />
         </Item>
+        <Item>
+          <PanelToolbarLabel>Topic name</PanelToolbarLabel>
+          <PanelToolbarInput
+            type="text"
+            value={config.topicName}
+            onChange={(event) => {
+              saveConfig({ topicName: event.target.value });
+            }}
+            placeholder="Choose /cmd_vel if unsure"
+          />
+        </Item>
       </>
     );
   }
@@ -220,7 +233,7 @@ class Teleop extends React.PureComponent<Props, PanelState> {
     const {
       capabilities,
       topics,
-      config: { buttonColor },
+      config: { buttonColor, topicName },
     } = this.props;
 
     const { datatypeNames, parsedObject, error, pressing } = this.state;
@@ -228,7 +241,9 @@ class Teleop extends React.PureComponent<Props, PanelState> {
 
     return (
       <Flex col style={{ height: "100%", padding: "12px" }} onKeyPress={this.handleKey}>
-        <Publisher ref={this._publisher} name="Publish" topic="/cmd_vel" datatype="geometry_msgs/Twist" />
+        {topicName && (
+          <Publisher ref={this._publisher} name="Publish" topic={topicName} datatype="geometry_msgs/Twist" />
+        )}
         
         <KeyListener global keyDownHandlers={this._keyHandlers} keyUpHandlers={this._keyHandlers} />
         <PanelToolbar floating menuContent={this._renderMenuContent()} />

--- a/packages/webviz-core/src/panels/Teleop/index.js
+++ b/packages/webviz-core/src/panels/Teleop/index.js
@@ -1,0 +1,276 @@
+// @flow
+//
+//  Copyright (c) 2019-present, Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+import CheckboxBlankOutlineIcon from "@mdi/svg/svg/checkbox-blank-outline.svg";
+import CheckboxMarkedIcon from "@mdi/svg/svg/checkbox-marked.svg";
+import * as React from "react";
+import { hot } from "react-hot-loader/root";
+import styled from "styled-components";
+
+import { PanelToolbarInput, PanelToolbarLabel } from "webviz-core/shared/panelToolbarStyles";
+import Autocomplete from "webviz-core/src/components/Autocomplete";
+import Button from "webviz-core/src/components/Button";
+import Flex from "webviz-core/src/components/Flex";
+import Item from "webviz-core/src/components/Menu/Item";
+import Panel from "webviz-core/src/components/Panel";
+import PanelToolbar from "webviz-core/src/components/PanelToolbar";
+import Publisher from "webviz-core/src/components/Publisher";
+import KeyListener from "webviz-core/src/components/KeyListener";
+import { PlayerCapabilities, type Topic } from "webviz-core/src/players/types";
+import colors from "webviz-core/src/styles/colors.module.scss";
+import { colors as c } from "webviz-core/src/util/sharedStyleConstants";
+import type { RosDatatypes } from "webviz-core/src/types/RosDatatypes";
+import { string } from "prop-types";
+
+type Config = {|
+  buttonColor: string,
+|};
+
+type Props = {
+  config: Config,
+  saveConfig: ($Shape<Config>) => void,
+
+  // player state
+  capabilities: string[],
+  topics: Topic[],
+  datatypes: RosDatatypes,
+};
+
+type PanelState = {|
+  cachedProps: $Shape<Props>,
+  datatypeNames: string[],
+  parsedObject: ?any,
+  error: ?string,
+  pressing: any,
+  topic: string,
+|};
+
+const STextArea = styled.textarea`
+  width: 100%;
+  height: 100%;
+  resize: none;
+`;
+
+const STextAreaContainer = styled.div`
+  flex-grow: 1;
+  padding: 12px 0;
+`;
+
+const SErrorText = styled.div`
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  padding: 4px;
+  color: ${colors.red};
+`;
+
+const SSpan = styled.span`
+  opacity: 0.8;
+`;
+const SRow = styled.div`
+  display: flex;
+  line-height: 24px;
+  flex-shrink: 0;
+`;
+
+function getTopicName(topic: Topic): string {
+  return topic.name;
+}
+
+function parseInput(value: string): $Shape<PanelState> {
+  let parsedObject;
+  let error = null;
+  try {
+    const parsedAny = JSON.parse(value);
+    if (Array.isArray(parsedAny)) {
+      error = "Message content must be an object, not an array";
+    } else if (parsedAny === null) {
+      error = "Message content must be an object, not null";
+    } else if (typeof parsedAny !== "object") {
+      error = `Message content must be an object, not ‘${typeof parsedAny}’`;
+    } else {
+      parsedObject = parsedAny;
+    }
+  } catch (e) {
+    error = value ? e.message : "";
+  }
+  return { error, parsedObject };
+}
+
+class Teleop extends React.PureComponent<Props, PanelState> {
+  static panelType = "Teleop";
+  static defaultConfig = {
+    buttonColor: "#00A871",
+  };
+
+  _publisher = React.createRef<Publisher>();
+
+  state = {
+    cachedProps: {},
+    datatypeNames: [],
+    error: null,
+    parsedObject: undefined,
+    pressing: {ArrowLeft: false, ArrowRight: false, ArrowUp: false, ArrowDown: false},
+  };
+
+  static getDerivedStateFromProps(props: Props, state: PanelState) {
+    const newState: $Shape<PanelState> = parseInput(props.config.value);
+    let changed = false;
+
+    if (props !== state.cachedProps) {
+      newState.cachedProps = props;
+      changed = true;
+    }
+
+    if (props.datatypes !== state.cachedProps.datatypes) {
+      newState.datatypeNames = Object.keys(props.datatypes).sort();
+      changed = true;
+    }
+
+    return changed ? newState : null;
+  }
+
+  composeTwist = (key) => {
+    const COMMANDS = { // Map x, y, z, th here
+      ArrowUp: [1, 0, 0, 0], 
+      ArrowDown: [-1, 0, 0, 0], 
+      ArrowLeft: [0, 0, 0, 1], 
+      ArrowRight: [0, 0, 0, -1],
+      " ": [0, 0, 0, 0], // Stop
+    };
+    const [x, y, z, th] = COMMANDS[key];
+    const speed = 0.5, turn = 1.0;
+    return {
+      linear: {
+        x: x*speed,
+        y: y*speed,
+        z: z*speed
+      },
+      angular: {
+        x: 0,
+        y: 0,
+        z: th * turn
+      }
+    }
+  };
+
+  _onChange = (event: SyntheticInputEvent<HTMLTextAreaElement>) => {
+    this.props.saveConfig({ value: event.target.value });
+  };
+
+  _onCommandButtonClick = (command) => {
+    // Simulate key press and release
+    this._handleKey({key: command, type: "keydown"});
+    this._handleKey({key: command, type: "keyup"});
+  };
+
+  _handleKey = (event) => {
+    this.setState(function(state, props) {
+      let newPressing = state.pressing;
+      newPressing[event.key] = event.type == "keydown";
+      if(this._publisher.current){
+        if(event.type=="keydown" ){
+          this._publisher.current.publish(this.composeTwist(event.key));
+        }
+      } else {
+        console.error("Publisher not set!");
+      }
+      return {
+        pressing: newPressing
+      };
+    });
+
+    this.forceUpdate(); // HACK Appears to be required to update the colors quickly???
+  };
+
+  // Add handler here for all desired keybindings (they are all the same!)
+  _keyHandlers = {
+    ArrowLeft: this._handleKey,
+    ArrowRight: this._handleKey,
+    ArrowUp: this._handleKey,
+    ArrowDown: this._handleKey,
+    " ": this._handleKey, // Space
+  };
+
+  _renderMenuContent() {
+    const { config, saveConfig } = this.props;
+
+    return (
+      <>
+        <Item>
+          <PanelToolbarLabel>Button color (rgba or hex)</PanelToolbarLabel>
+          <PanelToolbarInput
+            type="text"
+            value={config.buttonColor}
+            onChange={(event) => {
+              saveConfig({ buttonColor: event.target.value });
+            }}
+            placeholder="rgba(1,1,1,1) or #FFFFFF"
+          />
+        </Item>
+      </>
+    );
+  }
+
+  render() {
+    const {
+      capabilities,
+      topics,
+      config: { buttonColor },
+    } = this.props;
+
+    const { datatypeNames, parsedObject, error, pressing } = this.state;
+    const canPublish = capabilities.includes(PlayerCapabilities.advertise);
+
+    return (
+      <Flex col style={{ height: "100%", padding: "12px" }} onKeyPress={this.handleKey}>
+        <Publisher ref={this._publisher} name="Publish" topic="/cmd_vel" datatype="geometry_msgs/Twist" />
+        
+        <KeyListener global keyDownHandlers={this._keyHandlers} keyUpHandlers={this._keyHandlers} />
+        <PanelToolbar floating menuContent={this._renderMenuContent()} />
+        <Flex row style={{ flex: "0 0 auto", justifyContent: "center", "paddingTop": "5px", "paddingBottom": "5px"}}>
+          <Button
+            style={{backgroundColor: pressing.ArrowUp ? colors.red : buttonColor}}
+            disabled={!canPublish}
+            tooltip={canPublish ? "" : "Connect to ROS to publish data"}
+            onClick={(e) => this._onCommandButtonClick("ArrowUp")}
+          >↑</Button>
+        </Flex>
+        <Flex row style={{ flex: "0 0 auto", justifyContent: "center", "paddingTop": "5px", "paddingBottom": "5px"}}>
+          <Button
+            style={{backgroundColor: pressing.ArrowLeft ? colors.red : buttonColor}}
+            disabled={!canPublish}
+            tooltip={canPublish ? "" : "Connect to ROS to publish data"}
+            onClick={(e) => this._onCommandButtonClick("ArrowLeft")}
+          >←</Button>
+          <Button
+            style={{backgroundColor: pressing.ArrowDown ? colors.red : buttonColor}}
+            disabled={!canPublish}
+            tooltip={canPublish ? "" : "Connect to ROS to publish data"}
+            onClick={(e) => this._onCommandButtonClick("ArrowDown")}
+          >↓</Button>
+          <Button
+            style={{backgroundColor: pressing.ArrowRight ? colors.red : buttonColor}}
+            disabled={!canPublish}
+            tooltip={canPublish ? "" : "Connect to ROS to publish data"}
+            onClick={(e) => this._onCommandButtonClick("ArrowRight")}
+          >→</Button>
+        </Flex>
+        <Flex row style={{ flex: "0 0 auto", justifyContent: "center", "paddingTop": "5px", "paddingBottom": "5px"}}>
+          <Button
+            style={{backgroundColor: pressing[" "] ? buttonColor : colors.red}}
+            disabled={!canPublish}
+            tooltip={canPublish ? "" : "Connect to ROS to publish data"}
+            onClick={(e) => this._onCommandButtonClick(" ")}
+          >Stop</Button>
+        </Flex>
+      </Flex>
+    );
+  }
+}
+
+export default hot(Panel<Config>(Teleop));

--- a/packages/webviz-core/src/panels/Teleop/index.stories.js
+++ b/packages/webviz-core/src/panels/Teleop/index.stories.js
@@ -1,0 +1,71 @@
+// @flow
+//
+//  Copyright (c) 2019-present, Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+import Teleop from "webviz-core/src/panels/Teleop";
+import { PlayerCapabilities } from "webviz-core/src/players/types";
+import PanelSetup from "webviz-core/src/stories/PanelSetup";
+
+const getFixture = (allowPublish) => {
+  return {
+    topics: [],
+    datatypes: {
+      "std_msgs/String": { fields: [{ name: "data", type: "string" }] },
+    },
+    frame: {},
+    capabilities: allowPublish ? [PlayerCapabilities.advertise] : [],
+  };
+};
+
+const advancedJSON = `{\n  "data": ""\n}`;
+const publishConfig = () => ({
+  buttonColor: "",
+});
+
+storiesOf("<Teleop>", module)
+  .add("example can publish", () => {
+    const allowPublish = true;
+    return (
+      <PanelSetup fixture={getFixture(allowPublish)}>
+        <Teleop config={publishConfig()} />
+      </PanelSetup>
+    );
+
+  })
+  .add("example can't publish", () => {
+    const allowPublish = false;
+    return (
+      <PanelSetup fixture={getFixture(allowPublish)}>
+        <Teleop config={publishConfig()} />
+      </PanelSetup>
+    );
+  })
+  .add("Example with datatype that no longer exists", () => {
+    return (
+      <PanelSetup fixture={{ topics: [], datatypes: {}, frame: {}, capabilities: [] }}>
+        <Teleop config={publishConfig()} />
+      </PanelSetup>
+    );
+  })
+  .add("example with valid preset JSON", () => {
+    const fixture = {
+      topics: [],
+      datatypes: {
+        "std_msgs/String": { fields: [{ name: "data", type: "string" }] },
+      },
+      frame: {},
+      capabilities: [PlayerCapabilities.advertise],
+    };
+
+    return (
+      <PanelSetup fixture={fixture}>
+        <Teleop config={publishConfig()} />
+      </PanelSetup>
+    );
+  });

--- a/packages/webviz-core/src/panels/Teleop/index.test.js
+++ b/packages/webviz-core/src/panels/Teleop/index.test.js
@@ -1,0 +1,37 @@
+// @flow
+//
+//  Copyright (c) 2019-present, Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+import { mount } from "enzyme";
+import React from "react";
+
+import Teleop from "webviz-core/src/panels/Teleop";
+import PanelSetup from "webviz-core/src/stories/PanelSetup";
+
+describe("Teleop panel", () => {
+  it("does not update its state on first render", async () => {
+    const saveConfig = jest.fn();
+    mount(
+      <PanelSetup
+        fixture={{
+          topics: [],
+          datatypes: { "std_msgs/String": { fields: [{ name: "data", type: "string" }] } },
+          frame: {},
+          capabilities: [],
+        }}>
+        <Teleop
+          config={{
+            buttonColor: "",
+          }}
+          saveConfig={saveConfig}
+        />
+      </PanelSetup>
+    );
+    // Gets called with unnecessary payload if we don't check whether state.cachedProps.config has
+    // already been initialized
+    expect(saveConfig).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!-- Thanks for contributing to Webviz! To help us understand and review your PR, please fill out the following sections: -->

_(First time contributor, so apologies for any mistakes)_

## Summary

This PR adds a Teleoperation panel which operates in a similar way to the [teleop_twist_keyboard](http://wiki.ros.org/teleop_twist_keyboard) node. It can be controlled by clicking buttons or with the arrow keys.

![Teleop panel](https://user-images.githubusercontent.com/23390438/102373700-7a9dcd00-3f8e-11eb-8815-6a79ee4e83ee.png)

The main motivation of this change would be its use in remotely controlled (i.e., non-autonomous) robots. Such robots can't currently be easily controlled via Webviz (at least, I don't know of a simple way), and it would be nice to have the teleoperation interface next to, for example, an Image panel showing the robot cameras, or a Map panel showing the robot location (or both!).

This PR started by copying the Publish panel, since its functionality is similar. The major difference is that the Teleop panel sends specific messages to a fixed (configurable) topic with a fixed (non-configurable) datatype, instead of arbitrary mesages to any topic. Unnecessary settings were deleted, and the UI was edited to only contain a few buttons which trigger a message publication via a Publisher component. A global KeyListener element was also added, to allow keypresses to also trigger the messages.

## Test plan

The new panel was manually tested on a local installation, with ROS running on a Docker container and the Websockets server exposed via port 9090. This change makes no sense when using local or remote bags.
The test files from the Publish panel were also copied, adapted and run. All tests pass successfully.

## Versioning impact

This PR should only require a minor semver update. 

## Addendum: Known limitations & questions
* At present, the panel suffers from issue https://github.com/cruise-automation/webviz/issues/534 which is also present in the Publish panel, since they both use the same Publisher component. However, unlike the Publish panel, this one displays an error message over the panel, with a "Reload Panel" button. Clicking on the button (seems to) fix the error. A fix to the linked issue should (?) remove this bug.
* The panel only allows four directions (up, down, left, right) plus a Stop command. More complex robots can use up to nine keys  for direction, plus a few extra to change rotation and translation speed. Should those additional keys be implemented?
* Currently, the four directions are bound to the arrow keys, and Stop is bound to the Space key. Should the keybindings be configurable? If so, how? Maybe a dropdown for every command, with a list of valid keys?