### PR TITLE
Upgrade prettier to 1.16.0

### DIFF
--- a/docs/src/App.js
+++ b/docs/src/App.js
@@ -31,21 +31,18 @@ function ScrollTo({ component: Tag = "div", location, children, match, disableAn
     hasLink = linkStr === lastPathPartials;
   }
 
-  React.useEffect(
-    () => {
-      let disableScroll = false;
-      const urlPartials = window.location.href.split("?");
-      if (urlPartials.length > 1) {
-        const queryStr = urlPartials[1];
-        const search = new URLSearchParams(queryStr);
-        disableScroll = search.get("disableScroll");
-      }
-      if (!disableScroll && hasLink) {
-        window.scrollTo({ top: wrapperRef.current.offsetTop, behavior: "smooth" });
-      }
-    },
-    [lastPathPartials]
-  );
+  React.useEffect(() => {
+    let disableScroll = false;
+    const urlPartials = window.location.href.split("?");
+    if (urlPartials.length > 1) {
+      const queryStr = urlPartials[1];
+      const search = new URLSearchParams(queryStr);
+      disableScroll = search.get("disableScroll");
+    }
+    if (!disableScroll && hasLink) {
+      window.scrollTo({ top: wrapperRef.current.offsetTop, behavior: "smooth" });
+    }
+  }, [lastPathPartials]);
   return (
     <div ref={wrapperRef}>
       {linkStr ? (

--- a/docs/src/jsx/tutorials/StopReleaseDuck.js
+++ b/docs/src/jsx/tutorials/StopReleaseDuck.js
@@ -81,15 +81,12 @@ function Example() {
   });
   const duckPosition = sphereMarker.points[count];
   // make the duck stop
-  useEffect(
-    () => {
-      const duckPositionId = sphereMarker.id + count;
-      if (!shouldStopDuck && clickedObjectIds.some(({ id, instanceIndex }) => id + instanceIndex === duckPositionId)) {
-        setShouldStopDuck(true);
-      }
-    },
-    [clickedObjectIds, shouldStopDuck, count, sphereMarker.id]
-  );
+  useEffect(() => {
+    const duckPositionId = sphereMarker.id + count;
+    if (!shouldStopDuck && clickedObjectIds.some(({ id, instanceIndex }) => id + instanceIndex === duckPositionId)) {
+      setShouldStopDuck(true);
+    }
+  }, [clickedObjectIds, shouldStopDuck, count, sphereMarker.id]);
 
   return (
     <Worldview

--- a/package-lock.json
+++ b/package-lock.json
@@ -24493,9 +24493,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.2.tgz",
-      "integrity": "sha512-YgPLFFA0CdKL4Eg2IHtUSjzj/BWgszDHiNQAe0VAIBse34148whfdzLagRL+QiKS+YfK5ftB6X4v/MBw8yCoug==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.0.tgz",
+      "integrity": "sha512-MCBCYeAuZfejUPdEpkleLWvpRBwLii/Sp5jQs0eb8Ul/drGIDjkL6tAU24tk6yCGf0KPV5rhPPPlczfBmN2pWQ==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "polygon-generator": "^1.1.2",
     "postcss-flexbugs-fixes": "^4.1.0",
     "postcss-loader": "^3.0.0",
-    "prettier": "1.15.2",
+    "prettier": "1.16.0",
     "puppeteer": "2.0.0",
     "quickhull3d": "2.0.4",
     "raw-loader": "^0.5.1",

--- a/packages/@cruise-automation/hooks/src/useAnimationFrame.js
+++ b/packages/@cruise-automation/hooks/src/useAnimationFrame.js
@@ -25,17 +25,14 @@ export default function useAnimationFrame(
     });
   }
 
-  useEffect(
-    () => {
-      if (!disable) {
-        createAnimationFrame(callback);
+  useEffect(() => {
+    if (!disable) {
+      createAnimationFrame(callback);
+    }
+    return function cleanup() {
+      if (rafId.current) {
+        cancelAnimationFrame(rafId.current);
       }
-      return function cleanup() {
-        if (rafId.current) {
-          cancelAnimationFrame(rafId.current);
-        }
-      };
-    },
-    [callback, disable, ...dependencies]
-  );
+    };
+  }, [callback, disable, ...dependencies]);
 }

--- a/packages/@cruise-automation/hooks/src/useEventListener.js
+++ b/packages/@cruise-automation/hooks/src/useEventListener.js
@@ -16,13 +16,10 @@ export default function useEventListener(
   handler: (any) => void,
   dependencies: any[]
 ) {
-  useEffect(
-    () => {
-      if (enable) {
-        target.addEventListener(type, handler);
-        return () => target.removeEventListener(type, handler);
-      }
-    },
-    [target, type, enable, ...dependencies]
-  );
+  useEffect(() => {
+    if (enable) {
+      target.addEventListener(type, handler);
+      return () => target.removeEventListener(type, handler);
+    }
+  }, [target, type, enable, ...dependencies]);
 }

--- a/packages/regl-worldview/src/utils/Dimensions.js
+++ b/packages/regl-worldview/src/utils/Dimensions.js
@@ -61,17 +61,14 @@ export default function Dimensions({ children }: Props) {
     }
   }, []);
 
-  useEffect(
-    () => {
-      if (!parentElement) {
-        return;
-      }
-      resizeObserver.observe(parentElement);
-      // Make sure to unobserve when we unmount the component.
-      return () => resizeObserver.unobserve(parentElement);
-    },
-    [parentElement, resizeObserver]
-  );
+  useEffect(() => {
+    if (!parentElement) {
+      return;
+    }
+    resizeObserver.observe(parentElement);
+    // Make sure to unobserve when we unmount the component.
+    return () => resizeObserver.unobserve(parentElement);
+  }, [parentElement, resizeObserver]);
 
   // This only happens during the first render - we use it to grab the parentElement of this div.
   if (dimensions == null) {

--- a/packages/webviz-core/src/PanelAPI/useBlockMessageByTopicWithFallback.js
+++ b/packages/webviz-core/src/PanelAPI/useBlockMessageByTopicWithFallback.js
@@ -59,16 +59,13 @@ function usePlaybackMessage<T>(topic: string): ?T {
 export default function useBlockMessageByTopicWithFallback<T>(topic: string): ?T {
   const { blocks, messageReadersByTopic } = PanelAPI.useBlocksByTopic([topic]);
 
-  const binaryBlocksMessage = useMemo(
-    () => {
-      if (!messageReadersByTopic[topic]) {
-        return;
-      }
-      const maybeBlockWithMessage = blocks.find((block) => block[topic]?.length);
-      return maybeBlockWithMessage?.[topic]?.[0];
-    },
-    [blocks, messageReadersByTopic, topic]
-  );
+  const binaryBlocksMessage = useMemo(() => {
+    if (!messageReadersByTopic[topic]) {
+      return;
+    }
+    const maybeBlockWithMessage = blocks.find((block) => block[topic]?.length);
+    return maybeBlockWithMessage?.[topic]?.[0];
+  }, [blocks, messageReadersByTopic, topic]);
 
   const parsedBlockMessage =
     binaryBlocksMessage && blockMessageCache.parseMessages([binaryBlocksMessage], messageReadersByTopic)[0]?.message;

--- a/packages/webviz-core/src/PanelAPI/useMessagesByTopic.js
+++ b/packages/webviz-core/src/PanelAPI/useMessagesByTopic.js
@@ -44,36 +44,30 @@ export function useMessagesByTopic<T: any>({
   const addMessages: (
     $ReadOnly<{ [string]: $ReadOnlyArray<TypedMessage<T>> }>,
     $ReadOnlyArray<TypedMessage<T>>
-  ) => $ReadOnly<{ [string]: $ReadOnlyArray<TypedMessage<T>> }> = useCallback(
-    (
-      prevMessagesByTopic: $ReadOnly<{ [string]: $ReadOnlyArray<TypedMessage<T>> }>,
-      messages: $ReadOnlyArray<TypedMessage<T>>
-    ) => {
-      const newMessagesByTopic = groupBy(messages, "topic");
-      const ret = { ...prevMessagesByTopic };
-      Object.keys(newMessagesByTopic).forEach((topic) => {
-        ret[topic] = concatAndTruncate(ret[topic], newMessagesByTopic[topic], historySize);
-      });
-      return ret;
-    },
-    [historySize]
-  );
+  ) => $ReadOnly<{ [string]: $ReadOnlyArray<TypedMessage<T>> }> = useCallback((
+    prevMessagesByTopic: $ReadOnly<{ [string]: $ReadOnlyArray<TypedMessage<T>> }>,
+    messages: $ReadOnlyArray<TypedMessage<T>>
+  ) => {
+    const newMessagesByTopic = groupBy(messages, "topic");
+    const ret = { ...prevMessagesByTopic };
+    Object.keys(newMessagesByTopic).forEach((topic) => {
+      ret[topic] = concatAndTruncate(ret[topic], newMessagesByTopic[topic], historySize);
+    });
+    return ret;
+  }, [historySize]);
 
-  const restore = useCallback(
-    (
-      prevMessagesByTopic: ?$ReadOnly<{ [string]: $ReadOnlyArray<TypedMessage<T>> }>
-    ): $ReadOnly<{ [string]: $ReadOnlyArray<TypedMessage<T>> }> => {
-      const newMessagesByTopic: { [topic: string]: TypedMessage<T>[] } = {};
-      // When changing topics, we try to keep as many messages around from the previous set of
-      // topics as possible.
-      for (const topic of requestedTopics) {
-        newMessagesByTopic[topic] =
-          prevMessagesByTopic && prevMessagesByTopic[topic] ? prevMessagesByTopic[topic].slice(-historySize) : [];
-      }
-      return newMessagesByTopic;
-    },
-    [requestedTopics, historySize]
-  );
+  const restore = useCallback((
+    prevMessagesByTopic: ?$ReadOnly<{ [string]: $ReadOnlyArray<TypedMessage<T>> }>
+  ): $ReadOnly<{ [string]: $ReadOnlyArray<TypedMessage<T>> }> => {
+    const newMessagesByTopic: { [topic: string]: TypedMessage<T>[] } = {};
+    // When changing topics, we try to keep as many messages around from the previous set of
+    // topics as possible.
+    for (const topic of requestedTopics) {
+      newMessagesByTopic[topic] =
+        prevMessagesByTopic && prevMessagesByTopic[topic] ? prevMessagesByTopic[topic].slice(-historySize) : [];
+    }
+    return newMessagesByTopic;
+  }, [requestedTopics, historySize]);
 
   return useMessageReducer({
     topics: requestedTopics,

--- a/packages/webviz-core/src/components/AppMenu/index.js
+++ b/packages/webviz-core/src/components/AppMenu/index.js
@@ -28,13 +28,10 @@ function AppMenu(props: Props) {
   const dispatch = useDispatch();
 
   const layout = useSelector((state: ReduxState) => state.persistedState.panels.layout);
-  const onPanelSelect = useCallback(
-    ({ type, config, relatedConfigs }: PanelSelection) => {
-      dispatch(addPanel(({ type, layout, config, relatedConfigs, tabId: null }: AddPanelPayload)));
-      logEvent({ name: getEventNames().PANEL_ADD, tags: { [getEventTags().PANEL_TYPE]: type } });
-    },
-    [dispatch, layout]
-  );
+  const onPanelSelect = useCallback(({ type, config, relatedConfigs }: PanelSelection) => {
+    dispatch(addPanel(({ type, layout, config, relatedConfigs, tabId: null }: AddPanelPayload)));
+    logEvent({ name: getEventNames().PANEL_ADD, tags: { [getEventTags().PANEL_TYPE]: type } });
+  }, [dispatch, layout]);
 
   return (
     <ChildToggle position="below" onToggle={onToggle} isOpen={isOpen}>

--- a/packages/webviz-core/src/components/AutoSizingCanvas/index.stories.js
+++ b/packages/webviz-core/src/components/AutoSizingCanvas/index.stories.js
@@ -22,19 +22,16 @@ function Example({
 }) {
   const [width, setWidth] = useState(300);
   const [pixelRatio, setPixelRatio] = useState(devicePixelRatio);
-  useEffect(
-    () => {
-      setTimeout(() => {
-        if (changeSize) {
-          setWidth(150);
-        }
-        if (changePixelRatio) {
-          setPixelRatio(2);
-        }
-      }, 10);
-    },
-    [changePixelRatio, changeSize]
-  );
+  useEffect(() => {
+    setTimeout(() => {
+      if (changeSize) {
+        setWidth(150);
+      }
+      if (changePixelRatio) {
+        setPixelRatio(2);
+      }
+    }, 10);
+  }, [changePixelRatio, changeSize]);
 
   return (
     <div style={{ width, height: 100, backgroundColor: "green" }}>

--- a/packages/webviz-core/src/components/Checkbox.js
+++ b/packages/webviz-core/src/components/Checkbox.js
@@ -52,14 +52,11 @@ export default function Checkbox({
   dataTest,
 }: Props) {
   const Component = checked ? CheckboxMarkedIcon : CheckboxBlankOutlineIcon;
-  const onClick = React.useCallback(
-    () => {
-      if (!disabled) {
-        onChange(!checked);
-      }
-    },
-    [checked, disabled, onChange]
-  );
+  const onClick = React.useCallback(() => {
+    if (!disabled) {
+      onChange(!checked);
+    }
+  }, [checked, disabled, onChange]);
 
   const styledLabel = (
     <SLabel labelDirection={labelDirection} disabled={disabled} style={labelStyle}>

--- a/packages/webviz-core/src/components/Dimensions.js
+++ b/packages/webviz-core/src/components/Dimensions.js
@@ -59,17 +59,14 @@ export default function Dimensions({ children }: Props) {
     }
   }, []);
 
-  useEffect(
-    () => {
-      if (!parentElement) {
-        return;
-      }
-      resizeObserver.observe(parentElement);
-      // Make sure to unobserve when we unmount the component.
-      return () => resizeObserver.unobserve(parentElement);
-    },
-    [parentElement, resizeObserver]
-  );
+  useEffect(() => {
+    if (!parentElement) {
+      return;
+    }
+    resizeObserver.observe(parentElement);
+    // Make sure to unobserve when we unmount the component.
+    return () => resizeObserver.unobserve(parentElement);
+  }, [parentElement, resizeObserver]);
 
   // This only happens during the first render - we use it to grab the parentElement of this div.
   if (dimensions == null) {

--- a/packages/webviz-core/src/components/GlobalKeyListener.js
+++ b/packages/webviz-core/src/components/GlobalKeyListener.js
@@ -41,70 +41,67 @@ export default function GlobalKeyListener({ openSaveLayoutModal, openLayoutModal
   const actions = useMemo(() => bindActionCreators({ redoLayoutChange, undoLayoutChange }, dispatch), [dispatch]);
   const { takeScreenshot } = useContext(ScreenshotsContext);
 
-  const keyDownHandler: (KeyboardEvent) => void = useCallback(
-    (e) => {
-      const target = e.target;
+  const keyDownHandler: (KeyboardEvent) => void = useCallback((e) => {
+    const target = e.target;
 
-      if (
-        target instanceof HTMLInputElement ||
-        target instanceof HTMLTextAreaElement ||
-        (target instanceof HTMLElement && target.isContentEditable)
-      ) {
-        // The user is typing in an editable field; ignore the event.
+    if (
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      (target instanceof HTMLElement && target.isContentEditable)
+    ) {
+      // The user is typing in an editable field; ignore the event.
+      return;
+    }
+
+    const lowercaseEventKey = e.key.toLowerCase();
+    if (e.key === "?") {
+      history.push(`/help${window.location.search}`);
+    }
+
+    if (!(e.ctrlKey || e.metaKey)) {
+      return;
+    }
+    if (lowercaseEventKey === "z") {
+      // Don't use ctrl-Z for layout history actions inside the Monaco Editor. It isn't
+      // controlled, and changes inside it don't result in updates to the Redux state. We could
+      // consider making the editor controlled, with a separate "unsaved state".
+      if (inNativeUndoRedoElement(e.target)) {
         return;
       }
 
-      const lowercaseEventKey = e.key.toLowerCase();
-      if (e.key === "?") {
-        history.push(`/help${window.location.search}`);
+      // Use e.shiftKey instead of e.key to decide between undo and redo because of capslock.
+      e.stopPropagation();
+      e.preventDefault();
+      if (e.shiftKey) {
+        actions.redoLayoutChange();
+      } else {
+        actions.undoLayoutChange();
       }
-
-      if (!(e.ctrlKey || e.metaKey)) {
-        return;
+    } else if (lowercaseEventKey === "s" && openSaveLayoutModal) {
+      e.preventDefault();
+      openSaveLayoutModal();
+    } else if (lowercaseEventKey === "e" && openLayoutModal) {
+      e.preventDefault();
+      openLayoutModal();
+    } else if (lowercaseEventKey === "/") {
+      e.preventDefault();
+      history.push(`/shortcuts${window.location.search}`);
+    } else if (lowercaseEventKey === "j" && process.env.NODE_ENV !== "production") {
+      // TODO (DWinegar): Remove this key listener once we get the screenshots for comments working.
+      e.preventDefault();
+      const element = document.querySelector(".PanelLayout-root");
+      if (!element) {
+        throw new Error(`takeScreenshot could not find element with selector ".PanelLayout-root"`);
       }
-      if (lowercaseEventKey === "z") {
-        // Don't use ctrl-Z for layout history actions inside the Monaco Editor. It isn't
-        // controlled, and changes inside it don't result in updates to the Redux state. We could
-        // consider making the editor controlled, with a separate "unsaved state".
-        if (inNativeUndoRedoElement(e.target)) {
-          return;
-        }
-
-        // Use e.shiftKey instead of e.key to decide between undo and redo because of capslock.
-        e.stopPropagation();
-        e.preventDefault();
-        if (e.shiftKey) {
-          actions.redoLayoutChange();
-        } else {
-          actions.undoLayoutChange();
-        }
-      } else if (lowercaseEventKey === "s" && openSaveLayoutModal) {
-        e.preventDefault();
-        openSaveLayoutModal();
-      } else if (lowercaseEventKey === "e" && openLayoutModal) {
-        e.preventDefault();
-        openLayoutModal();
-      } else if (lowercaseEventKey === "/") {
-        e.preventDefault();
-        history.push(`/shortcuts${window.location.search}`);
-      } else if (lowercaseEventKey === "j" && process.env.NODE_ENV !== "production") {
-        // TODO (DWinegar): Remove this key listener once we get the screenshots for comments working.
-        e.preventDefault();
-        const element = document.querySelector(".PanelLayout-root");
-        if (!element) {
-          throw new Error(`takeScreenshot could not find element with selector ".PanelLayout-root"`);
-        }
-        takeScreenshot(element)
-          .then((blob) => {
-            if (blob) {
-              downloadFiles([{ blob, fileName: "screenshot.png" }]);
-            }
-          })
-          .catch((error) => console.warn(error));
-      }
-    },
-    [openSaveLayoutModal, openLayoutModal, history, actions, takeScreenshot]
-  );
+      takeScreenshot(element)
+        .then((blob) => {
+          if (blob) {
+            downloadFiles([{ blob, fileName: "screenshot.png" }]);
+          }
+        })
+        .catch((error) => console.warn(error));
+    }
+  }, [openSaveLayoutModal, openLayoutModal, history, actions, takeScreenshot]);
 
   // Not using KeyListener because we want to preventDefault on [ctrl+z] but not on [z], and we want
   // to handle events when text areas have focus.

--- a/packages/webviz-core/src/components/GlobalVariableSlider.js
+++ b/packages/webviz-core/src/components/GlobalVariableSlider.js
@@ -21,13 +21,10 @@ export default function GlobalVariableSlider(props: Props): ReactNode {
   const { globalVariables, setGlobalVariables } = useGlobalVariables();
   const globalVariableValue = globalVariables[props.globalVariableName];
 
-  const onChange = useCallback(
-    (newValue) => {
-      if (newValue !== globalVariableValue) {
-        setGlobalVariables({ [props.globalVariableName]: newValue });
-      }
-    },
-    [props.globalVariableName, globalVariableValue, setGlobalVariables]
-  );
+  const onChange = useCallback((newValue) => {
+    if (newValue !== globalVariableValue) {
+      setGlobalVariables({ [props.globalVariableName]: newValue });
+    }
+  }, [props.globalVariableName, globalVariableValue, setGlobalVariables]);
   return <SliderWithTicks value={globalVariableValue} sliderProps={props.sliderProps} onChange={onChange} />;
 }

--- a/packages/webviz-core/src/components/GlobalVariablesMenu.js
+++ b/packages/webviz-core/src/components/GlobalVariablesMenu.js
@@ -88,25 +88,19 @@ function GlobalVariablesMenu(props: Props) {
 
   const dispatch = useDispatch();
   const layout = useSelector((state) => state.persistedState.panels.layout);
-  const addPanelToLayout = useCallback(
-    () => {
-      setIsOpen((open) => !open);
-      dispatch(addPanel(({ type: GlobalVariables.panelType, layout, tabId: null }: AddPanelPayload)));
+  const addPanelToLayout = useCallback(() => {
+    setIsOpen((open) => !open);
+    dispatch(addPanel(({ type: GlobalVariables.panelType, layout, tabId: null }: AddPanelPayload)));
 
-      logEvent({ name: getEventNames().PANEL_ADD, tags: { [getEventTags().PANEL_TYPE]: GlobalVariables.panelType } });
-    },
-    [dispatch, layout]
-  );
+    logEvent({ name: getEventNames().PANEL_ADD, tags: { [getEventTags().PANEL_TYPE]: GlobalVariables.panelType } });
+  }, [dispatch, layout]);
 
   const { globalVariables } = useGlobalVariables();
-  useEffect(
-    () => {
-      setHasChangedVariable(!skipAnimation && !isActiveElementEditable());
-      const timerId = setTimeout(() => setHasChangedVariable(false), ANIMATION_RESET_DELAY_MS);
-      return () => clearTimeout(timerId);
-    },
-    [globalVariables, skipAnimation]
-  );
+  useEffect(() => {
+    setHasChangedVariable(!skipAnimation && !isActiveElementEditable());
+    const timerId = setTimeout(() => setHasChangedVariable(false), ANIMATION_RESET_DELAY_MS);
+    return () => clearTimeout(timerId);
+  }, [globalVariables, skipAnimation]);
 
   return (
     <ChildToggle position="below" onToggle={onToggle} isOpen={isOpen} dataTest="open-global-variables">

--- a/packages/webviz-core/src/components/GlobalVariablesTable.js
+++ b/packages/webviz-core/src/components/GlobalVariablesTable.js
@@ -151,26 +151,19 @@ function LinkedGlobalVariableRow({ name }: { name: string }): Node {
     [linkedGlobalVariables, name]
   );
 
-  const unlink = useCallback(
-    (path) => {
-      setLinkedGlobalVariables(
-        linkedGlobalVariables.filter(
-          ({ name: varName, topic, markerKeyPath }) =>
-            !(varName === name && [topic, ...markerKeyPath].join(".") === path)
-        )
-      );
-    },
-    [linkedGlobalVariables, name, setLinkedGlobalVariables]
-  );
+  const unlink = useCallback((path) => {
+    setLinkedGlobalVariables(
+      linkedGlobalVariables.filter(
+        ({ name: varName, topic, markerKeyPath }) => !(varName === name && [topic, ...markerKeyPath].join(".") === path)
+      )
+    );
+  }, [linkedGlobalVariables, name, setLinkedGlobalVariables]);
 
-  const unlinkAndDelete = useCallback(
-    () => {
-      const newLinkedGlobalVariables = linkedGlobalVariables.filter(({ name: varName }) => varName !== name);
-      setLinkedGlobalVariables(newLinkedGlobalVariables);
-      setGlobalVariables({ [name]: undefined });
-    },
-    [linkedGlobalVariables, name, setGlobalVariables, setLinkedGlobalVariables]
-  );
+  const unlinkAndDelete = useCallback(() => {
+    const newLinkedGlobalVariables = linkedGlobalVariables.filter(({ name: varName }) => varName !== name);
+    setLinkedGlobalVariables(newLinkedGlobalVariables);
+    setGlobalVariables({ [name]: undefined });
+  }, [linkedGlobalVariables, name, setGlobalVariables, setLinkedGlobalVariables]);
 
   return (
     <>
@@ -246,25 +239,22 @@ function GlobalVariablesTable(): Node {
   previousGlobalVariablesRef.current = previousGlobalVariables;
 
   const [changedVariables, setChangedVariables] = useState<string[]>([]);
-  useEffect(
-    () => {
-      if (skipAnimation.current || isActiveElementEditable()) {
-        return;
-      }
-      const newChangedVariables = union(
-        Object.keys(globalVariables),
-        Object.keys(previousGlobalVariablesRef.current || {})
-      ).filter((name) => {
-        const previousValue = previousGlobalVariablesRef.current?.[name];
-        return previousValue !== globalVariables[name];
-      });
+  useEffect(() => {
+    if (skipAnimation.current || isActiveElementEditable()) {
+      return;
+    }
+    const newChangedVariables = union(
+      Object.keys(globalVariables),
+      Object.keys(previousGlobalVariablesRef.current || {})
+    ).filter((name) => {
+      const previousValue = previousGlobalVariablesRef.current?.[name];
+      return previousValue !== globalVariables[name];
+    });
 
-      setChangedVariables(newChangedVariables);
-      const timerId = setTimeout(() => setChangedVariables([]), ANIMATION_RESET_DELAY_MS);
-      return () => clearTimeout(timerId);
-    },
-    [globalVariables, skipAnimation]
-  );
+    setChangedVariables(newChangedVariables);
+    const timerId = setTimeout(() => setChangedVariables([]), ANIMATION_RESET_DELAY_MS);
+    return () => clearTimeout(timerId);
+  }, [globalVariables, skipAnimation]);
 
   return (
     <SGlobalVariablesTable>

--- a/packages/webviz-core/src/components/GradientPicker.js
+++ b/packages/webviz-core/src/components/GradientPicker.js
@@ -59,16 +59,13 @@ export default function GradientPicker({
   const hexMinColor = getHexFromColorSettingWithDefault(minColor);
   const hexMaxColor = getHexFromColorSettingWithDefault(maxColor);
 
-  const drawGradient = useCallback(
-    (ctx, width, height) => {
-      const gradient = ctx.createLinearGradient(0, 0, width, 0);
-      gradient.addColorStop(0, hexMinColor);
-      gradient.addColorStop(1, hexMaxColor);
-      ctx.fillStyle = gradient;
-      ctx.fillRect(0, 0, width, height);
-    },
-    [hexMaxColor, hexMinColor]
-  );
+  const drawGradient = useCallback((ctx, width, height) => {
+    const gradient = ctx.createLinearGradient(0, 0, width, 0);
+    gradient.addColorStop(0, hexMinColor);
+    gradient.addColorStop(1, hexMaxColor);
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, width, height);
+  }, [hexMaxColor, hexMinColor]);
 
   return (
     <>

--- a/packages/webviz-core/src/components/GradientPicker.stories.js
+++ b/packages/webviz-core/src/components/GradientPicker.stories.js
@@ -30,33 +30,30 @@ function Story({
   const [minColor, setMinColor] = useState(initialMinColor || "");
   const [maxColor, setMaxColor] = useState(initialMaxColor || "");
 
-  useLayoutEffect(
-    () => {
-      if (!(changeMinColorAfterMount || changeMaxColorAfterMount)) {
-        return;
-      }
-      const [minTriggerEl, maxTriggerEl] = document.querySelectorAll(".rc-color-picker-trigger");
+  useLayoutEffect(() => {
+    if (!(changeMinColorAfterMount || changeMaxColorAfterMount)) {
+      return;
+    }
+    const [minTriggerEl, maxTriggerEl] = document.querySelectorAll(".rc-color-picker-trigger");
 
-      if (changeMinColorAfterMount) {
-        minTriggerEl.click();
-        setImmediate(() => {
-          const hexInput = ((document.querySelector(".rc-color-picker-panel-params-hex"): any): HTMLInputElement);
-          hexInput.value = "#d2ff03";
-          TestUtils.Simulate.change(hexInput);
-          TestUtils.Simulate.blur(hexInput);
-        });
-      } else {
-        maxTriggerEl.click();
-        setImmediate(() => {
-          const hexInput = ((document.querySelector(".rc-color-picker-panel-params-hex"): any): HTMLInputElement);
-          hexInput.value = "#c501ff";
-          TestUtils.Simulate.change(hexInput);
-          TestUtils.Simulate.blur(hexInput);
-        });
-      }
-    },
-    [changeMaxColorAfterMount, changeMinColorAfterMount]
-  );
+    if (changeMinColorAfterMount) {
+      minTriggerEl.click();
+      setImmediate(() => {
+        const hexInput = ((document.querySelector(".rc-color-picker-panel-params-hex"): any): HTMLInputElement);
+        hexInput.value = "#d2ff03";
+        TestUtils.Simulate.change(hexInput);
+        TestUtils.Simulate.blur(hexInput);
+      });
+    } else {
+      maxTriggerEl.click();
+      setImmediate(() => {
+        const hexInput = ((document.querySelector(".rc-color-picker-panel-params-hex"): any): HTMLInputElement);
+        hexInput.value = "#c501ff";
+        TestUtils.Simulate.change(hexInput);
+        TestUtils.Simulate.blur(hexInput);
+      });
+    }
+  }, [changeMaxColorAfterMount, changeMinColorAfterMount]);
 
   return (
     <div ref={containerRef} style={{ width: "400px", padding: "100px" }}>

--- a/packages/webviz-core/src/components/LayoutModal.js
+++ b/packages/webviz-core/src/components/LayoutModal.js
@@ -28,12 +28,9 @@ type Props = {|
 |};
 
 function UnconnectedLayoutModal({ onRequestClose, loadLayout: loadFetchedLayout, panels, history }: Props) {
-  const onChange = useCallback(
-    (layoutPayload: PanelsState) => {
-      loadFetchedLayout(layoutPayload);
-    },
-    [loadFetchedLayout]
-  );
+  const onChange = useCallback((layoutPayload: PanelsState) => {
+    loadFetchedLayout(layoutPayload);
+  }, [loadFetchedLayout]);
   return (
     <ShareJsonModal
       history={history}

--- a/packages/webviz-core/src/components/LogList.js
+++ b/packages/webviz-core/src/components/LogList.js
@@ -66,19 +66,16 @@ function LogList<Item>({ items, renderRow }: {| items: $ReadOnlyArray<Item>, ren
   // `onWheel` is only called when the user explicitly scrolls using the scroll wheel or track pad.
   // This is reliable, so we don't need any buffers or checks. However, this doesn't cover all cases
   // of users scrolling (e.g. keyboard or dragging the scroll bar) so we also need `onScroll` below.
-  const onWheel = React.useCallback(
-    () => {
-      const containerEl = document.getElementById(listId.current);
-      if (!containerEl) {
-        return;
-      }
-      const newAutoScroll = containerEl.scrollHeight - containerEl.scrollTop <= containerEl.clientHeight;
-      if (newAutoScroll !== autoScroll) {
-        setAutoScroll(newAutoScroll);
-      }
-    },
-    [autoScroll]
-  );
+  const onWheel = React.useCallback(() => {
+    const containerEl = document.getElementById(listId.current);
+    if (!containerEl) {
+      return;
+    }
+    const newAutoScroll = containerEl.scrollHeight - containerEl.scrollTop <= containerEl.clientHeight;
+    if (newAutoScroll !== autoScroll) {
+      setAutoScroll(newAutoScroll);
+    }
+  }, [autoScroll]);
 
   // As said above, we need `onScroll` to catch some of the user scroll events. However, it's also
   // triggered when a scroll happens for a different reason, e.g. by the browser or initiated from
@@ -86,22 +83,19 @@ function LogList<Item>({ items, renderRow }: {| items: $ReadOnlyArray<Item>, ren
   // rendering the `onScroll` events can't quite keep up with the actual rendering, so we require
   // rendering to not have happened for a second, and we have a bit of a buffer for how much
   // scrolling we require to have been done. In practice this seems to be working reasonably well.
-  const onScroll = React.useCallback(
-    () => {
-      if (Date.now() - lastRenderTime.current < 1000) {
-        return;
-      }
-      const containerEl = document.getElementById(listId.current);
-      if (!containerEl) {
-        return;
-      }
-      const newAutoScroll = containerEl.scrollHeight - containerEl.scrollTop <= containerEl.clientHeight + 5;
-      if (newAutoScroll !== autoScroll) {
-        setAutoScroll(newAutoScroll);
-      }
-    },
-    [autoScroll]
-  );
+  const onScroll = React.useCallback(() => {
+    if (Date.now() - lastRenderTime.current < 1000) {
+      return;
+    }
+    const containerEl = document.getElementById(listId.current);
+    if (!containerEl) {
+      return;
+    }
+    const newAutoScroll = containerEl.scrollHeight - containerEl.scrollTop <= containerEl.clientHeight + 5;
+    if (newAutoScroll !== autoScroll) {
+      setAutoScroll(newAutoScroll);
+    }
+  }, [autoScroll]);
 
   const onResetView = React.useCallback(() => {
     setAutoScroll(true);

--- a/packages/webviz-core/src/components/MessageOrderControls.js
+++ b/packages/webviz-core/src/components/MessageOrderControls.js
@@ -21,12 +21,9 @@ const messageOrderLabel = {
 export default function MessageOrderControls() {
   const messageOrder = useSelector((state) => state.persistedState.panels.playbackConfig.messageOrder);
   const dispatch = useDispatch();
-  const setMessageOrder = useCallback(
-    (newMessageOrder) => {
-      dispatch(setPlaybackConfig({ messageOrder: newMessageOrder }));
-    },
-    [dispatch]
-  );
+  const setMessageOrder = useCallback((newMessageOrder) => {
+    dispatch(setPlaybackConfig({ messageOrder: newMessageOrder }));
+  }, [dispatch]);
 
   const orderText = messageOrderLabel[messageOrder] || defaultPlaybackConfig.messageOrder;
   const tooltip = `Order messages by ${orderText.toLowerCase()}`;

--- a/packages/webviz-core/src/components/MessagePathSyntax/useLatestMessageDataItem.js
+++ b/packages/webviz-core/src/components/MessagePathSyntax/useLatestMessageDataItem.js
@@ -24,36 +24,33 @@ export function useLatestMessageDataItem(path: string, format: MessageFormat): ?
   const topics = useMemo(() => (rosPath ? [rosPath.topicName] : []), [rosPath]);
   const cachedGetMessagePathDataItems = useCachedGetMessagePathDataItems([path]);
 
-  const addMessages: (?MessageAndData, $ReadOnlyArray<Message>) => ?MessageAndData = useCallback(
-    (prevMessageAndData: ?MessageAndData, messages: $ReadOnlyArray<Message>) => {
-      // Iterate in reverse so we can early-return and not process all messages.
-      for (let i = messages.length - 1; i >= 0; --i) {
-        const message = messages[i];
-        const queriedData = cachedGetMessagePathDataItems(path, message);
-        if (queriedData == null) {
-          // Invalid path.
-          return;
-        }
-        if (queriedData.length > 0) {
-          return { message, queriedData };
-        }
+  const addMessages: (?MessageAndData, $ReadOnlyArray<Message>) => ?MessageAndData = useCallback((
+    prevMessageAndData: ?MessageAndData,
+    messages: $ReadOnlyArray<Message>
+  ) => {
+    // Iterate in reverse so we can early-return and not process all messages.
+    for (let i = messages.length - 1; i >= 0; --i) {
+      const message = messages[i];
+      const queriedData = cachedGetMessagePathDataItems(path, message);
+      if (queriedData == null) {
+        // Invalid path.
+        return;
       }
-      return prevMessageAndData;
-    },
-    [cachedGetMessagePathDataItems, path]
-  );
+      if (queriedData.length > 0) {
+        return { message, queriedData };
+      }
+    }
+    return prevMessageAndData;
+  }, [cachedGetMessagePathDataItems, path]);
 
-  const restore = useCallback(
-    (prevMessageAndData: ?MessageAndData): ?MessageAndData => {
-      if (prevMessageAndData) {
-        const queriedData = cachedGetMessagePathDataItems(path, prevMessageAndData.message);
-        if (queriedData && queriedData.length > 0) {
-          return { message: prevMessageAndData.message, queriedData };
-        }
+  const restore = useCallback((prevMessageAndData: ?MessageAndData): ?MessageAndData => {
+    if (prevMessageAndData) {
+      const queriedData = cachedGetMessagePathDataItems(path, prevMessageAndData.message);
+      if (queriedData && queriedData.length > 0) {
+        return { message: prevMessageAndData.message, queriedData };
       }
-    },
-    [cachedGetMessagePathDataItems, path]
-  );
+    }
+  }, [cachedGetMessagePathDataItems, path]);
 
   // A backfill is not automatically requested when the above callbacks' identities change, so we
   // need to do that manually.

--- a/packages/webviz-core/src/components/NoHeaderTopicsButton.js
+++ b/packages/webviz-core/src/components/NoHeaderTopicsButton.js
@@ -39,65 +39,59 @@ function getTopics({ playerState: { activeData } }) {
 
 function useTopicsWithoutHeaders() {
   const { topicsWithoutHeaderStamps, topics } = useMessagePipeline(getTopics);
-  return useMemo(
-    () => {
-      const topicsByName = groupBy(topics, "name");
-      return (topicsWithoutHeaderStamps || []).map((topicName) => {
-        return { topic: topicName, datatype: topicsByName[topicName]?.[0]?.datatype };
-      });
-    },
-    [topicsWithoutHeaderStamps, topics]
-  );
+  return useMemo(() => {
+    const topicsByName = groupBy(topics, "name");
+    return (topicsWithoutHeaderStamps || []).map((topicName) => {
+      return { topic: topicName, datatype: topicsByName[topicName]?.[0]?.datatype };
+    });
+  }, [topicsWithoutHeaderStamps, topics]);
 }
 
 export default function NoHeaderTopicsButton() {
   const topicsWithoutHeaders = useTopicsWithoutHeaders();
-  return useMemo(
-    () => {
-      if (!topicsWithoutHeaders.length) {
-        return null;
-      }
-      const rows = topicsWithoutHeaders.sort().map(({ topic, datatype }) => (
-        <tr key={topic}>
-          <td>{topic}</td>
-          <td>{datatype}</td>
-        </tr>
-      ));
-      const color = topicsWithoutHeaders.length > COLOR_THRESHOLD ? "#F7BE00" : "default";
-      const tooltip =
-        topicsWithoutHeaders.length === 1
-          ? "1 subscribed topic does not have headers"
-          : `${topicsWithoutHeaders.length} subscribed topics do not have headers`;
-      return (
-        <Icon
-          tooltip={tooltip}
-          onClick={() => {
-            const modal = renderToBody(
-              <Modal onRequestClose={() => modal.remove()}>
-                <SRoot>
-                  <Title>Topics without headers</Title>
-                  <TextContent>
-                    <p>These topics will not be visible in panels when ordering data by header stamp:</p>
-                    <table>
-                      <thead>
-                        <tr>
-                          <th>Topic</th>
-                          <th>Datatype</th>
-                        </tr>
-                      </thead>
-                      <tbody>{rows}</tbody>
-                    </table>
-                  </TextContent>
-                </SRoot>
-              </Modal>
-            );
-          }}
-          style={{ color, paddingRight: "6px" }}
-          dataTest="missing-headers-icon">
-          <InformationIcon />
-        </Icon>
-      );
-    },
-    [topicsWithoutHeaders]
-  );
+  return useMemo(() => {
+    if (!topicsWithoutHeaders.length) {
+      return null;
+    }
+    const rows = topicsWithoutHeaders.sort().map(({ topic, datatype }) => (
+      <tr key={topic}>
+        <td>{topic}</td>
+        <td>{datatype}</td>
+      </tr>
+    ));
+    const color = topicsWithoutHeaders.length > COLOR_THRESHOLD ? "#F7BE00" : "default";
+    const tooltip =
+      topicsWithoutHeaders.length === 1
+        ? "1 subscribed topic does not have headers"
+        : `${topicsWithoutHeaders.length} subscribed topics do not have headers`;
+    return (
+      <Icon
+        tooltip={tooltip}
+        onClick={() => {
+          const modal = renderToBody(
+            <Modal onRequestClose={() => modal.remove()}>
+              <SRoot>
+                <Title>Topics without headers</Title>
+                <TextContent>
+                  <p>These topics will not be visible in panels when ordering data by header stamp:</p>
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Topic</th>
+                        <th>Datatype</th>
+                      </tr>
+                    </thead>
+                    <tbody>{rows}</tbody>
+                  </table>
+                </TextContent>
+              </SRoot>
+            </Modal>
+          );
+        }}
+        style={{ color, paddingRight: "6px" }}
+        dataTest="missing-headers-icon">
+        <InformationIcon />
+      </Icon>
+    );
+  }, [topicsWithoutHeaders]);
 }

--- a/packages/webviz-core/src/components/PanelLayout.js
+++ b/packages/webviz-core/src/components/PanelLayout.js
@@ -75,72 +75,66 @@ export function UnconnectedPanelLayout(props: Props) {
       });
   }
 
-  const createTile = useCallback(
-    (config: any) => {
-      const defaultPanelType = "RosOut";
-      const type = config ? config.type || defaultPanelType : defaultPanelType;
-      const id = getPanelIdForType(type);
-      if (config.panelConfig) {
-        saveConfigs({ configs: [{ id, config: config.panelConfig }] });
-      }
-      return id;
-    },
-    [saveConfigs]
-  );
+  const createTile = useCallback((config: any) => {
+    const defaultPanelType = "RosOut";
+    const type = config ? config.type || defaultPanelType : defaultPanelType;
+    const id = getPanelIdForType(type);
+    if (config.panelConfig) {
+      saveConfigs({ configs: [{ id, config: config.panelConfig }] });
+    }
+    return id;
+  }, [saveConfigs]);
 
-  const renderTile = useCallback(
-    (id: string | {}, path: any) => {
-      // `id` is usually a string. But when `layout` is empty, `id` will be an empty object, in which case we don't need to render Tile
-      if (!id || typeof id !== "string") {
-        return;
-      }
-      const type = getPanelTypeFromId(id);
-      const MosaicWindowComponent = type === "Tab" ? MosaicDumbWindow : MosaicWindow;
+  const renderTile = useCallback((id: string | {}, path: any) => {
+    // `id` is usually a string. But when `layout` is empty, `id` will be an empty object, in which case we don't need to render Tile
+    if (!id || typeof id !== "string") {
+      return;
+    }
+    const type = getPanelTypeFromId(id);
+    const MosaicWindowComponent = type === "Tab" ? MosaicDumbWindow : MosaicWindow;
 
-      return (
-        <MosaicWindowComponent key={path} path={path} createNode={createTile} renderPreview={() => null} tabId={tabId}>
-          {(() => {
-            if (!hooksImported) {
-              return null;
-            }
-            // If we haven't found a panel of the given type, render the panel selector
-            const PanelComponent = PanelList.getComponentForType(type);
-            if (!PanelComponent) {
-              return (
-                <MosaicWindow path={path} createNode={createTile} renderPreview={() => null}>
-                  <Flex col center>
-                    <PanelToolbar floating isUnknownPanel />
-                    Unknown panel type: {type}.
-                  </Flex>
-                </MosaicWindow>
-              );
-            }
-            return <PanelComponent childId={id} tabId={tabId} />;
-          })()}
-          <div
-            style={{
-              top: 0,
-              left: 0,
-              width: "100%",
-              height: "100%",
-              position: "absolute",
-              background: colors.DARK2,
-              opacity: hooksImported ? 0 : 1,
-              pointerEvents: "none",
-              zIndex: 1,
-              transition: `all ${0.35}s ease-out ${Math.random() + 0.25}s`,
-            }}>
-            <Flex center style={{ width: "100%", height: "100%" }}>
-              <Icon large>
-                <SpinningLoadingIcon />
-              </Icon>
-            </Flex>
-          </div>
-        </MosaicWindowComponent>
-      );
-    },
-    [createTile, hooksImported, tabId]
-  );
+    return (
+      <MosaicWindowComponent key={path} path={path} createNode={createTile} renderPreview={() => null} tabId={tabId}>
+        {(() => {
+          if (!hooksImported) {
+            return null;
+          }
+          // If we haven't found a panel of the given type, render the panel selector
+          const PanelComponent = PanelList.getComponentForType(type);
+          if (!PanelComponent) {
+            return (
+              <MosaicWindow path={path} createNode={createTile} renderPreview={() => null}>
+                <Flex col center>
+                  <PanelToolbar floating isUnknownPanel />
+                  Unknown panel type: {type}.
+                </Flex>
+              </MosaicWindow>
+            );
+          }
+          return <PanelComponent childId={id} tabId={tabId} />;
+        })()}
+        <div
+          style={{
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
+            position: "absolute",
+            background: colors.DARK2,
+            opacity: hooksImported ? 0 : 1,
+            pointerEvents: "none",
+            zIndex: 1,
+            transition: `all ${0.35}s ease-out ${Math.random() + 0.25}s`,
+          }}>
+          <Flex center style={{ width: "100%", height: "100%" }}>
+            <Icon large>
+              <SpinningLoadingIcon />
+            </Icon>
+          </Flex>
+        </div>
+      </MosaicWindowComponent>
+    );
+  }, [createTile, hooksImported, tabId]);
   const isDemoMode = useExperimentalFeature("demoMode");
   const bodyToRender = useMemo(
     () =>
@@ -171,12 +165,9 @@ const ConnectedPanelLayout = ({ importHooks = true }: { importHooks?: boolean },
     () => bindActionCreators({ changePanelLayout, savePanelConfigs, setMosaicId }, dispatch),
     [dispatch]
   );
-  const onChange = useCallback(
-    (newLayout: MosaicNode) => {
-      actions.changePanelLayout({ layout: newLayout });
-    },
-    [actions]
-  );
+  const onChange = useCallback((newLayout: MosaicNode) => {
+    actions.changePanelLayout({ layout: newLayout });
+  }, [actions]);
   return (
     <UnconnectedPanelLayout
       forwardedRef={ref}

--- a/packages/webviz-core/src/components/PanelToolbar/index.js
+++ b/packages/webviz-core/src/components/PanelToolbar/index.js
@@ -69,34 +69,28 @@ function StandardMenuItems({ tabId, isUnknownPanel }: { tabId?: string, isUnknow
     mosaicWindowActions,
   ]);
 
-  const close = useCallback(
-    () => {
-      logEvent({ name: getEventNames().PANEL_REMOVE, tags: { [getEventTags().PANEL_TYPE]: getPanelType() } });
-      actions.closePanel({ tabId, root: mosaicActions.getRoot(), path: mosaicWindowActions.getPath() });
-    },
-    [actions, getPanelType, mosaicActions, mosaicWindowActions, tabId]
-  );
+  const close = useCallback(() => {
+    logEvent({ name: getEventNames().PANEL_REMOVE, tags: { [getEventTags().PANEL_TYPE]: getPanelType() } });
+    actions.closePanel({ tabId, root: mosaicActions.getRoot(), path: mosaicWindowActions.getPath() });
+  }, [actions, getPanelType, mosaicActions, mosaicWindowActions, tabId]);
 
-  const split = useCallback(
-    (store, id: ?string, direction: "row" | "column") => {
-      const type = getPanelType();
-      if (!id || !type) {
-        throw new Error("Trying to split unknown panel!");
-      }
-      logEvent({ name: getEventNames().PANEL_SPLIT, tags: { [getEventTags().PANEL_TYPE]: getPanelType() } });
+  const split = useCallback((store, id: ?string, direction: "row" | "column") => {
+    const type = getPanelType();
+    if (!id || !type) {
+      throw new Error("Trying to split unknown panel!");
+    }
+    logEvent({ name: getEventNames().PANEL_SPLIT, tags: { [getEventTags().PANEL_TYPE]: getPanelType() } });
 
-      const config = savedProps[id];
-      actions.splitPanel({
-        id,
-        tabId,
-        direction,
-        root: mosaicActions.getRoot(),
-        path: mosaicWindowActions.getPath(),
-        config,
-      });
-    },
-    [actions, getPanelType, mosaicActions, mosaicWindowActions, savedProps, tabId]
-  );
+    const config = savedProps[id];
+    actions.splitPanel({
+      id,
+      tabId,
+      direction,
+      root: mosaicActions.getRoot(),
+      path: mosaicWindowActions.getPath(),
+      config,
+    });
+  }, [actions, getPanelType, mosaicActions, mosaicWindowActions, savedProps, tabId]);
 
   const swap = useCallback(
     (id: ?string) => ({ type, config, relatedConfigs }: PanelSelection) => {
@@ -114,23 +108,20 @@ function StandardMenuItems({ tabId, isUnknownPanel }: { tabId?: string, isUnknow
     [actions, mosaicActions, mosaicWindowActions, tabId]
   );
 
-  const onImportClick = useCallback(
-    (store, id) => {
-      if (!id) {
-        return;
-      }
-      const panelConfigById = store.getState().persistedState.panels.savedProps;
-      const modal = renderToBody(
-        <ShareJsonModal
-          onRequestClose={() => modal.remove()}
-          value={panelConfigById[id] || {}}
-          onChange={(config) => actions.savePanelConfigs({ configs: [{ id, config, override: true }] })}
-          noun="panel configuration"
-        />
-      );
-    },
-    [actions]
-  );
+  const onImportClick = useCallback((store, id) => {
+    if (!id) {
+      return;
+    }
+    const panelConfigById = store.getState().persistedState.panels.savedProps;
+    const modal = renderToBody(
+      <ShareJsonModal
+        onRequestClose={() => modal.remove()}
+        value={panelConfigById[id] || {}}
+        onChange={(config) => actions.savePanelConfigs({ configs: [{ id, config, override: true }] })}
+        noun="panel configuration"
+      />
+    );
+  }, [actions]);
 
   const type = getPanelType();
   if (!type) {

--- a/packages/webviz-core/src/components/PlaybackControls/PlaybackBarHoverTicks.js
+++ b/packages/webviz-core/src/components/PlaybackControls/PlaybackBarHoverTicks.js
@@ -52,28 +52,25 @@ export default React.memo<Props>(({ componentId }: Props) => {
   const { startTime, endTime } = useMessagePipeline(getStartAndEndTime);
   const [width, setWidth] = useState<?number>();
 
-  const scaleBounds = useMemo(
-    () => {
-      if (width == null || startTime == null || endTime == null) {
-        return null;
-      }
-      return {
-        // HoverBar takes a ref to avoid rerendering (and avoid needing to rerender) when the bounds
-        // change in charts that scroll at playback speed.
-        current: [
-          {
-            id: componentId,
-            min: 0,
-            max: toSec(endTime) - toSec(startTime),
-            axes: "xAxes",
-            minAlongAxis: 0,
-            maxAlongAxis: width,
-          },
-        ],
-      };
-    },
-    [width, startTime, endTime, componentId]
-  );
+  const scaleBounds = useMemo(() => {
+    if (width == null || startTime == null || endTime == null) {
+      return null;
+    }
+    return {
+      // HoverBar takes a ref to avoid rerendering (and avoid needing to rerender) when the bounds
+      // change in charts that scroll at playback speed.
+      current: [
+        {
+          id: componentId,
+          min: 0,
+          max: toSec(endTime) - toSec(startTime),
+          axes: "xAxes",
+          minAlongAxis: 0,
+          maxAlongAxis: width,
+        },
+      ],
+    };
+  }, [width, startTime, endTime, componentId]);
 
   return (
     <>

--- a/packages/webviz-core/src/components/PlaybackControls/index.js
+++ b/packages/webviz-core/src/components/PlaybackControls/index.js
@@ -99,50 +99,44 @@ export const UnconnectedPlaybackControls = memo<PlaybackControlProps>((props: Pl
 
   const [hoverComponentId] = useState<string>(uuid.v4());
   const dispatch = useDispatch();
-  const onMouseMove = useCallback(
-    (e: SyntheticMouseEvent<HTMLDivElement>) => {
-      const { activeData } = playerState.current;
-      if (!activeData) {
-        return;
-      }
-      const { startTime, endTime } = activeData || {};
-      if (!startTime || !endTime || el.current == null || slider.current == null) {
-        return;
-      }
-      const currentEl = el.current;
-      const currentSlider = slider.current;
-      const x = e.clientX;
-      // fix the y position of the tooltip to float on top of the playback bar
-      const y = currentEl.getBoundingClientRect().top;
+  const onMouseMove = useCallback((e: SyntheticMouseEvent<HTMLDivElement>) => {
+    const { activeData } = playerState.current;
+    if (!activeData) {
+      return;
+    }
+    const { startTime, endTime } = activeData || {};
+    if (!startTime || !endTime || el.current == null || slider.current == null) {
+      return;
+    }
+    const currentEl = el.current;
+    const currentSlider = slider.current;
+    const x = e.clientX;
+    // fix the y position of the tooltip to float on top of the playback bar
+    const y = currentEl.getBoundingClientRect().top;
 
-      const value = currentSlider.getValueAtMouse(e);
-      const stamp = fromSec(value);
-      const timeFromStart = subtractTimes(stamp, startTime);
+    const value = currentSlider.getValueAtMouse(e);
+    const stamp = fromSec(value);
+    const timeFromStart = subtractTimes(stamp, startTime);
 
-      const tip = (
-        <div className={classnames(tooltipStyles.tooltip, styles.tip)}>
-          <TooltipItem title="ROS" value={formatTimeRaw(stamp)} />
-          <TooltipItem title="Time" value={formatTime(stamp)} />
-          <TooltipItem title="Elapsed" value={`${toSec(timeFromStart).toFixed(9)} sec`} />
-        </div>
-      );
-      Tooltip.show(x, y, tip, {
-        placement: "top",
-        offset: { x: 0, y: 0 },
-        arrow: <div className={tooltipStyles.arrow} />,
-      });
-      dispatch(setHoverValue({ componentId: hoverComponentId, type: "PLAYBACK_SECONDS", value: toSec(timeFromStart) }));
-    },
-    [playerState, dispatch, hoverComponentId]
-  );
+    const tip = (
+      <div className={classnames(tooltipStyles.tooltip, styles.tip)}>
+        <TooltipItem title="ROS" value={formatTimeRaw(stamp)} />
+        <TooltipItem title="Time" value={formatTime(stamp)} />
+        <TooltipItem title="Elapsed" value={`${toSec(timeFromStart).toFixed(9)} sec`} />
+      </div>
+    );
+    Tooltip.show(x, y, tip, {
+      placement: "top",
+      offset: { x: 0, y: 0 },
+      arrow: <div className={tooltipStyles.arrow} />,
+    });
+    dispatch(setHoverValue({ componentId: hoverComponentId, type: "PLAYBACK_SECONDS", value: toSec(timeFromStart) }));
+  }, [playerState, dispatch, hoverComponentId]);
 
-  const onMouseLeave = useCallback(
-    (_e: SyntheticMouseEvent<HTMLDivElement>) => {
-      Tooltip.hide();
-      dispatch(clearHoverValue({ componentId: hoverComponentId }));
-    },
-    [dispatch, hoverComponentId]
-  );
+  const onMouseLeave = useCallback((_e: SyntheticMouseEvent<HTMLDivElement>) => {
+    Tooltip.hide();
+    dispatch(clearHoverValue({ componentId: hoverComponentId }));
+  }, [dispatch, hoverComponentId]);
 
   const { activeData, progress } = player;
   const { isPlaying, startTime, endTime, currentTime } = activeData || {};

--- a/packages/webviz-core/src/components/PlaybackSpeedControls.js
+++ b/packages/webviz-core/src/components/PlaybackSpeedControls.js
@@ -31,15 +31,12 @@ export default function PlaybackSpeedControls() {
   const setPlaybackSpeed = useMessagePipeline(
     useCallback(({ setPlaybackSpeed: pipelineSetPlaybackSpeed }) => pipelineSetPlaybackSpeed, [])
   );
-  const setSpeed = useCallback(
-    (newSpeed) => {
-      dispatch(setPlaybackConfig({ speed: newSpeed }));
-      if (canSetSpeed) {
-        setPlaybackSpeed(newSpeed);
-      }
-    },
-    [canSetSpeed, dispatch, setPlaybackSpeed]
-  );
+  const setSpeed = useCallback((newSpeed) => {
+    dispatch(setPlaybackConfig({ speed: newSpeed }));
+    if (canSetSpeed) {
+      setPlaybackSpeed(newSpeed);
+    }
+  }, [canSetSpeed, dispatch, setPlaybackSpeed]);
 
   // Set the speed to the speed that we got from the config whenever we get a new Player.
   useEffect(() => setSpeed(configSpeed), [configSpeed, setSpeed]);

--- a/packages/webviz-core/src/components/Radio.stories.js
+++ b/packages/webviz-core/src/components/Radio.stories.js
@@ -37,14 +37,11 @@ function Box({
   onMount?: (HTMLDivElement) => void,
 }) {
   const ref = React.useRef();
-  React.useLayoutEffect(
-    () => {
-      if (ref.current && onMount) {
-        onMount(ref.current);
-      }
-    },
-    [onMount]
-  );
+  React.useLayoutEffect(() => {
+    if (ref.current && onMount) {
+      onMount(ref.current);
+    }
+  }, [onMount]);
   return (
     <div style={{ margin: 24, width: 432 }} ref={ref}>
       <p>{title}</p>

--- a/packages/webviz-core/src/components/ReactChartjs/index.stories.js
+++ b/packages/webviz-core/src/components/ReactChartjs/index.stories.js
@@ -108,17 +108,14 @@ function DatalabelUpdateExample({ forceDisableWorkerRendering }: { forceDisableW
 
 function DatalabelClickExample() {
   const [clickedDatalabel, setClickedDatalabel] = useState<any>(null);
-  const refFn = useCallback(
-    () => {
-      setTimeout(() => {
-        if (!clickedDatalabel) {
-          const [canvas] = document.getElementsByTagName("canvas");
-          TestUtils.Simulate.click(canvas, { clientX: 245, clientY: 419 });
-        }
-      }, 200);
-    },
-    [clickedDatalabel]
-  );
+  const refFn = useCallback(() => {
+    setTimeout(() => {
+      if (!clickedDatalabel) {
+        const [canvas] = document.getElementsByTagName("canvas");
+        TestUtils.Simulate.click(canvas, { clientX: 245, clientY: 419 });
+      }
+    }, 200);
+  }, [clickedDatalabel]);
 
   return (
     <div style={divStyle} ref={refFn}>

--- a/packages/webviz-core/src/components/Root.js
+++ b/packages/webviz-core/src/components/Root.js
@@ -49,17 +49,14 @@ type Props = {|
 
 function App({ importPanelLayout: importPanelLayoutProp }) {
   const containerRef = useRef<?HTMLDivElement>(undefined);
-  useEffect(
-    () => {
-      // Focus on page load to enable keyboard interaction.
-      if (containerRef.current) {
-        containerRef.current.focus();
-      }
-      // Add a hook for integration tests.
-      window.setPanelLayout = (payload) => importPanelLayoutProp(payload);
-    },
-    [importPanelLayoutProp]
-  );
+  useEffect(() => {
+    // Focus on page load to enable keyboard interaction.
+    if (containerRef.current) {
+      containerRef.current.focus();
+    }
+    // Add a hook for integration tests.
+    window.setPanelLayout = (payload) => importPanelLayoutProp(payload);
+  }, [importPanelLayoutProp]);
 
   return (
     <div ref={containerRef} className="app-container" tabIndex={0}>

--- a/packages/webviz-core/src/components/Screenshots/ScreenshotsProvider.js
+++ b/packages/webviz-core/src/components/Screenshots/ScreenshotsProvider.js
@@ -35,29 +35,26 @@ export function ScreenshotsProvider({ children }: { children: React$Node }) {
   const isTakingScreenshotRef = useRef(isTakingScreenshot);
   isTakingScreenshotRef.current = isTakingScreenshot;
 
-  const takeScreenshot = useCallback(
-    async (element: HTMLElement): Promise<?Blob> => {
-      if (isTakingScreenshotRef.current) {
-        return;
-      }
+  const takeScreenshot = useCallback(async (element: HTMLElement): Promise<?Blob> => {
+    if (isTakingScreenshotRef.current) {
+      return;
+    }
 
-      // We always pause playback when taking the screenshot.
-      pausePlayback();
-      setIsTakingScreenshot(true);
+    // We always pause playback when taking the screenshot.
+    pausePlayback();
+    setIsTakingScreenshot(true);
 
-      let image;
-      try {
-        image = await domToImage.toBlob(element, { scrollFix: true });
-      } catch (error) {
-        log.error(error);
-        sendNotification("Error taking screenshot", error.stack, "app", "error");
-      } finally {
-        setIsTakingScreenshot(false);
-      }
-      return image;
-    },
-    [pausePlayback]
-  );
+    let image;
+    try {
+      image = await domToImage.toBlob(element, { scrollFix: true });
+    } catch (error) {
+      log.error(error);
+      sendNotification("Error taking screenshot", error.stack, "app", "error");
+    } finally {
+      setIsTakingScreenshot(false);
+    }
+    return image;
+  }, [pausePlayback]);
 
   const contextValue = {
     takeScreenshot,

--- a/packages/webviz-core/src/components/TextField.js
+++ b/packages/webviz-core/src/components/TextField.js
@@ -66,59 +66,44 @@ export default function TextField({
   const prevIncomingVal = useRef("");
   const inputRef = useRef(null);
 
-  useLayoutEffect(
-    () => {
-      // only compare if it's a controlled component
-      if (!defaultValue && !validateOnBlur && prevIncomingVal.current !== value) {
-        const validationResult = validator(value);
-        setError(validationResult || null);
-        setInputStr(value || "");
-      }
-      prevIncomingVal.current = value;
-    },
-    [defaultValue, validateOnBlur, validator, value]
-  );
+  useLayoutEffect(() => {
+    // only compare if it's a controlled component
+    if (!defaultValue && !validateOnBlur && prevIncomingVal.current !== value) {
+      const validationResult = validator(value);
+      setError(validationResult || null);
+      setInputStr(value || "");
+    }
+    prevIncomingVal.current = value;
+  }, [defaultValue, validateOnBlur, validator, value]);
 
-  useLayoutEffect(
-    () => {
-      if (inputRef.current && focusOnMount) {
-        inputRef.current.focus();
-      }
-    },
-    [focusOnMount]
-  );
+  useLayoutEffect(() => {
+    if (inputRef.current && focusOnMount) {
+      inputRef.current.focus();
+    }
+  }, [focusOnMount]);
 
-  useLayoutEffect(
-    () => {
-      if (onError) {
-        onError(error);
-      }
-    },
-    [error, onError]
-  );
+  useLayoutEffect(() => {
+    if (onError) {
+      onError(error);
+    }
+  }, [error, onError]);
 
-  const validate = useCallback(
-    (val) => {
-      const validationResult = validator(val);
-      if (validationResult) {
-        setError(validationResult);
-      } else {
-        setError(null);
-        onChange(val);
-      }
-    },
-    [onChange, validator]
-  );
+  const validate = useCallback((val) => {
+    const validationResult = validator(val);
+    if (validationResult) {
+      setError(validationResult);
+    } else {
+      setError(null);
+      onChange(val);
+    }
+  }, [onChange, validator]);
 
-  const handleChange = useCallback(
-    ({ target }) => {
-      setInputStr(target.value);
-      if (!validateOnBlur) {
-        validate(target.value);
-      }
-    },
-    [validate, validateOnBlur]
-  );
+  const handleChange = useCallback(({ target }) => {
+    setInputStr(target.value);
+    if (!validateOnBlur) {
+      validate(target.value);
+    }
+  }, [validate, validateOnBlur]);
 
   const handleBlur = useCallback(
     () => {

--- a/packages/webviz-core/src/components/TimeBasedChart/index.js
+++ b/packages/webviz-core/src/components/TimeBasedChart/index.js
@@ -220,135 +220,109 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
   const [followPlaybackState, setFollowPlaybackState] = useState<?FollowPlaybackState>(null);
   const [, forceUpdate] = useState();
 
-  const onVisibilityChange = useCallback(
-    () => {
-      if (document.visibilityState === "visible") {
-        // HACK: There is a Chrome bug that causes 2d canvas elements to get cleared when the page
-        // becomes hidden on certain hardware:
-        // https://bugs.chromium.org/p/chromium/issues/detail?id=588434
-        // https://bugs.chromium.org/p/chromium/issues/detail?id=591374
-        // We can hack around this by forcing a re-render when the page becomes visible again.
-        // There may be other canvases that this affects, but these seemed like the most important.
-        // Ideally we can find a global workaround but we're not sure there is one — can't just
-        // twiddle the width/height attribute of the canvas as suggested in one of the comments on
-        // a chrome bug; it seems like you really have to redraw the frame from scratch.
-        forceUpdate();
-      }
-    },
-    [forceUpdate]
-  );
-  useEffect(
-    () => {
-      document.addEventListener("visibilitychange", onVisibilityChange);
-      return () => {
-        document.removeEventListener("visibilitychange", onVisibilityChange);
-      };
-    },
-    [onVisibilityChange]
-  );
+  const onVisibilityChange = useCallback(() => {
+    if (document.visibilityState === "visible") {
+      // HACK: There is a Chrome bug that causes 2d canvas elements to get cleared when the page
+      // becomes hidden on certain hardware:
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=588434
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=591374
+      // We can hack around this by forcing a re-render when the page becomes visible again.
+      // There may be other canvases that this affects, but these seemed like the most important.
+      // Ideally we can find a global workaround but we're not sure there is one — can't just
+      // twiddle the width/height attribute of the canvas as suggested in one of the comments on
+      // a chrome bug; it seems like you really have to redraw the frame from scratch.
+      forceUpdate();
+    }
+  }, [forceUpdate]);
+  useEffect(() => {
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [onVisibilityChange]);
 
   const pauseFrame = useMessagePipeline(useCallback((messagePipeline) => messagePipeline.pauseFrame, []));
 
-  const onChartUpdate = useCallback(
-    () => {
-      const resumeFrame = pauseFrame("TimeBasedChart");
-      return () => {
-        resumeFrame();
-      };
-    },
-    [pauseFrame]
-  );
+  const onChartUpdate = useCallback(() => {
+    const resumeFrame = pauseFrame("TimeBasedChart");
+    return () => {
+      resumeFrame();
+    };
+  }, [pauseFrame]);
 
   const { saveCurrentView, yAxes } = props;
   const scaleBounds = useRef<?$ReadOnlyArray<ScaleBounds>>();
   const hoverBar = useRef<?HTMLElement>();
-  const onScaleBoundsUpdate = useCallback(
-    (scales) => {
-      scaleBounds.current = scales;
-      const firstYScale = scales.find(({ axes }) => axes === "yAxes");
-      const firstXScale = scales.find(({ axes }) => axes === "xAxes");
-      const width = firstXScale && firstXScale.max - firstXScale.min;
-      if (
-        firstYScale &&
-        saveCurrentView &&
-        typeof firstYScale.min === "number" &&
-        typeof firstYScale.max === "number"
-      ) {
-        saveCurrentView(firstYScale.min, firstYScale.max, width);
-      }
-      if (firstYScale != null && hoverBar.current != null) {
-        const { current } = hoverBar;
-        const topPx = Math.min(firstYScale.minAlongAxis, firstYScale.maxAlongAxis);
-        const bottomPx = Math.max(firstYScale.minAlongAxis, firstYScale.maxAlongAxis);
-        current.style.top = `${topPx}px`;
-        current.style.height = `${bottomPx - topPx}px`;
-      }
-    },
-    [saveCurrentView, scaleBounds]
-  );
+  const onScaleBoundsUpdate = useCallback((scales) => {
+    scaleBounds.current = scales;
+    const firstYScale = scales.find(({ axes }) => axes === "yAxes");
+    const firstXScale = scales.find(({ axes }) => axes === "xAxes");
+    const width = firstXScale && firstXScale.max - firstXScale.min;
+    if (firstYScale && saveCurrentView && typeof firstYScale.min === "number" && typeof firstYScale.max === "number") {
+      saveCurrentView(firstYScale.min, firstYScale.max, width);
+    }
+    if (firstYScale != null && hoverBar.current != null) {
+      const { current } = hoverBar;
+      const topPx = Math.min(firstYScale.minAlongAxis, firstYScale.maxAlongAxis);
+      const bottomPx = Math.max(firstYScale.minAlongAxis, firstYScale.maxAlongAxis);
+      current.style.top = `${topPx}px`;
+      current.style.height = `${bottomPx - topPx}px`;
+    }
+  }, [saveCurrentView, scaleBounds]);
 
   const { onClick } = props;
   const lastPanTime = useRef<?Date>();
 
-  const onClickAddingValues = useCallback(
-    (ev: SyntheticMouseEvent<HTMLCanvasElement>, datalabel: ?any) => {
-      if (!onClick) {
+  const onClickAddingValues = useCallback((ev: SyntheticMouseEvent<HTMLCanvasElement>, datalabel: ?any) => {
+    if (!onClick) {
+      return;
+    }
+    if (lastPanTime.current && new Date() - lastPanTime.current < PAN_CLICK_SUPPRESS_THRESHOLD_MS) {
+      // Ignore clicks that happen too soon after a pan. Sometimes clicks get fired at the end of
+      // drags on touchpads.
+      return;
+    }
+    const values = {};
+    (scaleBounds.current || []).forEach((bounds) => {
+      const chartPx =
+        bounds.axes === "xAxes"
+          ? // $FlowFixMe: getBoundingClientRect, ClientRect.x
+            ev.clientX - ev.target.getBoundingClientRect().x
+          : // $FlowFixMe: getBoundingClientRect, ClientRect.y
+            ev.clientY - ev.target.getBoundingClientRect().y;
+      const value = getChartValue(bounds, chartPx);
+      if (value == null) {
         return;
       }
-      if (lastPanTime.current && new Date() - lastPanTime.current < PAN_CLICK_SUPPRESS_THRESHOLD_MS) {
-        // Ignore clicks that happen too soon after a pan. Sometimes clicks get fired at the end of
-        // drags on touchpads.
-        return;
-      }
-      const values = {};
-      (scaleBounds.current || []).forEach((bounds) => {
-        const chartPx =
-          bounds.axes === "xAxes"
-            ? // $FlowFixMe: getBoundingClientRect, ClientRect.x
-              ev.clientX - ev.target.getBoundingClientRect().x
-            : // $FlowFixMe: getBoundingClientRect, ClientRect.y
-              ev.clientY - ev.target.getBoundingClientRect().y;
-        const value = getChartValue(bounds, chartPx);
-        if (value == null) {
-          return;
-        }
-        values[bounds.id] = value;
-      });
-      return onClick(ev, datalabel, values);
-    },
-    [onClick, scaleBounds, lastPanTime]
-  );
+      values[bounds.id] = value;
+    });
+    return onClick(ev, datalabel, values);
+  }, [onClick, scaleBounds, lastPanTime]);
 
   // Keep a ref to props.currentTime so onPanZoom can have stable identity
   const currentTimeRef = useRef<?number>();
   currentTimeRef.current = props.currentTime;
-  const onPanZoom = useCallback(
-    (newScaleBounds: ScaleBounds[]) => {
-      if (!hasUserPannedOrZoomed) {
-        setHasUserPannedOrZoomed(true);
-      }
-      // Preloaded plots follow playback at a fixed zoom and x-offset unless the user is in the
-      // initial "zoom to fit" state. Subsequent zooms/pans adjust the offsets.
-      const bounds = newScaleBounds.find(({ axes }) => axes === "xAxes");
-      if (bounds != null && bounds.min != null && bounds.max != null && currentTimeRef.current != null) {
-        const currentTime = currentTimeRef.current;
-        setFollowPlaybackState({ xOffsetMin: bounds.min - currentTime, xOffsetMax: bounds.max - currentTime });
-      }
-      lastPanTime.current = new Date();
-    },
-    [hasUserPannedOrZoomed]
-  );
+  const onPanZoom = useCallback((newScaleBounds: ScaleBounds[]) => {
+    if (!hasUserPannedOrZoomed) {
+      setHasUserPannedOrZoomed(true);
+    }
+    // Preloaded plots follow playback at a fixed zoom and x-offset unless the user is in the
+    // initial "zoom to fit" state. Subsequent zooms/pans adjust the offsets.
+    const bounds = newScaleBounds.find(({ axes }) => axes === "xAxes");
+    if (bounds != null && bounds.min != null && bounds.max != null && currentTimeRef.current != null) {
+      const currentTime = currentTimeRef.current;
+      setFollowPlaybackState({ xOffsetMin: bounds.min - currentTime, xOffsetMax: bounds.max - currentTime });
+    }
+    lastPanTime.current = new Date();
+  }, [hasUserPannedOrZoomed]);
 
-  const onResetZoom = useCallback(
-    () => {
-      if (chartComponent.current) {
-        chartComponent.current.resetZoom();
-        setHasUserPannedOrZoomed(false);
-      }
-      setFollowPlaybackState(null);
-    },
-    [setHasUserPannedOrZoomed, setFollowPlaybackState]
-  );
+  const onResetZoom = useCallback(() => {
+    if (chartComponent.current) {
+      chartComponent.current.resetZoom();
+      setHasUserPannedOrZoomed(false);
+    }
+    setFollowPlaybackState(null);
+  }, [setHasUserPannedOrZoomed, setFollowPlaybackState]);
 
   if (useDeepChangeDetector([props.defaultView], false)) {
     // Reset the view to the default when the default changes.
@@ -394,62 +368,60 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
     }
   }, []);
   // Always clean up tooltips when unmounting.
-  useEffect(
-    () => {
-      return () => {
-        hasUnmounted.current = true;
-        removeTooltip();
-      };
-    },
-    [removeTooltip]
-  );
+  useEffect(() => {
+    return () => {
+      hasUnmounted.current = true;
+      removeTooltip();
+    };
+  }, [removeTooltip]);
 
   const tooltips = props.tooltips || [];
   // We use a custom tooltip so we can style it more nicely, and so that it can break
   // out of the bounds of the canvas, in case the panel is small.
-  const updateTooltip = useCallback(
-    (currentChartComponent: ChartComponent, canvas: HTMLCanvasElement, tooltipItem: ?HoveredElement) => {
-      // This is an async callback, so it can fire after this component is unmounted. Make sure that we remove the
-      // tooltip if this fires after unmount.
-      if (!tooltipItem || hasUnmounted.current) {
-        return removeTooltip();
-      }
+  const updateTooltip = useCallback((
+    currentChartComponent: ChartComponent,
+    canvas: HTMLCanvasElement,
+    tooltipItem: ?HoveredElement
+  ) => {
+    // This is an async callback, so it can fire after this component is unmounted. Make sure that we remove the
+    // tooltip if this fires after unmount.
+    if (!tooltipItem || hasUnmounted.current) {
+      return removeTooltip();
+    }
 
-      // We have to iterate through all of the tooltips every time the user hovers over a point. However, the cost of
-      // running this search is small (< 10ms even with many tooltips) compared to the cost of indexing tooltips by
-      // coordinates and we care more about render time than tooltip responsiveness.
-      const tooltipData = tooltips.find(
-        (_tooltip) => _tooltip.x === tooltipItem.data.x && String(_tooltip.y) === String(tooltipItem.data.y)
+    // We have to iterate through all of the tooltips every time the user hovers over a point. However, the cost of
+    // running this search is small (< 10ms even with many tooltips) compared to the cost of indexing tooltips by
+    // coordinates and we care more about render time than tooltip responsiveness.
+    const tooltipData = tooltips.find(
+      (_tooltip) => _tooltip.x === tooltipItem.data.x && String(_tooltip.y) === String(tooltipItem.data.y)
+    );
+    if (!tooltipData) {
+      return removeTooltip();
+    }
+
+    if (!tooltip.current) {
+      tooltip.current = document.createElement("div");
+      if (canvas.parentNode) {
+        canvas.parentNode.appendChild(tooltip.current);
+      }
+    }
+
+    if (tooltip.current) {
+      ReactDOM.render(
+        <TimeBasedChartTooltip tooltip={tooltipData}>
+          <div
+            style={{
+              position: "absolute",
+              left: 0,
+              top: 0,
+              transform: `translate(${tooltipItem.view.x}px, ${tooltipItem.view.y}px)`,
+            }}
+          />
+        </TimeBasedChartTooltip>,
+        tooltip.current
       );
-      if (!tooltipData) {
-        return removeTooltip();
-      }
-
-      if (!tooltip.current) {
-        tooltip.current = document.createElement("div");
-        if (canvas.parentNode) {
-          canvas.parentNode.appendChild(tooltip.current);
-        }
-      }
-
-      if (tooltip.current) {
-        ReactDOM.render(
-          <TimeBasedChartTooltip tooltip={tooltipData}>
-            <div
-              style={{
-                position: "absolute",
-                left: 0,
-                top: 0,
-                transform: `translate(${tooltipItem.view.x}px, ${tooltipItem.view.y}px)`,
-              }}
-            />
-          </TimeBasedChartTooltip>,
-          tooltip.current
-        );
-      }
-    },
-    [removeTooltip, tooltips]
-  );
+    }
+  }, [removeTooltip, tooltips]);
 
   const [hoverComponentId] = useState(() => uuid.v4());
   const { xAxisIsPlaybackTime } = props;
@@ -470,43 +442,40 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
     [dispatch, hoverComponentId, xAxisIsPlaybackTime]
   );
 
-  const onMouseMove = useCallback(
-    async (event: MouseEvent) => {
-      const currentChartComponent = chartComponent.current;
-      if (!currentChartComponent || !currentChartComponent.canvas) {
-        removeTooltip();
-        clearGlobalHoverTime();
-        return;
-      }
-      const { canvas } = currentChartComponent;
-      const canvasRect = canvas.getBoundingClientRect();
-      const xBounds = scaleBounds.current && scaleBounds.current.find(({ axes }) => axes === "xAxes");
-      const yBounds = scaleBounds.current && scaleBounds.current.find(({ axes }) => axes === "yAxes");
-      const xMousePosition = event.pageX - canvasRect.left;
-      const yMousePosition = event.pageY - canvasRect.top;
-      const isTargetingCanvas = event.target === canvas;
-      if (!inBounds(xMousePosition, xBounds) || !inBounds(yMousePosition, yBounds) || !isTargetingCanvas) {
-        removeTooltip();
-        clearGlobalHoverTime();
-        return;
-      }
+  const onMouseMove = useCallback(async (event: MouseEvent) => {
+    const currentChartComponent = chartComponent.current;
+    if (!currentChartComponent || !currentChartComponent.canvas) {
+      removeTooltip();
+      clearGlobalHoverTime();
+      return;
+    }
+    const { canvas } = currentChartComponent;
+    const canvasRect = canvas.getBoundingClientRect();
+    const xBounds = scaleBounds.current && scaleBounds.current.find(({ axes }) => axes === "xAxes");
+    const yBounds = scaleBounds.current && scaleBounds.current.find(({ axes }) => axes === "yAxes");
+    const xMousePosition = event.pageX - canvasRect.left;
+    const yMousePosition = event.pageY - canvasRect.top;
+    const isTargetingCanvas = event.target === canvas;
+    if (!inBounds(xMousePosition, xBounds) || !inBounds(yMousePosition, yBounds) || !isTargetingCanvas) {
+      removeTooltip();
+      clearGlobalHoverTime();
+      return;
+    }
 
-      const value = getChartValue(xBounds, xMousePosition);
-      if (value != null) {
-        setGlobalHoverTime(value);
-      } else {
-        clearGlobalHoverTime();
-      }
+    const value = getChartValue(xBounds, xMousePosition);
+    if (value != null) {
+      setGlobalHoverTime(value);
+    } else {
+      clearGlobalHoverTime();
+    }
 
-      if (tooltips && tooltips.length) {
-        const tooltipElement = await currentChartComponent.getElementAtXAxis(event);
-        updateTooltip(currentChartComponent, canvas, tooltipElement);
-      } else {
-        removeTooltip();
-      }
-    },
-    [updateTooltip, removeTooltip, tooltips, clearGlobalHoverTime, setGlobalHoverTime, scaleBounds]
-  );
+    if (tooltips && tooltips.length) {
+      const tooltipElement = await currentChartComponent.getElementAtXAxis(event);
+      updateTooltip(currentChartComponent, canvas, tooltipElement);
+    } else {
+      removeTooltip();
+    }
+  }, [updateTooltip, removeTooltip, tooltips, clearGlobalHoverTime, setGlobalHoverTime, scaleBounds]);
 
   // Normally we set the x axis step-size and display automatically, but we need consistency when
   // scrolling with playback because the vertical lines can flicker, and x axis labels can have an

--- a/packages/webviz-core/src/components/TimeBasedChart/index.stories.js
+++ b/packages/webviz-core/src/components/TimeBasedChart/index.stories.js
@@ -141,17 +141,14 @@ function ZoomExample() {
 function PauseFrameExample() {
   const [, forceUpdate] = useState(0);
   const [unpauseFrameCount, setUnpauseFrameCount] = useState(0);
-  const pauseFrame = useCallback(
-    () => {
-      return () => {
-        // Set a limit here to avoid unlimited cascading updates.
-        if (unpauseFrameCount < 2) {
-          setUnpauseFrameCount(unpauseFrameCount + 1);
-        }
-      };
-    },
-    [unpauseFrameCount, setUnpauseFrameCount]
-  );
+  const pauseFrame = useCallback(() => {
+    return () => {
+      // Set a limit here to avoid unlimited cascading updates.
+      if (unpauseFrameCount < 2) {
+        setUnpauseFrameCount(unpauseFrameCount + 1);
+      }
+    };
+  }, [unpauseFrameCount, setUnpauseFrameCount]);
 
   const refFn = useCallback(() => {
     setTimeout(() => {
@@ -181,21 +178,18 @@ function RemoveChartExample() {
   const [, forceUpdate] = useState(0);
   const [showChart, setShowChart] = useState(true);
   const [statusMessage, setStatusMessage] = useState("FAILURE - START");
-  const pauseFrame = useCallback(
-    () => {
-      if (showChart) {
-        setShowChart(false);
+  const pauseFrame = useCallback(() => {
+    if (showChart) {
+      setShowChart(false);
+    }
+    return () => {
+      if (statusMessage === "FAILURE - START") {
+        setStatusMessage("SUCCESS");
+      } else {
+        setStatusMessage("FAILURE - CANNOT CALL RESUME FRAME TWICE");
       }
-      return () => {
-        if (statusMessage === "FAILURE - START") {
-          setStatusMessage("SUCCESS");
-        } else {
-          setStatusMessage("FAILURE - CANNOT CALL RESUME FRAME TWICE");
-        }
-      };
-    },
-    [showChart, setShowChart, statusMessage, setStatusMessage]
-  );
+    };
+  }, [showChart, setShowChart, statusMessage, setStatusMessage]);
 
   const refFn = useCallback(() => {
     setTimeout(() => {

--- a/packages/webviz-core/src/components/ValidatedInput.stories.js
+++ b/packages/webviz-core/src/components/ValidatedInput.stories.js
@@ -45,14 +45,11 @@ function Example({
 }) {
   const [value, setValue] = React.useState(obj);
 
-  React.useEffect(
-    () => {
-      setTimeout(() => {
-        setValue(changedObj);
-      }, 10);
-    },
-    [changedObj]
-  );
+  React.useEffect(() => {
+    setTimeout(() => {
+      setValue(changedObj);
+    }, 10);
+  }, [changedObj]);
 
   return (
     <Box>

--- a/packages/webviz-core/src/hooks/useUserNodes.js
+++ b/packages/webviz-core/src/hooks/useUserNodes.js
@@ -16,14 +16,11 @@ type Props = {
 };
 
 const useUserNodes = ({ nodePlayer, userNodes }: Props) => {
-  React.useEffect(
-    () => {
-      if (nodePlayer) {
-        nodePlayer.setUserNodes(userNodes);
-      }
-    },
-    [userNodes, nodePlayer]
-  );
+  React.useEffect(() => {
+    if (nodePlayer) {
+      nodePlayer.setUserNodes(userNodes);
+    }
+  }, [userNodes, nodePlayer]);
 
   return null;
 };

--- a/packages/webviz-core/src/panels/GlobalVariableSlider/index.js
+++ b/packages/webviz-core/src/panels/GlobalVariableSlider/index.js
@@ -50,15 +50,12 @@ function SliderSettingsMenu(props: MenuProps) {
   const { updateConfig, config } = props;
   const { sliderProps, globalVariableName } = config;
 
-  const updateSliderProps = useCallback(
-    (partial: $Shape<SliderProps>) => {
-      updateConfig({
-        ...config,
-        sliderProps: { ...sliderProps, ...partial },
-      });
-    },
-    [config, sliderProps, updateConfig]
-  );
+  const updateSliderProps = useCallback((partial: $Shape<SliderProps>) => {
+    updateConfig({
+      ...config,
+      sliderProps: { ...sliderProps, ...partial },
+    });
+  }, [config, sliderProps, updateConfig]);
 
   const onChangeVariableName = useCallback(
     (newGlobalVariableName) =>
@@ -119,25 +116,19 @@ function GlobalVariableSliderPanel(props: Props): ReactNode {
   const { globalVariables, setGlobalVariables } = useGlobalVariables();
 
   const globalVariableValue = globalVariables[globalVariableName];
-  const saveSliderProps = useCallback(
-    (updatedConfig) => {
-      // If the name of the global variable changes, immediately set its value.
-      // Without this, the variable won't be set until the slider is moved.
-      if (updatedConfig.globalVariableName !== config.globalVariableName) {
-        setGlobalVariables({ [updatedConfig.globalVariableName]: globalVariableValue });
-      }
-      saveConfig(updatedConfig);
-    },
-    [config.globalVariableName, globalVariableValue, saveConfig, setGlobalVariables]
-  );
-  const additionalOutput = useMemo(
-    () => {
-      return getGlobalHooks()
-        .perPanelHooks()
-        .GlobalVariableSlider.getVariableSpecificOutput(globalVariableName, globalVariables);
-    },
-    [globalVariableName, globalVariables]
-  );
+  const saveSliderProps = useCallback((updatedConfig) => {
+    // If the name of the global variable changes, immediately set its value.
+    // Without this, the variable won't be set until the slider is moved.
+    if (updatedConfig.globalVariableName !== config.globalVariableName) {
+      setGlobalVariables({ [updatedConfig.globalVariableName]: globalVariableValue });
+    }
+    saveConfig(updatedConfig);
+  }, [config.globalVariableName, globalVariableValue, saveConfig, setGlobalVariables]);
+  const additionalOutput = useMemo(() => {
+    return getGlobalHooks()
+      .perPanelHooks()
+      .GlobalVariableSlider.getVariableSpecificOutput(globalVariableName, globalVariables);
+  }, [globalVariableName, globalVariables]);
   const menuContent = useMemo(() => <SliderSettingsMenu config={config} updateConfig={saveSliderProps} />, [
     config,
     saveSliderProps,

--- a/packages/webviz-core/src/panels/ImageView/ImageCanvas.stories.js
+++ b/packages/webviz-core/src/panels/ImageView/ImageCanvas.stories.js
@@ -313,19 +313,16 @@ function Mono16Story({ bigEndian }: { bigEndian: boolean }) {
 function ShouldCallOnRenderImage({ children }: { children: (() => () => void) => React.Node }) {
   const [callsOnStartRenderImage, setCallsOnStartRenderImage] = React.useState(false);
   const [callsOnFinishRenderImage, setCallsOnFinishRenderImage] = React.useState(false);
-  const onStartRenderImage = React.useCallback(
-    () => {
-      if (!callsOnStartRenderImage) {
-        setCallsOnStartRenderImage(true);
+  const onStartRenderImage = React.useCallback(() => {
+    if (!callsOnStartRenderImage) {
+      setCallsOnStartRenderImage(true);
+    }
+    return () => {
+      if (!callsOnFinishRenderImage) {
+        setCallsOnFinishRenderImage(true);
       }
-      return () => {
-        if (!callsOnFinishRenderImage) {
-          setCallsOnFinishRenderImage(true);
-        }
-      };
-    },
-    [callsOnStartRenderImage, callsOnFinishRenderImage, setCallsOnStartRenderImage, setCallsOnFinishRenderImage]
-  );
+    };
+  }, [callsOnStartRenderImage, callsOnFinishRenderImage, setCallsOnStartRenderImage, setCallsOnFinishRenderImage]);
 
   const hasPassed = callsOnStartRenderImage && callsOnFinishRenderImage;
   return (

--- a/packages/webviz-core/src/panels/Internals.js
+++ b/packages/webviz-core/src/panels/Internals.js
@@ -89,69 +89,60 @@ function Internals(): React.Node {
   );
   const publishers = useMessagePipeline(useCallback(({ publishers: pipelinePublishers }) => pipelinePublishers, []));
 
-  const [groupedSubscriptions, subscriptionGroups] = React.useMemo(
-    () => {
-      const grouped = groupBy(subscriptions, getSubscriptionGroup);
-      return [grouped, Object.keys(grouped)];
-    },
-    [subscriptions]
-  );
+  const [groupedSubscriptions, subscriptionGroups] = React.useMemo(() => {
+    const grouped = groupBy(subscriptions, getSubscriptionGroup);
+    return [grouped, Object.keys(grouped)];
+  }, [subscriptions]);
 
-  const renderedSubscriptions = React.useMemo(
-    () => {
-      if (subscriptions.length === 0) {
-        return "(none)";
-      }
-      return Object.keys(groupedSubscriptions)
-        .sort()
-        .map((key) => {
-          return (
-            <React.Fragment key={key}>
-              <div style={{ marginTop: 16 }}>{key}:</div>
-              <ul>
-                {sortBy(groupedSubscriptions[key], (sub) => sub.topic).map((sub, i) => (
-                  <li key={i}>
-                    <tt>
-                      {sub.topic}
-                      {topicsByName[sub.topic] &&
-                        topicsByName[sub.topic].originalTopic &&
-                        ` (original topic: ${topicsByName[sub.topic].originalTopic})`}
-                    </tt>
-                  </li>
-                ))}
-              </ul>
-            </React.Fragment>
-          );
-        });
-    },
-    [groupedSubscriptions, subscriptions.length, topicsByName]
-  );
+  const renderedSubscriptions = React.useMemo(() => {
+    if (subscriptions.length === 0) {
+      return "(none)";
+    }
+    return Object.keys(groupedSubscriptions)
+      .sort()
+      .map((key) => {
+        return (
+          <React.Fragment key={key}>
+            <div style={{ marginTop: 16 }}>{key}:</div>
+            <ul>
+              {sortBy(groupedSubscriptions[key], (sub) => sub.topic).map((sub, i) => (
+                <li key={i}>
+                  <tt>
+                    {sub.topic}
+                    {topicsByName[sub.topic] &&
+                      topicsByName[sub.topic].originalTopic &&
+                      ` (original topic: ${topicsByName[sub.topic].originalTopic})`}
+                  </tt>
+                </li>
+              ))}
+            </ul>
+          </React.Fragment>
+        );
+      });
+  }, [groupedSubscriptions, subscriptions.length, topicsByName]);
 
-  const renderedPublishers = React.useMemo(
-    () => {
-      if (publishers.length === 0) {
-        return "(none)";
-      }
-      const groupedPublishers = groupBy(publishers, getPublisherGroup);
-      return Object.keys(groupedPublishers)
-        .sort()
-        .map((key) => {
-          return (
-            <React.Fragment key={key}>
-              <div style={{ marginTop: 16 }}>{key}:</div>
-              <ul>
-                {sortBy(groupedPublishers[key], (sub) => sub.topic).map((sub, i) => (
-                  <li key={i}>
-                    <tt>{sub.topic}</tt>
-                  </li>
-                ))}
-              </ul>
-            </React.Fragment>
-          );
-        });
-    },
-    [publishers]
-  );
+  const renderedPublishers = React.useMemo(() => {
+    if (publishers.length === 0) {
+      return "(none)";
+    }
+    const groupedPublishers = groupBy(publishers, getPublisherGroup);
+    return Object.keys(groupedPublishers)
+      .sort()
+      .map((key) => {
+        return (
+          <React.Fragment key={key}>
+            <div style={{ marginTop: 16 }}>{key}:</div>
+            <ul>
+              {sortBy(groupedPublishers[key], (sub) => sub.topic).map((sub, i) => (
+                <li key={i}>
+                  <tt>{sub.topic}</tt>
+                </li>
+              ))}
+            </ul>
+          </React.Fragment>
+        );
+      });
+  }, [publishers]);
 
   const [recordGroup, setRecordGroup] = React.useState<string>(RECORD_ALL);
   const [recordingTopics, setRecordingTopics] = React.useState<?(string[])>();
@@ -171,30 +162,27 @@ function Internals(): React.Node {
     downloadTextFile(JSON.stringify(recordedData.current) || "{}", "fixture.json");
   }
 
-  const historyRecorder = React.useMemo(
-    () => {
-      if (!recordingTopics) {
-        return false;
-      }
-      return (
-        <MessageHistoryDEPRECATED paths={recordingTopics} historySize={1}>
-          {({ itemsByPath }) => {
-            const frame = mapValues(itemsByPath, (items) => items.map(({ message }) => message));
-            recordedData.current = {
-              topics: filterMap(Object.keys(itemsByPath), (topic) =>
-                itemsByPath[topic] && itemsByPath[topic].length
-                  ? { name: topic, datatype: topicsByName[topic].datatype }
-                  : null
-              ),
-              frame,
-            };
-            return null;
-          }}
-        </MessageHistoryDEPRECATED>
-      );
-    },
-    [recordingTopics, topicsByName]
-  );
+  const historyRecorder = React.useMemo(() => {
+    if (!recordingTopics) {
+      return false;
+    }
+    return (
+      <MessageHistoryDEPRECATED paths={recordingTopics} historySize={1}>
+        {({ itemsByPath }) => {
+          const frame = mapValues(itemsByPath, (items) => items.map(({ message }) => message));
+          recordedData.current = {
+            topics: filterMap(Object.keys(itemsByPath), (topic) =>
+              itemsByPath[topic] && itemsByPath[topic].length
+                ? { name: topic, datatype: topicsByName[topic].datatype }
+                : null
+            ),
+            frame,
+          };
+          return null;
+        }}
+      </MessageHistoryDEPRECATED>
+    );
+  }, [recordingTopics, topicsByName]);
 
   return (
     <Container>

--- a/packages/webviz-core/src/panels/NodePlayground/BottomBar/index.js
+++ b/packages/webviz-core/src/panels/NodePlayground/BottomBar/index.js
@@ -58,16 +58,13 @@ const BottomBar = ({ nodeId, isSaved, save, diagnostics, logs }: Props) => {
   const clearLogs = React.useCallback((payload: string) => dispatch(clearUserNodeLogs(payload)), [dispatch]);
   const scrollContainer = useRef(null);
 
-  useEffect(
-    () => {
-      if (autoScroll) {
-        if (scrollContainer.current) {
-          scrollContainer.current.scrollTop = scrollContainer.current.scrollHeight;
-        }
+  useEffect(() => {
+    if (autoScroll) {
+      if (scrollContainer.current) {
+        scrollContainer.current.scrollTop = scrollContainer.current.scrollHeight;
       }
-    },
-    [autoScroll, logs]
-  );
+    }
+  }, [autoScroll, logs]);
 
   return (
     <Flex col style={{ backgroundColor: colors.DARK1, position: "absolute", bottom: 0, right: 0, left: 0 }}>

--- a/packages/webviz-core/src/panels/NodePlayground/Editor.js
+++ b/packages/webviz-core/src/panels/NodePlayground/Editor.js
@@ -70,29 +70,23 @@ const Editor = ({
   const autoFormatOnSaveRef = React.useRef(autoFormatOnSave);
   autoFormatOnSaveRef.current = autoFormatOnSave;
 
-  React.useEffect(
-    () => {
-      if (editorRef.current) {
-        if (vimMode) {
-          vimModeRef.current = initVimMode(editorRef.current);
-        } else if (vimModeRef.current) {
-          // Turn off VimMode.
-          vimModeRef.current.dispose();
-        }
+  React.useEffect(() => {
+    if (editorRef.current) {
+      if (vimMode) {
+        vimModeRef.current = initVimMode(editorRef.current);
+      } else if (vimModeRef.current) {
+        // Turn off VimMode.
+        vimModeRef.current.dispose();
       }
-    },
-    [vimMode]
-  );
+    }
+  }, [vimMode]);
 
-  React.useEffect(
-    () => {
-      monacoApi.languages.typescript.typescriptDefaults.addExtraLib(
-        rosLib,
-        `file:///node_modules/@types/${projectConfig.rosLib.fileName}`
-      );
-    },
-    [rosLib]
-  );
+  React.useEffect(() => {
+    monacoApi.languages.typescript.typescriptDefaults.addExtraLib(
+      rosLib,
+      `file:///node_modules/@types/${projectConfig.rosLib.fileName}`
+    );
+  }, [rosLib]);
 
   /*
   In order to support go-to across files we override the code editor service doOpenEditor method.
@@ -102,161 +96,143 @@ const Editor = ({
   this override script we'll end up loading the model in the useEffect below, and then using this
   selection to move to the correct line.
   */
-  codeEditorService.doOpenEditor = React.useCallback(
-    (editor, input) => {
-      const requestedModel = monacoApi.editor.getModel(input.resource);
-      if (!requestedModel) {
-        return editor;
-      }
-
-      // If we are jumping to a definition within the user node, don't push
-      // to script override.
-      if (requestedModel.uri.path === script?.filePath) {
-        gotoSelection(editor, input.options.selection);
-        return;
-      }
-
-      setScriptOverride({
-        filePath: requestedModel.uri.path,
-        code: requestedModel.getValue(),
-        readOnly: true,
-        selection: input.options ? input.options.selection : undefined,
-      });
+  codeEditorService.doOpenEditor = React.useCallback((editor, input) => {
+    const requestedModel = monacoApi.editor.getModel(input.resource);
+    if (!requestedModel) {
       return editor;
-    },
-    [script, setScriptOverride]
-  );
+    }
 
-  React.useEffect(
-    () => {
-      const editor = editorRef.current;
-      if (!editorRef || !script) {
-        return;
-      }
-      const filePath = monacoApi.Uri.parse(`file://${script.filePath}`);
-      const model =
-        monacoApi.editor.getModel(filePath) || monacoApi.editor.createModel(script.code, "typescript", filePath);
+    // If we are jumping to a definition within the user node, don't push
+    // to script override.
+    if (requestedModel.uri.path === script?.filePath) {
+      gotoSelection(editor, input.options.selection);
+      return;
+    }
 
-      // Update the model's code if it was updated outside the Editor.
-      // Without this, monaco can continue to show old code if the userScripts are changed outside of the Editor
-      if (model.getValue() !== script.code) {
-        model.setValue(script.code);
-      }
+    setScriptOverride({
+      filePath: requestedModel.uri.path,
+      code: requestedModel.getValue(),
+      readOnly: true,
+      selection: input.options ? input.options.selection : undefined,
+    });
+    return editor;
+  }, [script, setScriptOverride]);
 
-      editor.setModel(model);
-      gotoSelection(editor, script.selection);
-    },
-    [script]
-  );
+  React.useEffect(() => {
+    const editor = editorRef.current;
+    if (!editorRef || !script) {
+      return;
+    }
+    const filePath = monacoApi.Uri.parse(`file://${script.filePath}`);
+    const model =
+      monacoApi.editor.getModel(filePath) || monacoApi.editor.createModel(script.code, "typescript", filePath);
 
-  const options = React.useMemo(
-    () => {
-      return {
-        wordWrap: "on",
-        minimap: {
-          enabled: false,
-        },
-        readOnly: script?.readOnly,
-      };
-    },
-    [script]
-  );
+    // Update the model's code if it was updated outside the Editor.
+    // Without this, monaco can continue to show old code if the userScripts are changed outside of the Editor
+    if (model.getValue() !== script.code) {
+      model.setValue(script.code);
+    }
 
-  const willMount = React.useCallback(
-    (monaco) => {
-      if (!script) {
-        return;
-      }
-      monaco.editor.defineTheme(VS_WEBVIZ_THEME, vsWebvizTheme);
+    editor.setModel(model);
+    gotoSelection(editor, script.selection);
+  }, [script]);
 
-      // Set eager model sync to enable intellisense between the user code and utility files
-      monaco.languages.typescript.typescriptDefaults.setEagerModelSync(true);
-      monaco.languages.typescript.javascriptDefaults.setEagerModelSync(true);
+  const options = React.useMemo(() => {
+    return {
+      wordWrap: "on",
+      minimap: {
+        enabled: false,
+      },
+      readOnly: script?.readOnly,
+    };
+  }, [script]);
 
-      monaco.languages.registerDocumentFormattingEditProvider("typescript", {
-        provideDocumentFormattingEdits: async (model) => {
-          try {
-            return [
-              {
-                range: model.getFullModelRange(),
-                text: await getPrettifiedCode(model.getValue()),
-              },
-            ];
-          } catch (e) {
-            return [];
-          }
-        },
-      });
+  const willMount = React.useCallback((monaco) => {
+    if (!script) {
+      return;
+    }
+    monaco.editor.defineTheme(VS_WEBVIZ_THEME, vsWebvizTheme);
 
-      // Disable validation in screenshots to avoid flaky tests
-      if (inScreenshotTests()) {
-        monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
-          noSyntaxValidation: true,
-          noSemanticValidation: true,
-        });
-      }
+    // Set eager model sync to enable intellisense between the user code and utility files
+    monaco.languages.typescript.typescriptDefaults.setEagerModelSync(true);
+    monaco.languages.typescript.javascriptDefaults.setEagerModelSync(true);
 
-      // Load declarations and additional utility files from project config
-
-      // This ensures the type defs we enforce in
-      // the 'compile' step match that of monaco. Adding the 'lib'
-      // this way (instead of specifying it in the compiler options)
-      // is a hack to overwrite the default type defs since the
-      // typescript language service does not expose such a method.
-      projectConfig.declarations.forEach((lib) =>
-        monaco.languages.typescript.typescriptDefaults.addExtraLib(
-          lib.sourceCode,
-          `file:///node_modules/@types/${lib.fileName}`
-        )
-      );
-      projectConfig.utilityFiles.forEach((sourceFile) => {
-        const filePath = monacoApi.Uri.parse(`file://${sourceFile.filePath}`);
-        const model =
-          monaco.editor.getModel(filePath) || monaco.editor.createModel(sourceFile.sourceCode, "typescript", filePath);
-        model.updateOptions({ tabSize: 2 });
-      });
-
-      const filePath = monacoApi.Uri.parse(`file://${script.filePath}`);
-      const model = monaco.editor.getModel(filePath) || monaco.editor.createModel(script.code, "typescript", filePath);
-
-      // Because anything else is blasphemy.
-      model.updateOptions({ tabSize: 2 });
-      return {
-        model,
-      };
-    },
-    [script]
-  );
-
-  const saveCode = React.useCallback(
-    async () => {
-      const model = editorRef.current && editorRef.current.getModel();
-      if (model && script && !script.readOnly) {
-        // We have to use a ref for autoFormatOnSaveRef because of how monaco scopes the action callbacks
-        if (autoFormatOnSaveRef.current) {
-          await editorRef.current.getAction("editor.action.formatDocument").run();
+    monaco.languages.registerDocumentFormattingEditProvider("typescript", {
+      provideDocumentFormattingEdits: async (model) => {
+        try {
+          return [
+            {
+              range: model.getFullModelRange(),
+              text: await getPrettifiedCode(model.getValue()),
+            },
+          ];
+        } catch (e) {
+          return [];
         }
-        save(model.getValue());
-      }
-    },
-    [save, script]
-  );
+      },
+    });
 
-  const didMount = React.useCallback(
-    (editor) => {
-      editorRef.current = editor;
-      if (vimMode) {
-        vimModeRef.current = initVimMode(editorRef.current);
-      }
-      editor.addAction({
-        id: "ctrl-s",
-        label: "Save current node",
-        keybindings: [monacoApi.KeyMod.CtrlCmd | monacoApi.KeyCode.KEY_S],
-        run: saveCode,
+    // Disable validation in screenshots to avoid flaky tests
+    if (inScreenshotTests()) {
+      monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+        noSyntaxValidation: true,
+        noSemanticValidation: true,
       });
-    },
-    [vimMode, saveCode]
-  );
+    }
+
+    // Load declarations and additional utility files from project config
+
+    // This ensures the type defs we enforce in
+    // the 'compile' step match that of monaco. Adding the 'lib'
+    // this way (instead of specifying it in the compiler options)
+    // is a hack to overwrite the default type defs since the
+    // typescript language service does not expose such a method.
+    projectConfig.declarations.forEach((lib) =>
+      monaco.languages.typescript.typescriptDefaults.addExtraLib(
+        lib.sourceCode,
+        `file:///node_modules/@types/${lib.fileName}`
+      )
+    );
+    projectConfig.utilityFiles.forEach((sourceFile) => {
+      const filePath = monacoApi.Uri.parse(`file://${sourceFile.filePath}`);
+      const model =
+        monaco.editor.getModel(filePath) || monaco.editor.createModel(sourceFile.sourceCode, "typescript", filePath);
+      model.updateOptions({ tabSize: 2 });
+    });
+
+    const filePath = monacoApi.Uri.parse(`file://${script.filePath}`);
+    const model = monaco.editor.getModel(filePath) || monaco.editor.createModel(script.code, "typescript", filePath);
+
+    // Because anything else is blasphemy.
+    model.updateOptions({ tabSize: 2 });
+    return {
+      model,
+    };
+  }, [script]);
+
+  const saveCode = React.useCallback(async () => {
+    const model = editorRef.current && editorRef.current.getModel();
+    if (model && script && !script.readOnly) {
+      // We have to use a ref for autoFormatOnSaveRef because of how monaco scopes the action callbacks
+      if (autoFormatOnSaveRef.current) {
+        await editorRef.current.getAction("editor.action.formatDocument").run();
+      }
+      save(model.getValue());
+    }
+  }, [save, script]);
+
+  const didMount = React.useCallback((editor) => {
+    editorRef.current = editor;
+    if (vimMode) {
+      vimModeRef.current = initVimMode(editorRef.current);
+    }
+    editor.addAction({
+      id: "ctrl-s",
+      label: "Save current node",
+      keybindings: [monacoApi.KeyMod.CtrlCmd | monacoApi.KeyCode.KEY_S],
+      run: saveCode,
+    });
+  }, [vimMode, saveCode]);
 
   const onChange = React.useCallback((srcCode: string) => setScriptCode(srcCode), [setScriptCode]);
 

--- a/packages/webviz-core/src/panels/NodePlayground/Sidebar.js
+++ b/packages/webviz-core/src/panels/NodePlayground/Sidebar.js
@@ -176,27 +176,24 @@ const Sidebar = ({
   const utilsSelected = explorer === "utils";
   const templatesSelected = explorer === "templates";
 
-  const gotoUtils = React.useCallback(
-    (filePath) => {
-      import(/* webpackChunkName: "monaco-api" */ "monaco-editor/esm/vs/editor/editor.api").then((monacoApi) => {
-        const monacoFilePath = monacoApi.Uri.parse(`file://${filePath}`);
-        const requestedModel = monacoApi.editor.getModel(monacoFilePath);
-        if (!requestedModel) {
-          return;
-        }
-        setScriptOverride(
-          {
-            filePath: requestedModel.uri.path,
-            code: requestedModel.getValue(),
-            readOnly: true,
-            selection: undefined,
-          },
-          2
-        );
-      });
-    },
-    [setScriptOverride]
-  );
+  const gotoUtils = React.useCallback((filePath) => {
+    import(/* webpackChunkName: "monaco-api" */ "monaco-editor/esm/vs/editor/editor.api").then((monacoApi) => {
+      const monacoFilePath = monacoApi.Uri.parse(`file://${filePath}`);
+      const requestedModel = monacoApi.editor.getModel(monacoFilePath);
+      if (!requestedModel) {
+        return;
+      }
+      setScriptOverride(
+        {
+          filePath: requestedModel.uri.path,
+          code: requestedModel.getValue(),
+          readOnly: true,
+          selection: undefined,
+        },
+        2
+      );
+    });
+  }, [setScriptOverride]);
 
   const explorers = React.useMemo(
     () => ({

--- a/packages/webviz-core/src/panels/Note/index.js
+++ b/packages/webviz-core/src/panels/Note/index.js
@@ -31,12 +31,9 @@ const STextArea = styled.textarea`
 type Config = { noteText: string };
 type Props = { config: Config, saveConfig: SaveConfig<Config> };
 function Note({ config, saveConfig }: Props) {
-  const onChangeText = useCallback(
-    (event: SyntheticInputEvent<HTMLTextAreaElement>) => {
-      saveConfig({ noteText: event.target.value });
-    },
-    [saveConfig]
-  );
+  const onChangeText = useCallback((event: SyntheticInputEvent<HTMLTextAreaElement>) => {
+    saveConfig({ noteText: event.target.value });
+  }, [saveConfig]);
 
   return (
     <Flex col style={{ height: "100%" }}>

--- a/packages/webviz-core/src/panels/PanelList/index.js
+++ b/packages/webviz-core/src/panels/PanelList/index.js
@@ -152,27 +152,24 @@ function DraggablePanelItem({ searchQuery, panel, onClick, onDrop, checked, high
     },
   });
 
-  React.useEffect(
-    () => {
-      if (highlighted && scrollRef.current) {
-        const highlightedItem = scrollRef.current.getBoundingClientRect();
-        const scrollContainer = scrollRef.current?.parentElement?.parentElement?.parentElement;
-        if (scrollContainer) {
-          const scrollContainerToTop = scrollContainer.getBoundingClientRect().top;
+  React.useEffect(() => {
+    if (highlighted && scrollRef.current) {
+      const highlightedItem = scrollRef.current.getBoundingClientRect();
+      const scrollContainer = scrollRef.current?.parentElement?.parentElement?.parentElement;
+      if (scrollContainer) {
+        const scrollContainerToTop = scrollContainer.getBoundingClientRect().top;
 
-          const isInView =
-            highlightedItem.top >= 0 &&
-            highlightedItem.top >= scrollContainerToTop &&
-            highlightedItem.top + 50 <= window.innerHeight;
+        const isInView =
+          highlightedItem.top >= 0 &&
+          highlightedItem.top >= scrollContainerToTop &&
+          highlightedItem.top + 50 <= window.innerHeight;
 
-          if (!isInView && scrollRef.current) {
-            scrollRef.current.scrollIntoView({ behavior: "smooth" });
-          }
+        if (!isInView && scrollRef.current) {
+          scrollRef.current.scrollIntoView({ behavior: "smooth" });
         }
       }
-    },
-    [highlighted]
-  );
+    }
+  }, [highlighted]);
 
   return (
     <div ref={drag}>
@@ -239,21 +236,25 @@ function PanelList(props: Props) {
 
   // Update panel layout in Redux when a panel menu item is dropped;
   // actual operations to change layout supplied by react-mosaic-component
-  const onPanelMenuItemDrop = React.useCallback(
-    ({ config, relatedConfigs, type, position, path, tabId }: DropDescription) => {
-      dispatch(
-        dropPanel({
-          newPanelType: type,
-          destinationPath: path,
-          position,
-          tabId,
-          config,
-          relatedConfigs,
-        })
-      );
-    },
-    [dispatch]
-  );
+  const onPanelMenuItemDrop = React.useCallback(({
+    config,
+    relatedConfigs,
+    type,
+    position,
+    path,
+    tabId,
+  }: DropDescription) => {
+    dispatch(
+      dropPanel({
+        newPanelType: type,
+        destinationPath: path,
+        position,
+        tabId,
+        config,
+        relatedConfigs,
+      })
+    );
+  }, [dispatch]);
 
   const handleSearchChange = React.useCallback((e: SyntheticInputEvent<HTMLInputElement>) => {
     // TODO(Audrey): press enter to select the first item, allow using arrow key to go up and down
@@ -289,53 +290,47 @@ function PanelList(props: Props) {
     [filteredItems, highlightedPanelIdx]
   );
 
-  const onKeyDown = React.useCallback(
-    (e) => {
-      if (e.key === "ArrowDown" && highlightedPanelIdx != null) {
-        setHighlightedPanelIdx((highlightedPanelIdx + 1) % filteredItems.length);
-      } else if (e.key === "ArrowUp" && highlightedPanelIdx != null) {
-        const newIdx = (highlightedPanelIdx - 1) % (filteredItems.length - 1);
-        setHighlightedPanelIdx(newIdx >= 0 ? newIdx : filteredItems.length + newIdx);
-      } else if (e.key === "Enter" && highlightedPanel) {
-        const { component, presetSettings } = highlightedPanel;
-        onPanelSelect({
-          type: component.panelType,
+  const onKeyDown = React.useCallback((e) => {
+    if (e.key === "ArrowDown" && highlightedPanelIdx != null) {
+      setHighlightedPanelIdx((highlightedPanelIdx + 1) % filteredItems.length);
+    } else if (e.key === "ArrowUp" && highlightedPanelIdx != null) {
+      const newIdx = (highlightedPanelIdx - 1) % (filteredItems.length - 1);
+      setHighlightedPanelIdx(newIdx >= 0 ? newIdx : filteredItems.length + newIdx);
+    } else if (e.key === "Enter" && highlightedPanel) {
+      const { component, presetSettings } = highlightedPanel;
+      onPanelSelect({
+        type: component.panelType,
+        config: presetSettings?.config,
+        relatedConfigs: presetSettings?.relatedConfigs,
+      });
+    }
+  }, [filteredItems.length, highlightedPanel, highlightedPanelIdx, onPanelSelect]);
+
+  const displayPanelListItem = React.useCallback(({ presetSettings, title, component: { panelType } }) => {
+    return (
+      <DraggablePanelItem
+        key={`${panelType}-${title}`}
+        mosaicId={mosaicId}
+        panel={{
+          type: panelType,
+          title,
           config: presetSettings?.config,
           relatedConfigs: presetSettings?.relatedConfigs,
-        });
-      }
-    },
-    [filteredItems.length, highlightedPanel, highlightedPanelIdx, onPanelSelect]
-  );
-
-  const displayPanelListItem = React.useCallback(
-    ({ presetSettings, title, component: { panelType } }) => {
-      return (
-        <DraggablePanelItem
-          key={`${panelType}-${title}`}
-          mosaicId={mosaicId}
-          panel={{
+        }}
+        onDrop={onPanelMenuItemDrop}
+        onClick={() =>
+          onPanelSelect({
             type: panelType,
-            title,
             config: presetSettings?.config,
             relatedConfigs: presetSettings?.relatedConfigs,
-          }}
-          onDrop={onPanelMenuItemDrop}
-          onClick={() =>
-            onPanelSelect({
-              type: panelType,
-              config: presetSettings?.config,
-              relatedConfigs: presetSettings?.relatedConfigs,
-            })
-          }
-          checked={title === selectedPanelTitle}
-          highlighted={highlightedPanel?.title === title}
-          searchQuery={searchQuery}
-        />
-      );
-    },
-    [highlightedPanel, mosaicId, onPanelMenuItemDrop, onPanelSelect, searchQuery, selectedPanelTitle]
-  );
+          })
+        }
+        checked={title === selectedPanelTitle}
+        highlighted={highlightedPanel?.title === title}
+        searchQuery={searchQuery}
+      />
+    );
+  }, [highlightedPanel, mosaicId, onPanelMenuItemDrop, onPanelSelect, searchQuery, selectedPanelTitle]);
 
   return (
     <div data-test-panel-category style={{ height: "100%", width: "320px" }}>

--- a/packages/webviz-core/src/panels/PlaybackPerformance/index.stories.js
+++ b/packages/webviz-core/src/panels/PlaybackPerformance/index.stories.js
@@ -31,14 +31,11 @@ const defaultActiveData: PlayerStateActiveData = {
 
 function Example({ states }: { states: UnconnectedPlaybackPerformanceProps[] }) {
   const [state, setState] = React.useState(states);
-  React.useEffect(
-    () => {
-      if (state.length > 1) {
-        setState(state.slice(1));
-      }
-    },
-    [state]
-  );
+  React.useEffect(() => {
+    if (state.length > 1) {
+      setState(state.slice(1));
+    }
+  }, [state]);
   return <UnconnectedPlaybackPerformance {...state[0]} />;
 }
 

--- a/packages/webviz-core/src/panels/Plot/PlotLegend.js
+++ b/packages/webviz-core/src/panels/Plot/PlotLegend.js
@@ -55,29 +55,23 @@ export default function PlotLegend(props: PlotLegendProps) {
   const { paths, saveConfig, showLegend, xAxisVal, xAxisPath, pathsWithMismatchedDataLengths } = props;
   const lastPath = last(paths);
 
-  const onInputChange = useCallback(
-    (value: string, index: ?number) => {
-      if (index == null) {
-        throw new Error("index not set");
-      }
-      const newPaths = paths.slice();
-      newPaths[index] = { ...newPaths[index], value: value.trim() };
-      saveConfig({ paths: newPaths });
-    },
-    [paths, saveConfig]
-  );
+  const onInputChange = useCallback((value: string, index: ?number) => {
+    if (index == null) {
+      throw new Error("index not set");
+    }
+    const newPaths = paths.slice();
+    newPaths[index] = { ...newPaths[index], value: value.trim() };
+    saveConfig({ paths: newPaths });
+  }, [paths, saveConfig]);
 
-  const onInputTimestampMethodChange = useCallback(
-    (value: TimestampMethod, index: ?number) => {
-      if (index == null) {
-        throw new Error("index not set");
-      }
-      const newPaths = paths.slice();
-      newPaths[index] = { ...newPaths[index], timestampMethod: value };
-      saveConfig({ paths: newPaths });
-    },
-    [paths, saveConfig]
-  );
+  const onInputTimestampMethodChange = useCallback((value: TimestampMethod, index: ?number) => {
+    if (index == null) {
+      throw new Error("index not set");
+    }
+    const newPaths = paths.slice();
+    newPaths[index] = { ...newPaths[index], timestampMethod: value };
+    saveConfig({ paths: newPaths });
+  }, [paths, saveConfig]);
 
   const { toggleToHideLegend, toggleToShowLegend } = useMemo(
     () => ({

--- a/packages/webviz-core/src/panels/Plot/PlotMenu.js
+++ b/packages/webviz-core/src/panels/Plot/PlotMenu.js
@@ -112,77 +112,74 @@ export default function PlotMenu({
   stableDatasets.current = datasets;
   const stableTooltips = useRef<TimeBasedChartTooltipData[]>(tooltips);
   stableTooltips.current = tooltips;
-  return useMemo(
-    () => {
-      const followWidthItem =
-        xAxisVal === "timestamp" ? (
-          <>
-            <Item onClick={() => saveConfig({ followingViewWidth: "" })} tooltip="Plot width in sec">
-              <SFlexRow>
-                <SLabel>X range</SLabel>
-                <PanelToolbarInput
-                  type="number"
-                  className={cx(styles.input, { [styles.inputError]: !isValidWidth(displayWidth) })}
-                  value={displayWidth}
-                  onChange={({ target: { value } }) => {
-                    const isZero = parseFloat(value) === 0;
-                    saveConfig({ followingViewWidth: isZero ? "" : value });
-                  }}
-                  min="0"
-                  onClick={(event) => event.stopPropagation()}
-                  placeholder="auto"
-                />
-              </SFlexRow>
-            </Item>
-            <Item>
-              <SButton onClick={setWidth}>Set to current view</SButton>
-            </Item>
-          </>
-        ) : null;
-      return (
+  return useMemo(() => {
+    const followWidthItem =
+      xAxisVal === "timestamp" ? (
         <>
-          <Item onClick={() => downloadCsvFile(stableDatasets.current, stableTooltips.current, xAxisVal)}>
-            Download plot data (csv)
-          </Item>
-          <hr />
-          <Item isHeader>Zoom extents</Item>
-          <Item onClick={() => saveConfig({ maxYValue: maxYValue === "" ? "10" : "" })} tooltip="Maximum y-axis value">
+          <Item onClick={() => saveConfig({ followingViewWidth: "" })} tooltip="Plot width in sec">
             <SFlexRow>
-              <SLabel>Y max</SLabel>
+              <SLabel>X range</SLabel>
               <PanelToolbarInput
                 type="number"
-                className={cx(styles.input, { [styles.inputError]: !isValidInput(maxYValue) })}
-                value={maxYValue}
-                onChange={(event) => {
-                  saveConfig({ maxYValue: event.target.value });
+                className={cx(styles.input, { [styles.inputError]: !isValidWidth(displayWidth) })}
+                value={displayWidth}
+                onChange={({ target: { value } }) => {
+                  const isZero = parseFloat(value) === 0;
+                  saveConfig({ followingViewWidth: isZero ? "" : value });
                 }}
-                onClick={(event) => event.stopPropagation()}
-                placeholder="auto"
-              />
-            </SFlexRow>
-          </Item>
-          <Item onClick={() => saveConfig({ minYValue: minYValue === "" ? "-10" : "" })} tooltip="Minimum y-axis value">
-            <SFlexRow>
-              <SLabel>Y min</SLabel>
-              <PanelToolbarInput
-                type="number"
-                className={cx(styles.input, { [styles.inputError]: !isValidInput(minYValue) })}
-                value={minYValue}
-                onChange={(event) => {
-                  saveConfig({ minYValue: event.target.value });
-                }}
+                min="0"
                 onClick={(event) => event.stopPropagation()}
                 placeholder="auto"
               />
             </SFlexRow>
           </Item>
           <Item>
-            <SButton onClick={setMinMax}>Set to current view</SButton>
+            <SButton onClick={setWidth}>Set to current view</SButton>
           </Item>
-          {followWidthItem}
         </>
-      );
-    },
-    [xAxisVal, displayWidth, setWidth, maxYValue, minYValue, setMinMax, saveConfig]
-  );
+      ) : null;
+    return (
+      <>
+        <Item onClick={() => downloadCsvFile(stableDatasets.current, stableTooltips.current, xAxisVal)}>
+          Download plot data (csv)
+        </Item>
+        <hr />
+        <Item isHeader>Zoom extents</Item>
+        <Item onClick={() => saveConfig({ maxYValue: maxYValue === "" ? "10" : "" })} tooltip="Maximum y-axis value">
+          <SFlexRow>
+            <SLabel>Y max</SLabel>
+            <PanelToolbarInput
+              type="number"
+              className={cx(styles.input, { [styles.inputError]: !isValidInput(maxYValue) })}
+              value={maxYValue}
+              onChange={(event) => {
+                saveConfig({ maxYValue: event.target.value });
+              }}
+              onClick={(event) => event.stopPropagation()}
+              placeholder="auto"
+            />
+          </SFlexRow>
+        </Item>
+        <Item onClick={() => saveConfig({ minYValue: minYValue === "" ? "-10" : "" })} tooltip="Minimum y-axis value">
+          <SFlexRow>
+            <SLabel>Y min</SLabel>
+            <PanelToolbarInput
+              type="number"
+              className={cx(styles.input, { [styles.inputError]: !isValidInput(minYValue) })}
+              value={minYValue}
+              onChange={(event) => {
+                saveConfig({ minYValue: event.target.value });
+              }}
+              onClick={(event) => event.stopPropagation()}
+              placeholder="auto"
+            />
+          </SFlexRow>
+        </Item>
+        <Item>
+          <SButton onClick={setMinMax}>Set to current view</SButton>
+        </Item>
+        {followWidthItem}
+      </>
+    );
+  }, [xAxisVal, displayWidth, setWidth, maxYValue, minYValue, setMinMax, saveConfig]);
 }

--- a/packages/webviz-core/src/panels/Plot/index.js
+++ b/packages/webviz-core/src/panels/Plot/index.js
@@ -249,17 +249,14 @@ function Plot(props: Props) {
     }
   }
 
-  const onClick = useCallback(
-    (_, __, { X_AXIS_ID: seekSeconds }) => {
-      if (!startTime || seekSeconds == null || !seek || xAxisVal !== "timestamp") {
-        return;
-      }
-      // The player validates and clamps the time.
-      const seekTime = TimeUtil.add(startTime, fromSec(seekSeconds));
-      seek(seekTime);
-    },
-    [seek, startTime, xAxisVal]
-  );
+  const onClick = useCallback((_, __, { X_AXIS_ID: seekSeconds }) => {
+    if (!startTime || seekSeconds == null || !seek || xAxisVal !== "timestamp") {
+      return;
+    }
+    // The player validates and clamps the time.
+    const seekTime = TimeUtil.add(startTime, fromSec(seekSeconds));
+    seek(seekTime);
+  }, [seek, startTime, xAxisVal]);
 
   return (
     <Flex col clip center style={{ position: "relative" }}>

--- a/packages/webviz-core/src/panels/RawMessages/index.js
+++ b/packages/webviz-core/src/panels/RawMessages/index.js
@@ -121,16 +121,12 @@ function RawMessages(props: Props) {
     topicRosPath,
     topics,
   ]);
-  const rootStructureItem: ?MessagePathStructureItem = useMemo(
-    () => {
-      if (!topic || !topicRosPath) {
-        return;
-      }
-      return traverseStructure(messagePathStructures(datatypes)[topic.datatype], topicRosPath.messagePath)
-        .structureItem;
-    },
-    [datatypes, topic, topicRosPath]
-  );
+  const rootStructureItem: ?MessagePathStructureItem = useMemo(() => {
+    if (!topic || !topicRosPath) {
+      return;
+    }
+    return traverseStructure(messagePathStructures(datatypes)[topic.datatype], topicRosPath.messagePath).structureItem;
+  }, [datatypes, topic, topicRosPath]);
 
   // When expandAll is unset, we'll use expandedFields to get expanded info
   const [expandAll, setExpandAll] = useState(false);
@@ -158,48 +154,36 @@ function RawMessages(props: Props) {
   const baseItem = inTimetickDiffMode ? prevTickObj : currTickObj;
   const diffItem = inTimetickDiffMode ? currTickObj : diffTopicObj;
 
-  const onTopicPathChange = useCallback(
-    (newTopicPath: string) => {
-      saveConfig({ topicPath: newTopicPath });
-    },
-    [saveConfig]
-  );
+  const onTopicPathChange = useCallback((newTopicPath: string) => {
+    saveConfig({ topicPath: newTopicPath });
+  }, [saveConfig]);
 
-  const onDiffTopicPathChange = useCallback(
-    (newDiffTopicPath: string) => {
-      saveConfig({ diffTopicPath: newDiffTopicPath });
-    },
-    [saveConfig]
-  );
+  const onDiffTopicPathChange = useCallback((newDiffTopicPath: string) => {
+    saveConfig({ diffTopicPath: newDiffTopicPath });
+  }, [saveConfig]);
 
-  const onToggleDiff = useCallback(
-    () => {
-      saveConfig({ diffEnabled: !diffEnabled });
-    },
-    [diffEnabled, saveConfig]
-  );
+  const onToggleDiff = useCallback(() => {
+    saveConfig({ diffEnabled: !diffEnabled });
+  }, [diffEnabled, saveConfig]);
 
   const onToggleExpandAll = useCallback(() => {
     setExpandedFields(new Set());
     setExpandAll((currVal) => !currVal);
   }, []);
 
-  const onLabelClick = useCallback(
-    (keypath: string[]) => {
-      // Create a unique key according to the keypath / raw
-      const key = keypath.join("~");
-      const expandedFieldsCopy = new Set(expandedFields);
-      if (expandedFieldsCopy.has(key)) {
-        expandedFieldsCopy.delete(key);
-        setExpandedFields(expandedFieldsCopy);
-      } else {
-        expandedFieldsCopy.add(key);
-        setExpandedFields(expandedFieldsCopy);
-      }
-      setExpandAll(null);
-    },
-    [expandedFields]
-  );
+  const onLabelClick = useCallback((keypath: string[]) => {
+    // Create a unique key according to the keypath / raw
+    const key = keypath.join("~");
+    const expandedFieldsCopy = new Set(expandedFields);
+    if (expandedFieldsCopy.has(key)) {
+      expandedFieldsCopy.delete(key);
+      setExpandedFields(expandedFieldsCopy);
+    } else {
+      expandedFieldsCopy.add(key);
+      setExpandedFields(expandedFieldsCopy);
+    }
+    setExpandAll(null);
+  }, [expandedFields]);
 
   const valueRenderer = useCallback(
     (
@@ -289,179 +273,176 @@ function RawMessages(props: Props) {
     [datatypes, onTopicPathChange, openSiblingPanel]
   );
 
-  const renderSingleTopicOrDiffOutput = useCallback(
-    () => {
-      let shouldExpandNode;
-      if (expandAll !== null) {
-        shouldExpandNode = () => expandAll;
-      } else {
-        shouldExpandNode = (keypath) => {
-          return expandedFields.has(keypath.join("~"));
-        };
-      }
+  const renderSingleTopicOrDiffOutput = useCallback(() => {
+    let shouldExpandNode;
+    if (expandAll !== null) {
+      shouldExpandNode = () => expandAll;
+    } else {
+      shouldExpandNode = (keypath) => {
+        return expandedFields.has(keypath.join("~"));
+      };
+    }
 
-      if (!topicPath) {
-        return <EmptyState>No topic selected</EmptyState>;
-      }
-      if (diffEnabled && diffMethod === CUSTOM_METHOD && (!baseItem || !diffItem)) {
-        return <EmptyState>{`Waiting to diff next messages from "${topicPath}" and "${diffTopicPath}"`}</EmptyState>;
-      }
-      if (diffEnabled && diffMethod === OTHER_SOURCE_METHOD && (!baseItem || !diffItem)) {
-        return <EmptyState>{`Waiting to diff next messages from "${topicPath}" and "${otherSourceTopic}"`}</EmptyState>;
-      }
-      if (!baseItem) {
-        return <EmptyState>Waiting for next message</EmptyState>;
-      }
+    if (!topicPath) {
+      return <EmptyState>No topic selected</EmptyState>;
+    }
+    if (diffEnabled && diffMethod === CUSTOM_METHOD && (!baseItem || !diffItem)) {
+      return <EmptyState>{`Waiting to diff next messages from "${topicPath}" and "${diffTopicPath}"`}</EmptyState>;
+    }
+    if (diffEnabled && diffMethod === OTHER_SOURCE_METHOD && (!baseItem || !diffItem)) {
+      return <EmptyState>{`Waiting to diff next messages from "${topicPath}" and "${otherSourceTopic}"`}</EmptyState>;
+    }
+    if (!baseItem) {
+      return <EmptyState>Waiting for next message</EmptyState>;
+    }
 
-      const data = dataWithoutWrappingArray(baseItem.queriedData.map(({ value }) => (value: any)));
-      const hideWrappingArray = baseItem.queriedData.length === 1 && typeof baseItem.queriedData[0].value === "object";
-      const shouldDisplaySingleVal =
-        (data !== undefined && typeof data !== "object") ||
-        (isSingleElemArray(data) && getIndex(data, 0) != null && typeof getIndex(data, 0) !== "object");
-      const singleVal = isSingleElemArray(data) ? getIndex(data, 0) : data;
+    const data = dataWithoutWrappingArray(baseItem.queriedData.map(({ value }) => (value: any)));
+    const hideWrappingArray = baseItem.queriedData.length === 1 && typeof baseItem.queriedData[0].value === "object";
+    const shouldDisplaySingleVal =
+      (data !== undefined && typeof data !== "object") ||
+      (isSingleElemArray(data) && getIndex(data, 0) != null && typeof getIndex(data, 0) !== "object");
+    const singleVal = isSingleElemArray(data) ? getIndex(data, 0) : data;
 
-      const diffData = diffItem && dataWithoutWrappingArray(diffItem.queriedData.map(({ value }) => (value: any)));
-      const diff = diffEnabled && getDiff(maybeDeepParse(data), maybeDeepParse(diffData), null, showFullMessageForDiff);
-      const diffLabelTexts = objectValues(diffLabels).map(({ labelText }) => labelText);
+    const diffData = diffItem && dataWithoutWrappingArray(diffItem.queriedData.map(({ value }) => (value: any)));
+    const diff = diffEnabled && getDiff(maybeDeepParse(data), maybeDeepParse(diffData), null, showFullMessageForDiff);
+    const diffLabelTexts = objectValues(diffLabels).map(({ labelText }) => labelText);
 
-      const CheckboxComponent = showFullMessageForDiff ? CheckboxMarkedIcon : CheckboxBlankOutlineIcon;
-      return (
-        <Flex col clip scroll className={styles.container}>
-          <Metadata
-            data={data}
-            diffData={diffData}
-            diff={diff}
-            datatype={topic?.datatype}
-            message={baseItem.message}
-            diffMessage={diffItem?.message}
-          />
-          {shouldDisplaySingleVal ? (
-            <div className={styles.singleVal}>
-              <MaybeCollapsedValue itemLabel={String(singleVal)} />
-            </div>
-          ) : diffEnabled && isEqual({}, diff) ? (
-            <EmptyState>No difference found</EmptyState>
-          ) : (
-            <>
-              {diffEnabled && (
-                <div
-                  style={{ cursor: "pointer", fontSize: "11px" }}
-                  onClick={() => saveConfig({ showFullMessageForDiff: !showFullMessageForDiff })}>
-                  <Icon style={{ verticalAlign: "middle" }}>
-                    <CheckboxComponent />
-                  </Icon>{" "}
-                  Show full msg
-                </div>
-              )}
-              <Tree
-                labelRenderer={(raw) => <SDiffSpan onClick={() => onLabelClick(raw)}>{first(raw)}</SDiffSpan>}
-                shouldExpandNode={shouldExpandNode}
-                hideRoot
-                invertTheme={false}
-                getItemString={diffEnabled ? getItemStringForDiff : getItemString}
-                valueRenderer={(...args) => {
-                  if (diffEnabled) {
-                    return valueRenderer(null, diff, diff, ...args);
+    const CheckboxComponent = showFullMessageForDiff ? CheckboxMarkedIcon : CheckboxBlankOutlineIcon;
+    return (
+      <Flex col clip scroll className={styles.container}>
+        <Metadata
+          data={data}
+          diffData={diffData}
+          diff={diff}
+          datatype={topic?.datatype}
+          message={baseItem.message}
+          diffMessage={diffItem?.message}
+        />
+        {shouldDisplaySingleVal ? (
+          <div className={styles.singleVal}>
+            <MaybeCollapsedValue itemLabel={String(singleVal)} />
+          </div>
+        ) : diffEnabled && isEqual({}, diff) ? (
+          <EmptyState>No difference found</EmptyState>
+        ) : (
+          <>
+            {diffEnabled && (
+              <div
+                style={{ cursor: "pointer", fontSize: "11px" }}
+                onClick={() => saveConfig({ showFullMessageForDiff: !showFullMessageForDiff })}>
+                <Icon style={{ verticalAlign: "middle" }}>
+                  <CheckboxComponent />
+                </Icon>{" "}
+                Show full msg
+              </div>
+            )}
+            <Tree
+              labelRenderer={(raw) => <SDiffSpan onClick={() => onLabelClick(raw)}>{first(raw)}</SDiffSpan>}
+              shouldExpandNode={shouldExpandNode}
+              hideRoot
+              invertTheme={false}
+              getItemString={diffEnabled ? getItemStringForDiff : getItemString}
+              valueRenderer={(...args) => {
+                if (diffEnabled) {
+                  return valueRenderer(null, diff, diff, ...args);
+                }
+                if (hideWrappingArray) {
+                  // When the wrapping array is hidden, put it back here.
+                  return valueRenderer(rootStructureItem, [data], baseItem.queriedData, ...args, 0);
+                }
+                return valueRenderer(rootStructureItem, data, baseItem.queriedData, ...args);
+              }}
+              postprocessValue={(rawVal: mixed) => {
+                const val = maybeShallowParse(rawVal);
+                if (
+                  val != null &&
+                  typeof val === "object" &&
+                  Object.keys(val).length === 1 &&
+                  diffLabelTexts.includes(Object.keys(val)[0])
+                ) {
+                  if (Object.keys(val)[0] !== diffLabels.ID.labelText) {
+                    return objectValues(val)[0];
                   }
-                  if (hideWrappingArray) {
-                    // When the wrapping array is hidden, put it back here.
-                    return valueRenderer(rootStructureItem, [data], baseItem.queriedData, ...args, 0);
+                }
+                return val;
+              }}
+              theme={{
+                ...jsonTreeTheme,
+                tree: { margin: 0 },
+                nestedNode: ({ style }, keyPath) => {
+                  const baseStyle = {
+                    ...style,
+                    padding: "2px 0 2px 5px",
+                    marginTop: 2,
+                    textDecoration: "inherit",
+                  };
+                  if (!diffEnabled) {
+                    return { style: baseStyle };
                   }
-                  return valueRenderer(rootStructureItem, data, baseItem.queriedData, ...args);
-                }}
-                postprocessValue={(rawVal: mixed) => {
-                  const val = maybeShallowParse(rawVal);
-                  if (
-                    val != null &&
-                    typeof val === "object" &&
-                    Object.keys(val).length === 1 &&
-                    diffLabelTexts.includes(Object.keys(val)[0])
-                  ) {
-                    if (Object.keys(val)[0] !== diffLabels.ID.labelText) {
-                      return objectValues(val)[0];
-                    }
+                  let backgroundColor;
+                  let textDecoration;
+                  if (diffLabelsByLabelText[keyPath[0]]) {
+                    backgroundColor = diffLabelsByLabelText[keyPath[0]].backgroundColor;
+                    textDecoration = keyPath[0] === diffLabels.DELETED.labelText ? "line-through" : "none";
                   }
-                  return val;
-                }}
-                theme={{
-                  ...jsonTreeTheme,
-                  tree: { margin: 0 },
-                  nestedNode: ({ style }, keyPath) => {
-                    const baseStyle = {
-                      ...style,
-                      padding: "2px 0 2px 5px",
-                      marginTop: 2,
-                      textDecoration: "inherit",
-                    };
-                    if (!diffEnabled) {
-                      return { style: baseStyle };
-                    }
-                    let backgroundColor;
-                    let textDecoration;
-                    if (diffLabelsByLabelText[keyPath[0]]) {
-                      backgroundColor = diffLabelsByLabelText[keyPath[0]].backgroundColor;
-                      textDecoration = keyPath[0] === diffLabels.DELETED.labelText ? "line-through" : "none";
-                    }
-                    const nestedObj = get(diff, keyPath.slice().reverse(), {});
-                    const nestedObjKey = Object.keys(nestedObj)[0];
-                    if (diffLabelsByLabelText[nestedObjKey]) {
-                      backgroundColor = diffLabelsByLabelText[nestedObjKey].backgroundColor;
-                      textDecoration = nestedObjKey === diffLabels.DELETED.labelText ? "line-through" : "none";
-                    }
-                    return {
-                      style: { ...baseStyle, backgroundColor, textDecoration: textDecoration || "inherit" },
-                    };
-                  },
-                  nestedNodeLabel: ({ style }) => ({
-                    style: { ...style, textDecoration: "inherit" },
-                  }),
-                  nestedNodeChildren: ({ style }) => ({
-                    style: { ...style, textDecoration: "inherit" },
-                  }),
-                  value: ({ style }, nodeType, keyPath) => {
-                    const baseStyle = { ...style, textDecoration: "inherit" };
-                    if (!diffEnabled) {
-                      return { style: baseStyle };
-                    }
-                    let backgroundColor;
-                    let textDecoration;
-                    const nestedObj = get(diff, keyPath.slice().reverse(), {});
-                    const nestedObjKey = Object.keys(nestedObj)[0];
-                    if (diffLabelsByLabelText[nestedObjKey]) {
-                      backgroundColor = diffLabelsByLabelText[nestedObjKey].backgroundColor;
-                      textDecoration = nestedObjKey === diffLabels.DELETED.labelText ? "line-through" : "none";
-                    }
-                    return {
-                      style: { ...baseStyle, backgroundColor, textDecoration: textDecoration || "inherit" },
-                    };
-                  },
-                  label: { textDecoration: "inherit" },
-                }}
-                data={diffEnabled ? diff : data}
-              />
-            </>
-          )}
-        </Flex>
-      );
-    },
-    [
-      baseItem,
-      diffEnabled,
-      diffItem,
-      diffMethod,
-      diffTopicPath,
-      expandAll,
-      expandedFields,
-      onLabelClick,
-      otherSourceTopic,
-      rootStructureItem,
-      saveConfig,
-      showFullMessageForDiff,
-      topic,
-      topicPath,
-      valueRenderer,
-    ]
-  );
+                  const nestedObj = get(diff, keyPath.slice().reverse(), {});
+                  const nestedObjKey = Object.keys(nestedObj)[0];
+                  if (diffLabelsByLabelText[nestedObjKey]) {
+                    backgroundColor = diffLabelsByLabelText[nestedObjKey].backgroundColor;
+                    textDecoration = nestedObjKey === diffLabels.DELETED.labelText ? "line-through" : "none";
+                  }
+                  return {
+                    style: { ...baseStyle, backgroundColor, textDecoration: textDecoration || "inherit" },
+                  };
+                },
+                nestedNodeLabel: ({ style }) => ({
+                  style: { ...style, textDecoration: "inherit" },
+                }),
+                nestedNodeChildren: ({ style }) => ({
+                  style: { ...style, textDecoration: "inherit" },
+                }),
+                value: ({ style }, nodeType, keyPath) => {
+                  const baseStyle = { ...style, textDecoration: "inherit" };
+                  if (!diffEnabled) {
+                    return { style: baseStyle };
+                  }
+                  let backgroundColor;
+                  let textDecoration;
+                  const nestedObj = get(diff, keyPath.slice().reverse(), {});
+                  const nestedObjKey = Object.keys(nestedObj)[0];
+                  if (diffLabelsByLabelText[nestedObjKey]) {
+                    backgroundColor = diffLabelsByLabelText[nestedObjKey].backgroundColor;
+                    textDecoration = nestedObjKey === diffLabels.DELETED.labelText ? "line-through" : "none";
+                  }
+                  return {
+                    style: { ...baseStyle, backgroundColor, textDecoration: textDecoration || "inherit" },
+                  };
+                },
+                label: { textDecoration: "inherit" },
+              }}
+              data={diffEnabled ? diff : data}
+            />
+          </>
+        )}
+      </Flex>
+    );
+  }, [
+    baseItem,
+    diffEnabled,
+    diffItem,
+    diffMethod,
+    diffTopicPath,
+    expandAll,
+    expandedFields,
+    onLabelClick,
+    otherSourceTopic,
+    rootStructureItem,
+    saveConfig,
+    showFullMessageForDiff,
+    topic,
+    topicPath,
+    valueRenderer,
+  ]);
 
   return (
     <Flex col clip style={{ position: "relative" }}>

--- a/packages/webviz-core/src/panels/Tab/EmptyDropTarget.js
+++ b/packages/webviz-core/src/panels/Tab/EmptyDropTarget.js
@@ -72,13 +72,10 @@ export const EmptyDropTarget = ({ mosaicId, tabId }: Props) => {
     }),
   });
 
-  const onPanelSelect = useCallback(
-    ({ type, config, relatedConfigs }: PanelSelection) => {
-      dispatch(addPanel({ tabId, type, layout: null, config, relatedConfigs }));
-      logEvent({ name: getEventNames().PANEL_ADD, tags: { [getEventTags().PANEL_TYPE]: type } });
-    },
-    [dispatch, tabId]
-  );
+  const onPanelSelect = useCallback(({ type, config, relatedConfigs }: PanelSelection) => {
+    dispatch(addPanel({ tabId, type, layout: null, config, relatedConfigs }));
+    logEvent({ name: getEventNames().PANEL_ADD, tags: { [getEventTags().PANEL_TYPE]: type } });
+  }, [dispatch, tabId]);
 
   return (
     <SDropTarget ref={drop} isOver={isOver} data-test="empty-drop-target">

--- a/packages/webviz-core/src/panels/Tab/TabbedToolbar.js
+++ b/packages/webviz-core/src/panels/Tab/TabbedToolbar.js
@@ -83,12 +83,9 @@ export function TabbedToolbar(props: Props) {
       dispatch(moveTab(({ source, target }: MoveTabPayload)));
     },
   });
-  useEffect(
-    () => {
-      setDraggingTabState({ item, isOver });
-    },
-    [item, isOver, setDraggingTabState]
-  );
+  useEffect(() => {
+    setDraggingTabState({ item, isOver });
+  }, [item, isOver, setDraggingTabState]);
 
   return (
     <STabbedToolbar highlight={isOver}>

--- a/packages/webviz-core/src/panels/Tab/ToolbarTab.js
+++ b/packages/webviz-core/src/panels/Tab/ToolbarTab.js
@@ -84,24 +84,21 @@ export function ToolbarTab(props: Props) {
   );
   const setTabTitle = useCallback(() => actions.setTabTitle(tabIndex, title), [actions, tabIndex, title]);
 
-  const onClickTab = useCallback(
-    () => {
-      if (!isActive) {
-        selectTab();
-      } else {
-        setEditingTitle(true);
+  const onClickTab = useCallback(() => {
+    if (!isActive) {
+      selectTab();
+    } else {
+      setEditingTitle(true);
 
-        setImmediate(() => {
-          if (inputRef.current) {
-            const inputEl: HTMLInputElement = inputRef.current;
-            inputEl.focus();
-            inputEl.select();
-          }
-        });
-      }
-    },
-    [isActive, selectTab, inputRef]
-  );
+      setImmediate(() => {
+        if (inputRef.current) {
+          const inputEl: HTMLInputElement = inputRef.current;
+          inputEl.focus();
+          inputEl.select();
+        }
+      });
+    }
+  }, [isActive, selectTab, inputRef]);
 
   const endTitleEditing = useCallback(() => {
     setEditingTitle(false);
@@ -110,50 +107,35 @@ export function ToolbarTab(props: Props) {
     }
   }, []);
 
-  const confirmNewTitle = useCallback(
-    () => {
-      setTabTitle();
-      endTitleEditing();
-    },
-    [endTitleEditing, setTabTitle]
-  );
+  const confirmNewTitle = useCallback(() => {
+    setTabTitle();
+    endTitleEditing();
+  }, [endTitleEditing, setTabTitle]);
 
-  const resetTitle = useCallback(
-    () => {
-      setTitle(tabTitle || "");
-      endTitleEditing();
-    },
-    [endTitleEditing, tabTitle]
-  );
+  const resetTitle = useCallback(() => {
+    setTitle(tabTitle || "");
+    endTitleEditing();
+  }, [endTitleEditing, tabTitle]);
 
-  const onKeyDown = useCallback(
-    (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
-      if (event.key === "Escape") {
-        resetTitle();
-      } else if (event.key === "Enter") {
-        confirmNewTitle();
-      }
-    },
-    [confirmNewTitle, resetTitle]
-  );
+  const onKeyDown = useCallback((event: SyntheticKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Escape") {
+      resetTitle();
+    } else if (event.key === "Enter") {
+      confirmNewTitle();
+    }
+  }, [confirmNewTitle, resetTitle]);
 
   // If the tab is no longer active, stop editing the title
-  useEffect(
-    () => {
-      if (!isActive) {
-        setEditingTitle(false);
-      }
-    },
-    [isActive]
-  );
+  useEffect(() => {
+    if (!isActive) {
+      setEditingTitle(false);
+    }
+  }, [isActive]);
 
   // Update the cached title if the tabTitle changes
-  useEffect(
-    () => {
-      setTitle(tabTitle);
-    },
-    [tabTitle]
-  );
+  useEffect(() => {
+    setTitle(tabTitle);
+  }, [tabTitle]);
 
   return (
     <STab

--- a/packages/webviz-core/src/panels/Tab/index.js
+++ b/packages/webviz-core/src/panels/Tab/index.js
@@ -53,41 +53,26 @@ function Tab({ config, saveConfig }: Props) {
   });
 
   // Create the actions used by the tab
-  const selectTab = useCallback(
-    (idx) => {
-      saveConfig({ activeTabIdx: idx });
-    },
-    [saveConfig]
-  );
-  const setTabTitle = useCallback(
-    (idx, title) => {
-      const newTabs = tabs.slice();
-      newTabs[idx] = { ...tabs[idx], title };
-      saveConfig({ tabs: newTabs });
-    },
-    [saveConfig, tabs]
-  );
-  const removeTab = useCallback(
-    (idx) => {
-      const newTabs = tabs.slice(0, idx).concat(tabs.slice(idx + 1));
-      const lastIdx = tabs.length - 1;
-      saveConfig({ tabs: newTabs, activeTabIdx: activeTabIdx === lastIdx ? lastIdx - 1 : activeTabIdx });
-    },
-    [activeTabIdx, saveConfig, tabs]
-  );
-  const addTab = useCallback(
-    () => {
-      const newTab = { title: `${tabs.length + 1}`, layout: null };
-      saveConfig({ ...config, activeTabIdx: tabs.length, tabs: tabs.concat([newTab]) });
-    },
-    [config, saveConfig, tabs]
-  );
-  const onChangeLayout = useCallback(
-    (layout: string) => {
-      saveConfig(updateTabPanelLayout(layout, config));
-    },
-    [config, saveConfig]
-  );
+  const selectTab = useCallback((idx) => {
+    saveConfig({ activeTabIdx: idx });
+  }, [saveConfig]);
+  const setTabTitle = useCallback((idx, title) => {
+    const newTabs = tabs.slice();
+    newTabs[idx] = { ...tabs[idx], title };
+    saveConfig({ tabs: newTabs });
+  }, [saveConfig, tabs]);
+  const removeTab = useCallback((idx) => {
+    const newTabs = tabs.slice(0, idx).concat(tabs.slice(idx + 1));
+    const lastIdx = tabs.length - 1;
+    saveConfig({ tabs: newTabs, activeTabIdx: activeTabIdx === lastIdx ? lastIdx - 1 : activeTabIdx });
+  }, [activeTabIdx, saveConfig, tabs]);
+  const addTab = useCallback(() => {
+    const newTab = { title: `${tabs.length + 1}`, layout: null };
+    saveConfig({ ...config, activeTabIdx: tabs.length, tabs: tabs.concat([newTab]) });
+  }, [config, saveConfig, tabs]);
+  const onChangeLayout = useCallback((layout: string) => {
+    saveConfig(updateTabPanelLayout(layout, config));
+  }, [config, saveConfig]);
   const actions = useMemo(() => ({ addTab, removeTab, selectTab, setTabTitle }), [
     addTab,
     removeTab,

--- a/packages/webviz-core/src/panels/Table/index.js
+++ b/packages/webviz-core/src/panels/Table/index.js
@@ -123,23 +123,20 @@ function getColumnsFromObject(obj: RosObject, accessorPath: string): ColumnOptio
 
 const Table = ({ value, accessorPath }: {| value: mixed, accessorPath: string |}) => {
   const isNested = !!accessorPath;
-  const columns = React.useMemo(
-    () => {
-      if (
-        value === null ||
-        typeof value !== "object" ||
-        (Array.isArray(value) && typeof value[0] !== "object" && value[0] !== null)
-      ) {
-        return [];
-      }
+  const columns = React.useMemo(() => {
+    if (
+      value === null ||
+      typeof value !== "object" ||
+      (Array.isArray(value) && typeof value[0] !== "object" && value[0] !== null)
+    ) {
+      return [];
+    }
 
-      const rosObject: RosObject = ((Array.isArray(value) ? value[0] || {} : value): any);
+    const rosObject: RosObject = ((Array.isArray(value) ? value[0] || {} : value): any);
 
-      // Strong assumption about structure of data.
-      return getColumnsFromObject(rosObject, accessorPath);
-    },
-    [accessorPath, value]
-  );
+    // Strong assumption about structure of data.
+    return getColumnsFromObject(rosObject, accessorPath);
+  }, [accessorPath, value]);
 
   const data = React.useMemo(() => (Array.isArray(value) ? value : [value]), [value]);
 
@@ -295,12 +292,9 @@ type Props = { config: Config, saveConfig: SaveConfig<Config> };
 
 function TablePanel({ config, saveConfig }: Props) {
   const { topicPath } = config;
-  const onTopicPathChange = React.useCallback(
-    (newTopicPath: string) => {
-      saveConfig({ topicPath: newTopicPath });
-    },
-    [saveConfig]
-  );
+  const onTopicPathChange = React.useCallback((newTopicPath: string) => {
+    saveConfig({ topicPath: newTopicPath });
+  }, [saveConfig]);
 
   const topicRosPath: ?RosPath = React.useMemo(() => parseRosPath(topicPath), [topicPath]);
   const topicName = topicRosPath?.topicName || "";

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/FollowTFControl.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/FollowTFControl.js
@@ -131,62 +131,47 @@ const FollowTFControl = memo<Props>((props: Props) => {
 
   const autocomplete = createRef<Autocomplete>();
 
-  const getDefaultFollowTransformFrame = useCallback(
-    () => {
-      return nodesWithoutDefaultFollowTfFrame ? newFollowTfFrame : defaultFollowTfFrame;
-    },
-    [nodesWithoutDefaultFollowTfFrame, newFollowTfFrame]
-  );
+  const getDefaultFollowTransformFrame = useCallback(() => {
+    return nodesWithoutDefaultFollowTfFrame ? newFollowTfFrame : defaultFollowTfFrame;
+  }, [nodesWithoutDefaultFollowTfFrame, newFollowTfFrame]);
 
-  const getFollowButtonTooltip = useCallback(
-    () => {
-      if (!tfToFollow) {
-        if (lastSelectedFrame) {
-          return `Follow ${lastSelectedFrame}`;
-        }
-        return `Follow ${getDefaultFollowTransformFrame()}`;
-      } else if (!followOrientation) {
-        return "Follow Orientation";
+  const getFollowButtonTooltip = useCallback(() => {
+    if (!tfToFollow) {
+      if (lastSelectedFrame) {
+        return `Follow ${lastSelectedFrame}`;
       }
-      return "Unfollow";
-    },
-    [tfToFollow, followOrientation, lastSelectedFrame, getDefaultFollowTransformFrame]
-  );
+      return `Follow ${getDefaultFollowTransformFrame()}`;
+    } else if (!followOrientation) {
+      return "Follow Orientation";
+    }
+    return "Unfollow";
+  }, [tfToFollow, followOrientation, lastSelectedFrame, getDefaultFollowTransformFrame]);
 
-  const onClickFollowButton = useCallback(
-    () => {
-      if (!tfToFollow) {
-        if (lastSelectedFrame) {
-          return onFollowChange(lastSelectedFrame);
-        }
-        return onFollowChange(getDefaultFollowTransformFrame());
-      } else if (!followOrientation) {
-        return onFollowChange(tfToFollow, true);
+  const onClickFollowButton = useCallback(() => {
+    if (!tfToFollow) {
+      if (lastSelectedFrame) {
+        return onFollowChange(lastSelectedFrame);
       }
-      return onFollowChange(false);
-    },
-    [tfToFollow, lastSelectedFrame, onFollowChange, getDefaultFollowTransformFrame, followOrientation]
-  );
+      return onFollowChange(getDefaultFollowTransformFrame());
+    } else if (!followOrientation) {
+      return onFollowChange(tfToFollow, true);
+    }
+    return onFollowChange(false);
+  }, [tfToFollow, lastSelectedFrame, onFollowChange, getDefaultFollowTransformFrame, followOrientation]);
 
-  const onSelectFrame = useCallback(
-    (id: string, item: mixed, autocompleteNode: Autocomplete) => {
-      setLastSelectedFrame(id === getDefaultFollowTransformFrame() ? undefined : id);
-      onFollowChange(id, followOrientation);
-      autocompleteNode.blur();
-    },
-    [setLastSelectedFrame, getDefaultFollowTransformFrame, onFollowChange, followOrientation]
-  );
+  const onSelectFrame = useCallback((id: string, item: mixed, autocompleteNode: Autocomplete) => {
+    setLastSelectedFrame(id === getDefaultFollowTransformFrame() ? undefined : id);
+    onFollowChange(id, followOrientation);
+    autocompleteNode.blur();
+  }, [setLastSelectedFrame, getDefaultFollowTransformFrame, onFollowChange, followOrientation]);
 
-  const openFrameList = useCallback(
-    (event: SyntheticEvent<Element>) => {
-      event.preventDefault();
-      setForceShowFrameList(true);
-      if (autocomplete.current) {
-        autocomplete.current.focus();
-      }
-    },
-    [setForceShowFrameList, autocomplete]
-  );
+  const openFrameList = useCallback((event: SyntheticEvent<Element>) => {
+    event.preventDefault();
+    setForceShowFrameList(true);
+    if (autocomplete.current) {
+      autocomplete.current.focus();
+    }
+  }, [setForceShowFrameList, autocomplete]);
 
   // slight delay to prevent the arrow from disappearing when you're trying to click it
   const onMouseLeaveDebounced = useCallback(
@@ -196,13 +181,10 @@ const FollowTFControl = memo<Props>((props: Props) => {
     [setHovering]
   );
 
-  const onMouseEnter = useCallback(
-    () => {
-      onMouseLeaveDebounced.cancel();
-      setHovering(true);
-    },
-    [onMouseLeaveDebounced, setHovering]
-  );
+  const onMouseEnter = useCallback(() => {
+    onMouseLeaveDebounced.cancel();
+    setHovering(true);
+  }, [onMouseLeaveDebounced, setHovering]);
 
   const followingCustomFrame = tfToFollow && tfToFollow !== getDefaultFollowTransformFrame();
   const showFrameList = lastSelectedFrame != null || forceShowFrameList || followingCustomFrame;

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/FrameCompatibility.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/FrameCompatibility.js
@@ -26,23 +26,17 @@ const useFrame = (
   const frame = React.useRef({});
   const lastClearTime = PanelAPI.useMessageReducer({
     topics,
-    restore: React.useCallback(
-      () => {
-        frame.current = {};
-        return Date.now();
-      },
-      [frame]
-    ),
-    [callbackKey]: React.useCallback(
-      (time, messages: $ReadOnlyArray<Message>) => {
-        for (const message of messages) {
-          frame.current[message.topic] = frame.current[message.topic] || [];
-          frame.current[message.topic].push(message);
-        }
-        return time;
-      },
-      [frame]
-    ),
+    restore: React.useCallback(() => {
+      frame.current = {};
+      return Date.now();
+    }, [frame]),
+    [callbackKey]: React.useCallback((time, messages: $ReadOnlyArray<Message>) => {
+      for (const message of messages) {
+        frame.current[message.topic] = frame.current[message.topic] || [];
+        frame.current[message.topic].push(message);
+      }
+      return time;
+    }, [frame]),
   });
 
   const cleared = useChangeDetector([lastClearTime], false);

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/GlobalVariableStyles.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/GlobalVariableStyles.js
@@ -104,19 +104,20 @@ export default function GlobalVariableStyles(props: Props) {
   const { linkedGlobalVariables } = useLinkedGlobalVariables();
   const linkedGlobalVariablesByName = groupBy(linkedGlobalVariables, ({ name }) => name);
 
-  const updateSettingsForGlobalVariable = useCallback(
-    (globalVariableName, settings: { active: boolean, color: Color }, sourceIdx = 0) => {
-      const updatedSettings = new Array(2)
-        .fill()
-        .map((_, i) => colorOverrideBySourceIdxByVariable[globalVariableName]?.[i]);
-      updatedSettings[sourceIdx] = settings;
-      setColorOverrideBySourceIdxByVariable({
-        ...colorOverrideBySourceIdxByVariable,
-        [globalVariableName]: updatedSettings,
-      });
-    },
-    [colorOverrideBySourceIdxByVariable, setColorOverrideBySourceIdxByVariable]
-  );
+  const updateSettingsForGlobalVariable = useCallback((
+    globalVariableName,
+    settings: { active: boolean, color: Color },
+    sourceIdx = 0
+  ) => {
+    const updatedSettings = new Array(2)
+      .fill()
+      .map((_, i) => colorOverrideBySourceIdxByVariable[globalVariableName]?.[i]);
+    updatedSettings[sourceIdx] = settings;
+    setColorOverrideBySourceIdxByVariable({
+      ...colorOverrideBySourceIdxByVariable,
+      [globalVariableName]: updatedSettings,
+    });
+  }, [colorOverrideBySourceIdxByVariable, setColorOverrideBySourceIdxByVariable]);
 
   return (
     <ExpandingToolbar

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/Interactions/GlobalVariableLink/LinkToGlobalVariable.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/Interactions/GlobalVariableLink/LinkToGlobalVariable.js
@@ -48,15 +48,12 @@ export default function LinkToGlobalVariable({
   const [isOpen, _setIsOpen] = React.useState<boolean>(false);
   const [name, setName] = React.useState(() => getInitialName(markerKeyPath));
 
-  const setIsOpen = React.useCallback(
-    (newValue: boolean) => {
-      _setIsOpen(newValue);
-      if (newValue) {
-        setName(getInitialName(markerKeyPath));
-      }
-    },
-    [markerKeyPath]
-  );
+  const setIsOpen = React.useCallback((newValue: boolean) => {
+    _setIsOpen(newValue);
+    if (newValue) {
+      setName(getInitialName(markerKeyPath));
+    }
+  }, [markerKeyPath]);
 
   const { setGlobalVariables } = useGlobalVariables();
   const { linkedGlobalVariables, setLinkedGlobalVariables } = useLinkedGlobalVariables();

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/Interactions/InteractionContextMenu.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/Interactions/InteractionContextMenu.js
@@ -101,19 +101,16 @@ function InteractionContextMenuItem({
   );
 
   const { setHoveredMarkerMatchers } = useContext(ThreeDimensionalVizContext);
-  const onMouseEnter = useCallback(
-    () => {
-      if (topic) {
-        const { id, ns } = object;
-        const checks = [{ markerKeyPath: ["id"], value: id }];
-        if (ns) {
-          checks.push({ markerKeyPath: ["ns"], value: ns });
-        }
-        return setHoveredMarkerMatchers([{ topic, checks }]);
+  const onMouseEnter = useCallback(() => {
+    if (topic) {
+      const { id, ns } = object;
+      const checks = [{ markerKeyPath: ["id"], value: id }];
+      if (ns) {
+        checks.push({ markerKeyPath: ["ns"], value: ns });
       }
-    },
-    [object, setHoveredMarkerMatchers, topic]
-  );
+      return setHoveredMarkerMatchers([{ topic, checks }]);
+    }
+  }, [object, setHoveredMarkerMatchers, topic]);
   const onMouseLeave = useCallback(() => setHoveredMarkerMatchers([]), [setHoveredMarkerMatchers]);
   useEffect(() => onMouseLeave, [onMouseLeave]);
 

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/Interactions/PointCloudDetails.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/Interactions/PointCloudDetails.js
@@ -38,39 +38,33 @@ export default function PointCloudDetails({ selectedObject: { object, instanceIn
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
   const { clickedPoint, clickedPointColor, additionalFieldValues } =
-    useMemo(
-      () => {
-        return getClickedInfo(object, instanceIndex);
-      },
-      [instanceIndex, object]
-    ) || {};
+    useMemo(() => {
+      return getClickedInfo(object, instanceIndex);
+    }, [instanceIndex, object]) || {};
 
   const additionalFieldNames = useMemo(() => (additionalFieldValues && Object.keys(additionalFieldValues)) || [], [
     additionalFieldValues,
   ]);
 
   const hasAdditionalFieldNames = !!additionalFieldNames.length;
-  const onCopy = useCallback(
-    () => {
-      // GPU point clouds need to extract positions using getAllPoints()
-      const allPoints: number[] = object.points || getAllPoints(object);
-      const dataRows = [];
-      const len = allPoints.length / 3;
-      // get copy data
-      for (let i = 0; i < len; i++) {
-        const rowData = [allPoints[i * 3], allPoints[i * 3 + 1], allPoints[i * 3 + 2]];
-        rowData.push(...additionalFieldNames.map((fieldName) => object?.[fieldName]?.[i]));
-        dataRows.push(rowData.join(","));
-      }
+  const onCopy = useCallback(() => {
+    // GPU point clouds need to extract positions using getAllPoints()
+    const allPoints: number[] = object.points || getAllPoints(object);
+    const dataRows = [];
+    const len = allPoints.length / 3;
+    // get copy data
+    for (let i = 0; i < len; i++) {
+      const rowData = [allPoints[i * 3], allPoints[i * 3 + 1], allPoints[i * 3 + 2]];
+      rowData.push(...additionalFieldNames.map((fieldName) => object?.[fieldName]?.[i]));
+      dataRows.push(rowData.join(","));
+    }
 
-      const additionalColumns = hasAdditionalFieldNames ? `,${additionalFieldNames.join(",")}` : "";
-      const dataStr = `x,y,z${additionalColumns}\n${dataRows.join("\n")}`;
-      const blob = new Blob([dataStr], { type: "text/csv;charset=utf-8;" });
-      downloadFiles([{ blob, fileName: "PointCloud.csv" }]);
-      setIsOpen(false);
-    },
-    [additionalFieldNames, hasAdditionalFieldNames, object]
-  );
+    const additionalColumns = hasAdditionalFieldNames ? `,${additionalFieldNames.join(",")}` : "";
+    const dataStr = `x,y,z${additionalColumns}\n${dataRows.join("\n")}`;
+    const blob = new Blob([dataStr], { type: "text/csv;charset=utf-8;" });
+    downloadFiles([{ blob, fileName: "PointCloud.csv" }]);
+    setIsOpen(false);
+  }, [additionalFieldNames, hasAdditionalFieldNames, object]);
   const onToggle = useCallback(() => setIsOpen((open) => !open), []);
 
   if (!clickedPoint) {

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/Interactions/TopicLink.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/Interactions/TopicLink.js
@@ -25,19 +25,16 @@ type Props = {
 
 export default function TopicLink({ topic }: Props) {
   const { openSiblingPanel } = usePanelContext();
-  const openRawMessages = React.useCallback(
-    () => {
-      if (!openSiblingPanel) {
-        return;
-      }
-      openSiblingPanel(
-        RawMessages.panelType,
-        // $FlowFixMe
-        (config: RawMessagesConfig) => ({ ...config, topicPath: topic }: RawMessagesConfig)
-      );
-    },
-    [openSiblingPanel, topic]
-  );
+  const openRawMessages = React.useCallback(() => {
+    if (!openSiblingPanel) {
+      return;
+    }
+    openSiblingPanel(
+      RawMessages.panelType,
+      // $FlowFixMe
+      (config: RawMessagesConfig) => ({ ...config, topicPath: topic }: RawMessagesConfig)
+    );
+  }, [openSiblingPanel, topic]);
 
   return (
     <Tooltip placement="top" contents={`View ${topic} in Raw Messages panel`}>

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/LayoutToolbar.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/LayoutToolbar.js
@@ -84,17 +84,14 @@ function LayoutToolbar({
   toggleSearchTextOpen,
   transforms,
 }: Props) {
-  const additionalToolbarItemsElem = useMemo(
-    () => {
-      const AdditionalToolbarItems = getGlobalHooks().perPanelHooks().ThreeDimensionalViz.AdditionalToolbarItems;
-      return (
-        <div className={cx(styles.buttons, styles.cartographer)}>
-          <AdditionalToolbarItems transforms={transforms} />
-        </div>
-      );
-    },
-    [transforms]
-  );
+  const additionalToolbarItemsElem = useMemo(() => {
+    const AdditionalToolbarItems = getGlobalHooks().perPanelHooks().ThreeDimensionalViz.AdditionalToolbarItems;
+    return (
+      <div className={cx(styles.buttons, styles.cartographer)}>
+        <AdditionalToolbarItems transforms={transforms} />
+      </div>
+    );
+  }, [transforms]);
 
   return isHidden ? null : (
     <>

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PointCloudSettingsEditor.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PointCloudSettingsEditor.js
@@ -77,15 +77,12 @@ const RainbowText = React.memo(function RainbowText({ children: text }: { childr
 export default function PointCloudSettingsEditor(props: TopicSettingsEditorProps<PointCloud2, PointCloudSettings>) {
   const { message, settings = {}, onFieldChange, onSettingsChange } = props;
 
-  const onColorModeChange = useCallback(
-    (newValue: ?ColorMode | ((?ColorMode) => ?ColorMode)) => {
-      onSettingsChange((newSettings) => ({
-        ...newSettings,
-        colorMode: typeof newValue === "function" ? newValue(newSettings.colorMode) : newValue,
-      }));
-    },
-    [onSettingsChange]
-  );
+  const onColorModeChange = useCallback((newValue: ?ColorMode | ((?ColorMode) => ?ColorMode)) => {
+    onSettingsChange((newSettings) => ({
+      ...newSettings,
+      colorMode: typeof newValue === "function" ? newValue(newSettings.colorMode) : newValue,
+    }));
+  }, [onSettingsChange]);
 
   const hasRGB = message && message.fields && message.fields.some(({ name }) => name === "rgb");
   const defaultColorField = message && message.fields && message.fields.find(({ name }) => name !== "rgb")?.name;

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor.js
@@ -35,82 +35,79 @@ type PoseSettings = {|
 export default function PoseSettingsEditor(props: TopicSettingsEditorProps<PoseStamped, PoseSettings>) {
   const { message, settings, onFieldChange, onSettingsChange } = props;
 
-  const settingsByCarType = React.useMemo(
-    () => {
-      switch (settings.modelType) {
-        case "car-model": {
-          const alpha = settings.alpha != null ? settings.alpha : 1;
-          return (
-            <Flex col>
-              <SLabel>Alpha</SLabel>
-              <SInput
-                type="number"
-                value={alpha.toString()}
-                min={0}
-                max={1}
-                step={0.1}
-                onChange={(e) => onSettingsChange({ ...settings, alpha: parseFloat(e.target.value) })}
-              />
-            </Flex>
-          );
-        }
-        case "car-outline": {
-          return (
-            <>
-              <SLabel>Color of outline</SLabel>
-              <ColorPickerForTopicSettings
-                color={settings.overrideColor}
-                onChange={(newColor) => onFieldChange("overrideColor", newColor)}
-              />
-            </>
-          );
-        }
-        case "arrow":
-        default: {
-          const currentShaftWidth = settings.size?.shaftWidth ?? 2;
-          const currentHeadWidth = settings.size?.headWidth ?? 2;
-          const currentHeadLength = settings.size?.headLength ?? 0.1;
-          return (
-            <Flex col>
-              <SLabel>Color</SLabel>
-              <ColorPickerForTopicSettings
-                color={settings.overrideColor}
-                onChange={(newColor) => onFieldChange("overrideColor", newColor)}
-              />
-              <SLabel>Shaft width</SLabel>
-              <SInput
-                type="number"
-                value={currentShaftWidth}
-                placeholder="2"
-                onChange={(e) =>
-                  onSettingsChange({ ...settings, size: { ...settings.size, shaftWidth: parseFloat(e.target.value) } })
-                }
-              />
-              <SLabel>Head width</SLabel>
-              <SInput
-                type="number"
-                value={currentHeadWidth}
-                placeholder="2"
-                onChange={(e) =>
-                  onSettingsChange({ ...settings, size: { ...settings.size, headWidth: parseFloat(e.target.value) } })
-                }
-              />
-              <SLabel>Head length</SLabel>
-              <SInput
-                type="number"
-                value={currentHeadLength}
-                placeholder="0.1"
-                onChange={(e) =>
-                  onSettingsChange({ ...settings, size: { ...settings.size, headLength: parseFloat(e.target.value) } })
-                }
-              />
-            </Flex>
-          );
-        }
+  const settingsByCarType = React.useMemo(() => {
+    switch (settings.modelType) {
+      case "car-model": {
+        const alpha = settings.alpha != null ? settings.alpha : 1;
+        return (
+          <Flex col>
+            <SLabel>Alpha</SLabel>
+            <SInput
+              type="number"
+              value={alpha.toString()}
+              min={0}
+              max={1}
+              step={0.1}
+              onChange={(e) => onSettingsChange({ ...settings, alpha: parseFloat(e.target.value) })}
+            />
+          </Flex>
+        );
       }
-    },
-    [onFieldChange, onSettingsChange, settings]
-  );
+      case "car-outline": {
+        return (
+          <>
+            <SLabel>Color of outline</SLabel>
+            <ColorPickerForTopicSettings
+              color={settings.overrideColor}
+              onChange={(newColor) => onFieldChange("overrideColor", newColor)}
+            />
+          </>
+        );
+      }
+      case "arrow":
+      default: {
+        const currentShaftWidth = settings.size?.shaftWidth ?? 2;
+        const currentHeadWidth = settings.size?.headWidth ?? 2;
+        const currentHeadLength = settings.size?.headLength ?? 0.1;
+        return (
+          <Flex col>
+            <SLabel>Color</SLabel>
+            <ColorPickerForTopicSettings
+              color={settings.overrideColor}
+              onChange={(newColor) => onFieldChange("overrideColor", newColor)}
+            />
+            <SLabel>Shaft width</SLabel>
+            <SInput
+              type="number"
+              value={currentShaftWidth}
+              placeholder="2"
+              onChange={(e) =>
+                onSettingsChange({ ...settings, size: { ...settings.size, shaftWidth: parseFloat(e.target.value) } })
+              }
+            />
+            <SLabel>Head width</SLabel>
+            <SInput
+              type="number"
+              value={currentHeadWidth}
+              placeholder="2"
+              onChange={(e) =>
+                onSettingsChange({ ...settings, size: { ...settings.size, headWidth: parseFloat(e.target.value) } })
+              }
+            />
+            <SLabel>Head length</SLabel>
+            <SInput
+              type="number"
+              value={currentHeadLength}
+              placeholder="0.1"
+              onChange={(e) =>
+                onSettingsChange({ ...settings, size: { ...settings.size, headLength: parseFloat(e.target.value) } })
+              }
+            />
+          </Flex>
+        );
+      }
+    }
+  }, [onFieldChange, onSettingsChange, settings]);
 
   const badModelTypeSetting = React.useMemo(() => !["car-model", "car-outline", "arrow"].includes(settings.modelType), [
     settings,

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/index.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/index.js
@@ -154,12 +154,9 @@ const TopicSettingsEditor = React.memo<Props>(function TopicSettingsEditor({
   settings,
   onSettingsChange,
 }: Props) {
-  const onFieldChange = useCallback(
-    (fieldName: string, value: any) => {
-      onSettingsChange((newSettings) => ({ ...newSettings, [fieldName]: value }));
-    },
-    [onSettingsChange]
-  );
+  const onFieldChange = useCallback((fieldName: string, value: any) => {
+    onSettingsChange((newSettings) => ({ ...newSettings, [fieldName]: value }));
+  }, [onSettingsChange]);
 
   const Editor = topicSettingsEditorForDatatype(topic.datatype);
   if (!Editor) {

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicTree/TopicSettingsModal.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicTree/TopicSettingsModal.js
@@ -146,30 +146,23 @@ function TopicSettingsModal({
   settingsByKey,
 }: Props) {
   const topicSettingsKey = `t:${topicName}`;
-  const onSettingsChange = useCallback(
-    (settings: any | ((prevSettings: {}) => {})) => {
-      if (typeof settings !== "function" && isEmpty(settings)) {
-        // Remove the field if the topic settings are empty to prevent the panelConfig from every growing.
-        saveConfig({ settingsByKey: omit(settingsByKey, [topicSettingsKey]) });
-        return;
-      }
-      saveConfig({
-        settingsByKey: {
-          ...settingsByKey,
-          [topicSettingsKey]:
-            typeof settings === "function" ? settings(settingsByKey[topicSettingsKey] || {}) : settings,
-        },
-      });
-    },
-    [saveConfig, settingsByKey, topicSettingsKey]
-  );
+  const onSettingsChange = useCallback((settings: any | ((prevSettings: {}) => {})) => {
+    if (typeof settings !== "function" && isEmpty(settings)) {
+      // Remove the field if the topic settings are empty to prevent the panelConfig from every growing.
+      saveConfig({ settingsByKey: omit(settingsByKey, [topicSettingsKey]) });
+      return;
+    }
+    saveConfig({
+      settingsByKey: {
+        ...settingsByKey,
+        [topicSettingsKey]: typeof settings === "function" ? settings(settingsByKey[topicSettingsKey] || {}) : settings,
+      },
+    });
+  }, [saveConfig, settingsByKey, topicSettingsKey]);
 
-  const onFieldChange = useCallback(
-    (fieldName: string, value: any) => {
-      onSettingsChange((newSettings) => ({ ...newSettings, [fieldName]: value }));
-    },
-    [onSettingsChange]
-  );
+  const onFieldChange = useCallback((fieldName: string, value: any) => {
+    onSettingsChange((newSettings) => ({ ...newSettings, [fieldName]: value }));
+  }, [onSettingsChange]);
 
   const columnIndex = topicName.startsWith(SECOND_SOURCE_PREFIX) ? 1 : 0;
   const nonPrefixedTopic = columnIndex === 1 ? topicName.substr(SECOND_SOURCE_PREFIX.length) : topicName;

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicTree/TopicTree.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicTree/TopicTree.js
@@ -272,26 +272,20 @@ function TopicTree({
   const hasRootNodeChanged = useChangeDetector([rootTreeNode], false);
   expandedKeysRef.current = hasRootNodeChanged ? [...expandedKeys] : expandedKeys;
 
-  useEffect(
-    () => {
-      // auto focus whenever first rendering the topic tree
-      if (renderTopicTree && filterTextFieldRef.current) {
-        const filterTextFieldEl: HTMLInputElement = filterTextFieldRef.current;
-        filterTextFieldEl.focus();
-        filterTextFieldEl.select();
-      }
-    },
-    [renderTopicTree]
-  );
+  useEffect(() => {
+    // auto focus whenever first rendering the topic tree
+    if (renderTopicTree && filterTextFieldRef.current) {
+      const filterTextFieldEl: HTMLInputElement = filterTextFieldRef.current;
+      filterTextFieldEl.focus();
+      filterTextFieldEl.select();
+    }
+  }, [renderTopicTree]);
 
-  const topLevelNodesCollapsed = useMemo(
-    () => {
-      const topLevelChildren = rootTreeNode.type === "group" ? rootTreeNode.children : [];
-      const topLevelKeys = topLevelChildren.map(({ key }) => key);
-      return topLevelKeys.every((key) => !expandedKeys.includes(key));
-    },
-    [expandedKeys, rootTreeNode]
-  );
+  const topLevelNodesCollapsed = useMemo(() => {
+    const topLevelChildren = rootTreeNode.type === "group" ? rootTreeNode.children : [];
+    const topLevelKeys = topLevelChildren.map(({ key }) => key);
+    return topLevelKeys.every((key) => !expandedKeys.includes(key));
+  }, [expandedKeys, rootTreeNode]);
 
   const showNoMatchesState = !getIsTreeNodeVisibleInTree(rootTreeNode.key);
 
@@ -302,15 +296,12 @@ function TopicTree({
   const linkedGlobalVariablesByTopic = groupBy(linkedGlobalVariables, ({ topic }) => topic);
 
   // Close the TopicTree if the user hits the "Escape" key
-  const onKeyDown = useCallback(
-    (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
-      if (event.key === "Escape" && document.activeElement) {
-        document.activeElement.blur();
-        setShowTopicTree(false);
-      }
-    },
-    [setShowTopicTree]
-  );
+  const onKeyDown = useCallback((event: SyntheticKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Escape" && document.activeElement) {
+      document.activeElement.blur();
+      setShowTopicTree(false);
+    }
+  }, [setShowTopicTree]);
 
   return (
     <STopicTreeInner style={{ width: treeWidth }} isXSWidth={isXSWidth}>

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicTree/TreeNodeRow.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicTree/TreeNodeRow.js
@@ -174,26 +174,20 @@ export default function TreeNodeRow({
   maxNodeNameWidth -= showVisibleTopicsCount ? VISIBLE_COUNT_WIDTH + VISIBLE_COUNT_MARGIN * 2 : 0;
 
   const { setHoveredMarkerMatchers } = useContext(ThreeDimensionalVizContext);
-  const updateHoveredMarkerMatchers = useCallback(
-    (columnIndex, visible) => {
-      if (visible) {
-        const topic = [topicName, joinTopics(SECOND_SOURCE_PREFIX, topicName)][columnIndex];
-        setHoveredMarkerMatchers([{ topic }]);
-      }
-    },
-    [setHoveredMarkerMatchers, topicName]
-  );
+  const updateHoveredMarkerMatchers = useCallback((columnIndex, visible) => {
+    if (visible) {
+      const topic = [topicName, joinTopics(SECOND_SOURCE_PREFIX, topicName)][columnIndex];
+      setHoveredMarkerMatchers([{ topic }]);
+    }
+  }, [setHoveredMarkerMatchers, topicName]);
 
   const onMouseLeave = useCallback(() => setHoveredMarkerMatchers([]), [setHoveredMarkerMatchers]);
-  const mouseEventHandlersByColumnIdx = useMemo(
-    () => {
-      return new Array(2).fill().map((_, columnIndex) => ({
-        onMouseEnter: () => updateHoveredMarkerMatchers(columnIndex, true),
-        onMouseLeave,
-      }));
-    },
-    [onMouseLeave, updateHoveredMarkerMatchers]
-  );
+  const mouseEventHandlersByColumnIdx = useMemo(() => {
+    return new Array(2).fill().map((_, columnIndex) => ({
+      onMouseEnter: () => updateHoveredMarkerMatchers(columnIndex, true),
+      onMouseLeave,
+    }));
+  }, [onMouseLeave, updateHoveredMarkerMatchers]);
   const {
     toggleCheckAllAncestors,
     toggleNodeChecked,

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicTree/VisibilityToggle.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicTree/VisibilityToggle.js
@@ -149,18 +149,15 @@ export default function VisibilityToggle({
   columnIndex,
 }: Props) {
   // Handle shift + click/enter, option + click/enter, and click/enter.
-  const onChange = useCallback(
-    (e: MouseEvent | KeyboardEvent) => {
-      if (onShiftToggle && e.shiftKey) {
-        onShiftToggle();
-      } else if (onAltToggle && e.altKey) {
-        onAltToggle();
-      } else {
-        onToggle();
-      }
-    },
-    [onAltToggle, onShiftToggle, onToggle]
-  );
+  const onChange = useCallback((e: MouseEvent | KeyboardEvent) => {
+    if (onShiftToggle && e.shiftKey) {
+      onShiftToggle();
+    } else if (onAltToggle && e.altKey) {
+      onAltToggle();
+    } else {
+      onToggle();
+    }
+  }, [onAltToggle, onShiftToggle, onToggle]);
 
   if (!available) {
     return (

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicTree/renderNamespaceNodes.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicTree/renderNamespaceNodes.js
@@ -102,41 +102,29 @@ function NamespaceNodeRow({
     "TopicTreeContext"
   );
 
-  const updateHoveredMarkerMatchers = useCallback(
-    (columnIndex, visible) => {
-      if (visible) {
-        const topic = [topicName, joinTopics(SECOND_SOURCE_PREFIX, topicName)][columnIndex];
-        setHoveredMarkerMatchers([{ topic, checks: [{ markerKeyPath: ["ns"], value: namespace }] }]);
-      }
-    },
-    [namespace, setHoveredMarkerMatchers, topicName]
-  );
+  const updateHoveredMarkerMatchers = useCallback((columnIndex, visible) => {
+    if (visible) {
+      const topic = [topicName, joinTopics(SECOND_SOURCE_PREFIX, topicName)][columnIndex];
+      setHoveredMarkerMatchers([{ topic, checks: [{ markerKeyPath: ["ns"], value: namespace }] }]);
+    }
+  }, [namespace, setHoveredMarkerMatchers, topicName]);
 
   const onMouseLeave = useCallback(() => setHoveredMarkerMatchers([]), [setHoveredMarkerMatchers]);
-  const mouseEventHandlersByColumnIdx = useMemo(
-    () => {
-      return new Array(2).fill().map((topic, columnIndex) => ({
-        onMouseEnter: () => updateHoveredMarkerMatchers(columnIndex, true),
-        onMouseLeave,
-      }));
-    },
-    [updateHoveredMarkerMatchers, onMouseLeave]
-  );
+  const mouseEventHandlersByColumnIdx = useMemo(() => {
+    return new Array(2).fill().map((topic, columnIndex) => ({
+      onMouseEnter: () => updateHoveredMarkerMatchers(columnIndex, true),
+      onMouseLeave,
+    }));
+  }, [updateHoveredMarkerMatchers, onMouseLeave]);
 
-  const onToggle = useCallback(
-    (columnIndex) => {
-      toggleNamespaceChecked({ topicName, namespace, columnIndex });
-      updateHoveredMarkerMatchers(columnIndex, !visibleInSceneByColumn[columnIndex]);
-    },
-    [toggleNamespaceChecked, topicName, namespace, updateHoveredMarkerMatchers, visibleInSceneByColumn]
-  );
-  const onAltToggle = useCallback(
-    (columnIndex) => {
-      toggleCheckAllAncestors(nodeKey, columnIndex, topicName);
-      updateHoveredMarkerMatchers(columnIndex, !visibleInSceneByColumn[columnIndex]);
-    },
-    [toggleCheckAllAncestors, nodeKey, topicName, updateHoveredMarkerMatchers, visibleInSceneByColumn]
-  );
+  const onToggle = useCallback((columnIndex) => {
+    toggleNamespaceChecked({ topicName, namespace, columnIndex });
+    updateHoveredMarkerMatchers(columnIndex, !visibleInSceneByColumn[columnIndex]);
+  }, [toggleNamespaceChecked, topicName, namespace, updateHoveredMarkerMatchers, visibleInSceneByColumn]);
+  const onAltToggle = useCallback((columnIndex) => {
+    toggleCheckAllAncestors(nodeKey, columnIndex, topicName);
+    updateHoveredMarkerMatchers(columnIndex, !visibleInSceneByColumn[columnIndex]);
+  }, [toggleCheckAllAncestors, nodeKey, topicName, updateHoveredMarkerMatchers, visibleInSceneByColumn]);
 
   return (
     <STreeNodeRow

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicTree/renderStyleExpressionNodes.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicTree/renderStyleExpressionNodes.js
@@ -124,32 +124,30 @@ function StyleExpressionNode(props) {
 
   // Callbacks
   const onToggleMenu = useCallback(() => setIsOpen((prevIsOpen) => !prevIsOpen), []);
-  const updateSettingsForGlobalVariable = useCallback(
-    (globalVariableName, settings: { active: boolean, color: Color }, sourceIdx = 0) => {
-      const updatedSettings = new Array(2)
-        .fill()
-        .map((_, i) => colorOverrideBySourceIdxByVariable[globalVariableName]?.[i]);
-      updatedSettings[sourceIdx] = settings;
-      setColorOverrideBySourceIdxByVariable({
-        ...colorOverrideBySourceIdxByVariable,
-        [globalVariableName]: updatedSettings,
-      });
-    },
-    [colorOverrideBySourceIdxByVariable, setColorOverrideBySourceIdxByVariable]
-  );
+  const updateSettingsForGlobalVariable = useCallback((
+    globalVariableName,
+    settings: { active: boolean, color: Color },
+    sourceIdx = 0
+  ) => {
+    const updatedSettings = new Array(2)
+      .fill()
+      .map((_, i) => colorOverrideBySourceIdxByVariable[globalVariableName]?.[i]);
+    updatedSettings[sourceIdx] = settings;
+    setColorOverrideBySourceIdxByVariable({
+      ...colorOverrideBySourceIdxByVariable,
+      [globalVariableName]: updatedSettings,
+    });
+  }, [colorOverrideBySourceIdxByVariable, setColorOverrideBySourceIdxByVariable]);
 
   // Mouse-hover handlers
   const onMouseLeave = useCallback(() => setHoveredMarkerMatchers([]), [setHoveredMarkerMatchers]);
-  const mouseEventHandlersByColumnIdx = useMemo(
-    () => {
-      const topicNameByColumnIdx = [topic, joinTopics(SECOND_SOURCE_PREFIX, topic)];
-      return topicNameByColumnIdx.map((_topic) => ({
-        onMouseEnter: () => setHoveredMarkerMatchers([{ topic: _topic, checks: [{ markerKeyPath, value }] }]),
-        onMouseLeave,
-      }));
-    },
-    [markerKeyPath, onMouseLeave, setHoveredMarkerMatchers, topic, value]
-  );
+  const mouseEventHandlersByColumnIdx = useMemo(() => {
+    const topicNameByColumnIdx = [topic, joinTopics(SECOND_SOURCE_PREFIX, topic)];
+    return topicNameByColumnIdx.map((_topic) => ({
+      onMouseEnter: () => setHoveredMarkerMatchers([{ topic: _topic, checks: [{ markerKeyPath, value }] }]),
+      onMouseLeave,
+    }));
+  }, [markerKeyPath, onMouseLeave, setHoveredMarkerMatchers, topic, value]);
 
   const tooltipContent = (
     <TooltipRow>

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicTree/useSceneBuilderAndTransformsData.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicTree/useSceneBuilderAndTransformsData.js
@@ -45,20 +45,17 @@ export default function useSceneBuilderAndTransformsData({
   }
   const availableTfs = availableTfsRef.current;
 
-  const availableNamespacesByTopic = useMemo(
-    () => {
-      const result = { ...staticallyAvailableNamespacesByTopic };
-      for (const { name, topic } of sceneBuilder.allNamespaces) {
-        result[topic] = result[topic] || [];
-        result[topic].push(name);
-      }
-      if (availableTfs.length) {
-        result[TRANSFORM_TOPIC] = availableTfs;
-      }
-      return result;
-    },
-    [availableTfs, sceneBuilder.allNamespaces, staticallyAvailableNamespacesByTopic]
-  );
+  const availableNamespacesByTopic = useMemo(() => {
+    const result = { ...staticallyAvailableNamespacesByTopic };
+    for (const { name, topic } of sceneBuilder.allNamespaces) {
+      result[topic] = result[topic] || [];
+      result[topic].push(name);
+    }
+    if (availableTfs.length) {
+      result[TRANSFORM_TOPIC] = availableTfs;
+    }
+    return result;
+  }, [availableTfs, sceneBuilder.allNamespaces, staticallyAvailableNamespacesByTopic]);
 
   const sceneErrorsByKey = useMemo(
     () => mapKeys(sceneBuilder.errorsByTopic, (value, topicName) => generateNodeKey({ topicName })),

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicTree/useTopicTree.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicTree/useTopicTree.js
@@ -158,258 +158,235 @@ export default function useTree({
     providerTopics,
   ]);
 
-  const rootTreeNode = useMemo(
-    (): TreeNode => {
-      const allTopicNames = providerTopics.map((topic) => topic.name);
-      const nonPrefixedTopicNames = uniq(allTopicNames.map((name) => name.replace(SECOND_SOURCE_PREFIX, "")));
-      const availableTopicsNamesSet = new Set(allTopicNames);
+  const rootTreeNode = useMemo((): TreeNode => {
+    const allTopicNames = providerTopics.map((topic) => topic.name);
+    const nonPrefixedTopicNames = uniq(allTopicNames.map((name) => name.replace(SECOND_SOURCE_PREFIX, "")));
+    const availableTopicsNamesSet = new Set(allTopicNames);
 
-      // Precompute uncategorized topics to add to the transformedTreeConfig before generating the TreeNodes.
-      const uncategorizedTopicNames = difference(nonPrefixedTopicNames, topicTreeTopics);
-      const datatypesByTopic = mapValues(keyBy(providerTopics, "name"), (item) => item.datatype);
+    // Precompute uncategorized topics to add to the transformedTreeConfig before generating the TreeNodes.
+    const uncategorizedTopicNames = difference(nonPrefixedTopicNames, topicTreeTopics);
+    const datatypesByTopic = mapValues(keyBy(providerTopics, "name"), (item) => item.datatype);
 
-      const newChildren = [...(topicTreeConfig.children || [])];
-      if (uncategorizedTopicNames.length) {
-        // Add uncategorized group node to root config.
-        newChildren.push({
-          name: uncategorizedGroupName,
-          children: uncategorizedTopicNames.map((topicName) => ({ topicName })),
-        });
-      }
-      // Generate the rootTreeNode. Don't mutate the original treeConfig, just make a copy with newChildren.
-      return generateTreeNode(
-        { ...topicTreeConfig, children: newChildren },
-        { parentKey: undefined, datatypesByTopic, availableTopicsNamesSet, hasFeatureColumn }
-      );
-    },
-    [hasFeatureColumn, providerTopics, topicTreeConfig, topicTreeTopics, uncategorizedGroupName]
-  );
+    const newChildren = [...(topicTreeConfig.children || [])];
+    if (uncategorizedTopicNames.length) {
+      // Add uncategorized group node to root config.
+      newChildren.push({
+        name: uncategorizedGroupName,
+        children: uncategorizedTopicNames.map((topicName) => ({ topicName })),
+      });
+    }
+    // Generate the rootTreeNode. Don't mutate the original treeConfig, just make a copy with newChildren.
+    return generateTreeNode(
+      { ...topicTreeConfig, children: newChildren },
+      { parentKey: undefined, datatypesByTopic, availableTopicsNamesSet, hasFeatureColumn }
+    );
+  }, [hasFeatureColumn, providerTopics, topicTreeConfig, topicTreeTopics, uncategorizedGroupName]);
 
-  const nodesByKey: { [key: string]: TreeNode } = useMemo(
-    () => {
-      const flattenNodes = Array.from(flattenNode(rootTreeNode));
-      return keyBy(flattenNodes, "key");
-    },
-    [rootTreeNode]
-  );
+  const nodesByKey: { [key: string]: TreeNode } = useMemo(() => {
+    const flattenNodes = Array.from(flattenNode(rootTreeNode));
+    return keyBy(flattenNodes, "key");
+  }, [rootTreeNode]);
 
-  const selections = useMemo(
-    () => {
-      const checkedKeysSet = new Set(checkedKeys);
-      // Memoize node selections for extracting topic/namespace selections and checking node's visibility state.
-      const isSelectedMemo: { [string]: boolean } = {};
+  const selections = useMemo(() => {
+    const checkedKeysSet = new Set(checkedKeys);
+    // Memoize node selections for extracting topic/namespace selections and checking node's visibility state.
+    const isSelectedMemo: { [string]: boolean } = {};
 
-      // Check if a node is selected and fill in the isSelectedMemo cache for future access.
-      function isSelected(baseKey: ?string, isFeatureColumn: boolean): boolean {
-        // Only topic node or top level group node may not have parentKey, and if we reached this level,
-        // the descendants nodes should already been selected. Specifically, if a node key is included in the checkedKeys
-        // and it doesn't have any parent node, it's considered to be selected.
-        if (!baseKey) {
-          return true;
-        }
-
-        const node = nodesByKey[baseKey];
-        const featureKey = node?.featureKey || baseKey;
-        if (!isFeatureColumn && isSelectedMemo[baseKey] === undefined) {
-          isSelectedMemo[baseKey] =
-            checkedKeysSet.has(baseKey) &&
-            (node ? isSelected(node.parentKey, isFeatureColumn) : checkedKeysSet.has(`name:${uncategorizedGroupName}`));
-        } else if (isFeatureColumn && isSelectedMemo[featureKey] === undefined) {
-          isSelectedMemo[featureKey] =
-            checkedKeysSet.has(featureKey) &&
-            (node
-              ? isSelected(node.parentKey, isFeatureColumn)
-              : checkedKeysSet.has(`name_2:${uncategorizedGroupName}`));
-        }
-        return isSelectedMemo[isFeatureColumn ? featureKey : baseKey];
+    // Check if a node is selected and fill in the isSelectedMemo cache for future access.
+    function isSelected(baseKey: ?string, isFeatureColumn: boolean): boolean {
+      // Only topic node or top level group node may not have parentKey, and if we reached this level,
+      // the descendants nodes should already been selected. Specifically, if a node key is included in the checkedKeys
+      // and it doesn't have any parent node, it's considered to be selected.
+      if (!baseKey) {
+        return true;
       }
 
-      const selectedTopicNamesSet = new Set(
-        filterMap(checkedKeys, (key) => {
-          if (!key.startsWith("t:") || !isSelected(getBaseKey(key), key.includes(SECOND_SOURCE_PREFIX))) {
-            return;
-          }
-          return key.substr("t:".length);
-        })
-      );
+      const node = nodesByKey[baseKey];
+      const featureKey = node?.featureKey || baseKey;
+      if (!isFeatureColumn && isSelectedMemo[baseKey] === undefined) {
+        isSelectedMemo[baseKey] =
+          checkedKeysSet.has(baseKey) &&
+          (node ? isSelected(node.parentKey, isFeatureColumn) : checkedKeysSet.has(`name:${uncategorizedGroupName}`));
+      } else if (isFeatureColumn && isSelectedMemo[featureKey] === undefined) {
+        isSelectedMemo[featureKey] =
+          checkedKeysSet.has(featureKey) &&
+          (node ? isSelected(node.parentKey, isFeatureColumn) : checkedKeysSet.has(`name_2:${uncategorizedGroupName}`));
+      }
+      return isSelectedMemo[isFeatureColumn ? featureKey : baseKey];
+    }
 
-      // Add namespace selections if a topic has any namespaces modified. Any topics that don't have
-      // the namespaces set in selectedNamespacesByTopic will have the namespaces turned on by default.
-      const selectedNamespacesByTopic = (modifiedNamespaceTopics || []).reduce(
-        (memo, topicName) => ({ ...memo, [topicName]: [] }),
-        {}
-      );
-
-      // Go through the checked namespace keys, split the key to topicName + namespace, and
-      // collect the namespaces if the topic is selected.
-      checkedKeys.forEach((key) => {
-        if (!key.startsWith("ns:")) {
+    const selectedTopicNamesSet = new Set(
+      filterMap(checkedKeys, (key) => {
+        if (!key.startsWith("t:") || !isSelected(getBaseKey(key), key.includes(SECOND_SOURCE_PREFIX))) {
           return;
         }
-        const [_, topicName, namespace] = key.split(":");
-        if (!topicName || !namespace) {
-          throw new Error(`Incorrect checkedNode in panelConfig: ${key}`);
-        }
-        if (selectedTopicNamesSet.has(topicName)) {
-          if (!selectedNamespacesByTopic[topicName]) {
-            selectedNamespacesByTopic[topicName] = [];
-          }
-          selectedNamespacesByTopic[topicName].push(namespace);
-        }
-      });
+        return key.substr("t:".length);
+      })
+    );
 
-      const selectedTopicNames = Array.from(selectedTopicNamesSet);
+    // Add namespace selections if a topic has any namespaces modified. Any topics that don't have
+    // the namespaces set in selectedNamespacesByTopic will have the namespaces turned on by default.
+    const selectedNamespacesByTopic = (modifiedNamespaceTopics || []).reduce(
+      (memo, topicName) => ({ ...memo, [topicName]: [] }),
+      {}
+    );
 
-      // If any selectedNamespaces is empty, fill in all available namespaces as default if
-      // the topic for the namespace is not modified.
-      difference(selectedTopicNames, modifiedNamespaceTopics).forEach((topicName) => {
-        if (availableNamespacesByTopic[topicName] && !selectedNamespacesByTopic[topicName]) {
-          selectedNamespacesByTopic[topicName] = availableNamespacesByTopic[topicName];
+    // Go through the checked namespace keys, split the key to topicName + namespace, and
+    // collect the namespaces if the topic is selected.
+    checkedKeys.forEach((key) => {
+      if (!key.startsWith("ns:")) {
+        return;
+      }
+      const [_, topicName, namespace] = key.split(":");
+      if (!topicName || !namespace) {
+        throw new Error(`Incorrect checkedNode in panelConfig: ${key}`);
+      }
+      if (selectedTopicNamesSet.has(topicName)) {
+        if (!selectedNamespacesByTopic[topicName]) {
+          selectedNamespacesByTopic[topicName] = [];
         }
-      });
+        selectedNamespacesByTopic[topicName].push(namespace);
+      }
+    });
 
-      // Returns whether a node/namespace is rendered in the 3d scene. Keep it inside useMemo since it needs to access the same isSelectedMemo.
-      // A node is visible if it's available, itself and all ancestor nodes are selected.
-      function getIsTreeNodeVisibleInScene(node: ?TreeNode, columnIndex: number, namespace?: string): boolean {
-        if (!node) {
+    const selectedTopicNames = Array.from(selectedTopicNamesSet);
+
+    // If any selectedNamespaces is empty, fill in all available namespaces as default if
+    // the topic for the namespace is not modified.
+    difference(selectedTopicNames, modifiedNamespaceTopics).forEach((topicName) => {
+      if (availableNamespacesByTopic[topicName] && !selectedNamespacesByTopic[topicName]) {
+        selectedNamespacesByTopic[topicName] = availableNamespacesByTopic[topicName];
+      }
+    });
+
+    // Returns whether a node/namespace is rendered in the 3d scene. Keep it inside useMemo since it needs to access the same isSelectedMemo.
+    // A node is visible if it's available, itself and all ancestor nodes are selected.
+    function getIsTreeNodeVisibleInScene(node: ?TreeNode, columnIndex: number, namespace?: string): boolean {
+      if (!node) {
+        return false;
+      }
+      const baseKey = getBaseKey(node.key);
+      const isFeatureColumn = columnIndex === 1;
+      if (namespace && node.type === "topic") {
+        const prefixedTopicName =
+          node.type === "topic"
+            ? isFeatureColumn
+              ? `${SECOND_SOURCE_PREFIX}${node.topicName}`
+              : node.topicName
+            : undefined;
+        if (!prefixedTopicName) {
           return false;
         }
-        const baseKey = getBaseKey(node.key);
-        const isFeatureColumn = columnIndex === 1;
-        if (namespace && node.type === "topic") {
-          const prefixedTopicName =
-            node.type === "topic"
-              ? isFeatureColumn
-                ? `${SECOND_SOURCE_PREFIX}${node.topicName}`
-                : node.topicName
-              : undefined;
-          if (!prefixedTopicName) {
-            return false;
-          }
-          if (!(selectedNamespacesByTopic[prefixedTopicName] || []).includes(namespace)) {
-            return false;
-          }
-          // A namespace node is visible if the parent topic node is visible.
-          return getIsTreeNodeVisibleInScene(node, columnIndex);
+        if (!(selectedNamespacesByTopic[prefixedTopicName] || []).includes(namespace)) {
+          return false;
         }
-        return !!node.availableByColumn[columnIndex] && isSelected(baseKey, isFeatureColumn);
+        // A namespace node is visible if the parent topic node is visible.
+        return getIsTreeNodeVisibleInScene(node, columnIndex);
       }
-      return {
-        selectedTopicNames,
-        selectedNamespacesByTopic,
-        getIsTreeNodeVisibleInScene,
-      };
-    },
-    [availableNamespacesByTopic, checkedKeys, modifiedNamespaceTopics, nodesByKey, uncategorizedGroupName]
-  );
+      return !!node.availableByColumn[columnIndex] && isSelected(baseKey, isFeatureColumn);
+    }
+    return {
+      selectedTopicNames,
+      selectedNamespacesByTopic,
+      getIsTreeNodeVisibleInScene,
+    };
+  }, [availableNamespacesByTopic, checkedKeys, modifiedNamespaceTopics, nodesByKey, uncategorizedGroupName]);
 
   const { selectedTopicNames, selectedNamespacesByTopic, getIsTreeNodeVisibleInScene } = selections;
 
-  const visibleTopicsCountByKey = useMemo(
-    () => {
-      // No need to update if topics are unavailable.
-      if (!providerTopics.length) {
-        return DEFAULT_TOPICS_COUNT_BY_KEY;
-      }
-      const ret = {};
+  const visibleTopicsCountByKey = useMemo(() => {
+    // No need to update if topics are unavailable.
+    if (!providerTopics.length) {
+      return DEFAULT_TOPICS_COUNT_BY_KEY;
+    }
+    const ret = {};
 
-      selectedTopicNames.forEach((topicName) => {
-        const isFeatureColumn = topicName.startsWith(SECOND_SOURCE_PREFIX);
-        const baseTopicName = isFeatureColumn ? topicName.substr(SECOND_SOURCE_PREFIX.length) : topicName;
-        const topicKey = generateNodeKey({ topicName: baseTopicName });
-        const node = nodesByKey[topicKey];
-        const isTopicNodeVisible = getIsTreeNodeVisibleInScene(node, isFeatureColumn ? 1 : 0);
-        if (!isTopicNodeVisible) {
-          return;
-        }
-        // The topic node is visible, now traverse up the tree and update all parent's visibleTopicsCount.
-        const parentKey = nodesByKey[topicKey]?.parentKey;
-        let parentNode = parentKey ? nodesByKey[parentKey] : undefined;
-        while (parentNode) {
-          ret[parentNode.key] = (ret[parentNode.key] || 0) + 1;
-          parentNode = parentNode.parentKey ? nodesByKey[parentNode.parentKey] : undefined;
-        }
-      });
-      return ret;
-    },
-    [getIsTreeNodeVisibleInScene, nodesByKey, providerTopics.length, selectedTopicNames]
-  );
+    selectedTopicNames.forEach((topicName) => {
+      const isFeatureColumn = topicName.startsWith(SECOND_SOURCE_PREFIX);
+      const baseTopicName = isFeatureColumn ? topicName.substr(SECOND_SOURCE_PREFIX.length) : topicName;
+      const topicKey = generateNodeKey({ topicName: baseTopicName });
+      const node = nodesByKey[topicKey];
+      const isTopicNodeVisible = getIsTreeNodeVisibleInScene(node, isFeatureColumn ? 1 : 0);
+      if (!isTopicNodeVisible) {
+        return;
+      }
+      // The topic node is visible, now traverse up the tree and update all parent's visibleTopicsCount.
+      const parentKey = nodesByKey[topicKey]?.parentKey;
+      let parentNode = parentKey ? nodesByKey[parentKey] : undefined;
+      while (parentNode) {
+        ret[parentNode.key] = (ret[parentNode.key] || 0) + 1;
+        parentNode = parentNode.parentKey ? nodesByKey[parentNode.parentKey] : undefined;
+      }
+    });
+    return ret;
+  }, [getIsTreeNodeVisibleInScene, nodesByKey, providerTopics.length, selectedTopicNames]);
 
   // Memoize topic names to prevent subscription update when expanding/collapsing nodes.
   const memoizedSelectedTopicNames = useShallowMemo(selectedTopicNames);
 
-  const derivedCustomSettingsByKey = useMemo(
-    (): DerivedCustomSettingsByKey => {
-      const result = {};
-      for (const [topicKeyOrNamespaceKey, settings] of Object.entries(settingsByKey)) {
-        const isFeatureTopicOrNamespace = topicKeyOrNamespaceKey.includes(SECOND_SOURCE_PREFIX);
-        const columnIndex = isFeatureTopicOrNamespace ? 1 : 0;
-        let key;
-        if (topicKeyOrNamespaceKey.startsWith("ns:")) {
-          // Settings for namespace. Currently only handle overrideColor and there are no defaultTopicSettings for namespaces.
-          key = topicKeyOrNamespaceKey;
-          if (key.startsWith(`ns:${SECOND_SOURCE_PREFIX}`)) {
-            // Remove the feature prefix since we are going to store overrideColorByColumn under the base prefix.
-            key = key.replace(`ns:${SECOND_SOURCE_PREFIX}`, "ns:");
-          }
-          if (!result[key]) {
-            result[key] = {};
-          }
-        } else if (topicKeyOrNamespaceKey.startsWith("t:/")) {
-          // Settings for topic.
-          const topicName = topicKeyOrNamespaceKey.substr("t:".length);
-          const baseTopicName = isFeatureTopicOrNamespace ? topicName.substr(SECOND_SOURCE_PREFIX.length) : topicName;
-          key = generateNodeKey({ topicName: baseTopicName });
-          // If any topic has default settings, compare settings with default settings to determine if settings has changed.
-          const isDefaultSettings = defaultTopicSettings[topicName]
-            ? isEqual(settings, defaultTopicSettings[topicName])
-            : false;
+  const derivedCustomSettingsByKey = useMemo((): DerivedCustomSettingsByKey => {
+    const result = {};
+    for (const [topicKeyOrNamespaceKey, settings] of Object.entries(settingsByKey)) {
+      const isFeatureTopicOrNamespace = topicKeyOrNamespaceKey.includes(SECOND_SOURCE_PREFIX);
+      const columnIndex = isFeatureTopicOrNamespace ? 1 : 0;
+      let key;
+      if (topicKeyOrNamespaceKey.startsWith("ns:")) {
+        // Settings for namespace. Currently only handle overrideColor and there are no defaultTopicSettings for namespaces.
+        key = topicKeyOrNamespaceKey;
+        if (key.startsWith(`ns:${SECOND_SOURCE_PREFIX}`)) {
+          // Remove the feature prefix since we are going to store overrideColorByColumn under the base prefix.
+          key = key.replace(`ns:${SECOND_SOURCE_PREFIX}`, "ns:");
+        }
+        if (!result[key]) {
+          result[key] = {};
+        }
+      } else if (topicKeyOrNamespaceKey.startsWith("t:/")) {
+        // Settings for topic.
+        const topicName = topicKeyOrNamespaceKey.substr("t:".length);
+        const baseTopicName = isFeatureTopicOrNamespace ? topicName.substr(SECOND_SOURCE_PREFIX.length) : topicName;
+        key = generateNodeKey({ topicName: baseTopicName });
+        // If any topic has default settings, compare settings with default settings to determine if settings has changed.
+        const isDefaultSettings = defaultTopicSettings[topicName]
+          ? isEqual(settings, defaultTopicSettings[topicName])
+          : false;
 
-          result[key] = !result[key]
-            ? { isDefaultSettings }
-            : // Both base and feature have to be default settings for `isDefaultSettings` to be true.
-              { ...result[key], isDefaultSettings: isDefaultSettings && result[key].isDefaultSettings };
-        }
-        if (!key) {
-          console.error(`Key ${topicKeyOrNamespaceKey} in settingsByKey is not a valid key.`);
-          continue;
-        }
-
-        // $FlowFixMe some settings have overideColor field
-        if (settings.overrideColor) {
-          if (!result[key].overrideColorByColumn) {
-            result[key].overrideColorByColumn = [undefined, undefined];
-          }
-          result[key].overrideColorByColumn[columnIndex] = settings.overrideColor;
-        }
+        result[key] = !result[key]
+          ? { isDefaultSettings }
+          : // Both base and feature have to be default settings for `isDefaultSettings` to be true.
+            { ...result[key], isDefaultSettings: isDefaultSettings && result[key].isDefaultSettings };
       }
-      return result;
-    },
-    [defaultTopicSettings, settingsByKey]
-  );
+      if (!key) {
+        console.error(`Key ${topicKeyOrNamespaceKey} in settingsByKey is not a valid key.`);
+        continue;
+      }
 
-  const onNamespaceOverrideColorChange = useCallback(
-    (newColor: ?string, prefixedNamespaceKey: string) => {
-      const newSettingsByKey = newColor
-        ? { ...settingsByKey, [prefixedNamespaceKey]: { overrideColor: newColor } }
-        : omit(settingsByKey, prefixedNamespaceKey);
-      saveConfig({ settingsByKey: newSettingsByKey });
-    },
-    [saveConfig, settingsByKey]
-  );
-
-  const checkedNamespacesByTopicName = useMemo(
-    () => {
-      const checkedNamespaces = filterMap(checkedKeys, (item) => {
-        if (item.startsWith("ns:")) {
-          const [_, topicName, namespace] = item.split(":");
-          return { topicName, namespace };
+      // $FlowFixMe some settings have overideColor field
+      if (settings.overrideColor) {
+        if (!result[key].overrideColorByColumn) {
+          result[key].overrideColorByColumn = [undefined, undefined];
         }
-      });
-      return keyBy(checkedNamespaces, "topicName");
-    },
-    [checkedKeys]
-  );
+        result[key].overrideColorByColumn[columnIndex] = settings.overrideColor;
+      }
+    }
+    return result;
+  }, [defaultTopicSettings, settingsByKey]);
+
+  const onNamespaceOverrideColorChange = useCallback((newColor: ?string, prefixedNamespaceKey: string) => {
+    const newSettingsByKey = newColor
+      ? { ...settingsByKey, [prefixedNamespaceKey]: { overrideColor: newColor } }
+      : omit(settingsByKey, prefixedNamespaceKey);
+    saveConfig({ settingsByKey: newSettingsByKey });
+  }, [saveConfig, settingsByKey]);
+
+  const checkedNamespacesByTopicName = useMemo(() => {
+    const checkedNamespaces = filterMap(checkedKeys, (item) => {
+      if (item.startsWith("ns:")) {
+        const [_, topicName, namespace] = item.split(":");
+        return { topicName, namespace };
+      }
+    });
+    return keyBy(checkedNamespaces, "topicName");
+  }, [checkedKeys]);
 
   // A namespace is checked by default if none of the namespaces are in the checkedKeys and the selection is not modified.
   const getIsNamespaceCheckedByDefault = useCallback(
@@ -419,299 +396,287 @@ export default function useTree({
     [checkedNamespacesByTopicName, modifiedNamespaceTopics]
   );
 
-  const toggleNamespaceChecked = useCallback(
-    ({ topicName, namespace, columnIndex }: {| topicName: string, namespace: string, columnIndex: number |}) => {
-      const isFeatureColumn = columnIndex === 1;
-      const prefixedNamespaceKey = generateNodeKey({ topicName, namespace, isFeatureColumn });
+  const toggleNamespaceChecked = useCallback(({
+    topicName,
+    namespace,
+    columnIndex,
+  }: {|
+    topicName: string,
+    namespace: string,
+    columnIndex: number,
+  |}) => {
+    const isFeatureColumn = columnIndex === 1;
+    const prefixedNamespaceKey = generateNodeKey({ topicName, namespace, isFeatureColumn });
 
-      const prefixedTopicName = isFeatureColumn ? `${SECOND_SOURCE_PREFIX}${topicName}` : topicName;
-      const isNamespaceCheckedByDefault = getIsNamespaceCheckedByDefault(topicName, columnIndex);
+    const prefixedTopicName = isFeatureColumn ? `${SECOND_SOURCE_PREFIX}${topicName}` : topicName;
+    const isNamespaceCheckedByDefault = getIsNamespaceCheckedByDefault(topicName, columnIndex);
 
-      let newCheckedKeys;
-      if (isNamespaceCheckedByDefault) {
-        // Add all other namespaces under the topic to the checked keys.
-        const allNsKeys = (availableNamespacesByTopic[prefixedTopicName] || []).map((ns) =>
-          generateNodeKey({ topicName, namespace: ns, isFeatureColumn })
-        );
-        const otherNamespaceKeys = difference(allNsKeys, [prefixedNamespaceKey]);
-        newCheckedKeys = [...checkedKeys, ...otherNamespaceKeys];
-      } else {
-        newCheckedKeys = xor(checkedKeys, [prefixedNamespaceKey]);
-      }
-
-      saveConfig({
-        checkedKeys: newCheckedKeys,
-        modifiedNamespaceTopics: uniq([...modifiedNamespaceTopics, prefixedTopicName]),
-      });
-    },
-    [availableNamespacesByTopic, checkedKeys, getIsNamespaceCheckedByDefault, modifiedNamespaceTopics, saveConfig]
-  );
-
-  const toggleNodeChecked = useCallback(
-    (nodeKey: string, columnIndex: number) => {
-      const key = columnIndex === 1 ? nodesByKey[nodeKey].featureKey : nodeKey;
-      saveConfig({ checkedKeys: xor(checkedKeys, [key]) });
-    },
-    [checkedKeys, nodesByKey, saveConfig]
-  );
-
-  const toggleCheckAllDescendants = useCallback(
-    (nodeKey: string, columnIndex: number) => {
-      const node = nodesByKey[nodeKey];
-      const isFeatureColumn = columnIndex === 1;
-      const keyWithPrefix = isFeatureColumn ? node.featureKey : nodeKey;
-      const isNowChecked = !checkedKeys.includes(keyWithPrefix);
-      const nodeAndChildren = Array.from(flattenNode(node));
-      const nodeAndChildrenKeys = nodeAndChildren.map((item) => (isFeatureColumn ? item.featureKey : item.key));
-      const topicNames = nodeAndChildren.map((item) => (item.type === "topic" ? item.topicName : null)).filter(Boolean);
-      const namespaceChildrenKeys = flatten(
-        topicNames.map((topicName) =>
-          (availableNamespacesByTopic[isFeatureColumn ? `${SECOND_SOURCE_PREFIX}${topicName}` : topicName] || []).map(
-            (namespace) => generateNodeKey({ topicName, namespace, isFeatureColumn })
-          )
-        )
+    let newCheckedKeys;
+    if (isNamespaceCheckedByDefault) {
+      // Add all other namespaces under the topic to the checked keys.
+      const allNsKeys = (availableNamespacesByTopic[prefixedTopicName] || []).map((ns) =>
+        generateNodeKey({ topicName, namespace: ns, isFeatureColumn })
       );
+      const otherNamespaceKeys = difference(allNsKeys, [prefixedNamespaceKey]);
+      newCheckedKeys = [...checkedKeys, ...otherNamespaceKeys];
+    } else {
+      newCheckedKeys = xor(checkedKeys, [prefixedNamespaceKey]);
+    }
 
-      let newModififiedNamespaceTopics = [...modifiedNamespaceTopics];
-      topicNames.forEach((topicName) => {
-        const prefixedTopicName = isFeatureColumn ? `${SECOND_SOURCE_PREFIX}${topicName}` : topicName;
-        if (availableNamespacesByTopic[prefixedTopicName]) {
-          newModififiedNamespaceTopics.push(prefixedTopicName);
-        }
-      });
-      newModififiedNamespaceTopics = isEqual(newModififiedNamespaceTopics, modifiedNamespaceTopics)
-        ? modifiedNamespaceTopics
-        : uniq(newModififiedNamespaceTopics);
+    saveConfig({
+      checkedKeys: newCheckedKeys,
+      modifiedNamespaceTopics: uniq([...modifiedNamespaceTopics, prefixedTopicName]),
+    });
+  }, [availableNamespacesByTopic, checkedKeys, getIsNamespaceCheckedByDefault, modifiedNamespaceTopics, saveConfig]);
 
-      const nodeKeysToToggle = [...nodeAndChildrenKeys, ...namespaceChildrenKeys];
-      // Toggle all children nodes' checked state to be the same as the new checked state for the node.
-      saveConfig({
-        modifiedNamespaceTopics: newModififiedNamespaceTopics,
-        checkedKeys: isNowChecked
-          ? uniq([...checkedKeys, ...nodeKeysToToggle])
-          : difference(checkedKeys, nodeKeysToToggle),
-      });
-    },
-    [availableNamespacesByTopic, checkedKeys, modifiedNamespaceTopics, nodesByKey, saveConfig]
-  );
+  const toggleNodeChecked = useCallback((nodeKey: string, columnIndex: number) => {
+    const key = columnIndex === 1 ? nodesByKey[nodeKey].featureKey : nodeKey;
+    saveConfig({ checkedKeys: xor(checkedKeys, [key]) });
+  }, [checkedKeys, nodesByKey, saveConfig]);
 
-  const toggleCheckAllAncestors = useCallback(
-    (nodeKey: string, columnIndex: number, namespaceParentTopicName?: string) => {
-      const isFeatureColumn = columnIndex === 1;
-      const node = nodesByKey[nodeKey];
-      let keyWithPrefix = isFeatureColumn && node ? node.featureKey : nodeKey;
-      const prefixedTopicName =
-        isFeatureColumn && namespaceParentTopicName
-          ? `${SECOND_SOURCE_PREFIX}${namespaceParentTopicName}`
-          : namespaceParentTopicName;
+  const toggleCheckAllDescendants = useCallback((nodeKey: string, columnIndex: number) => {
+    const node = nodesByKey[nodeKey];
+    const isFeatureColumn = columnIndex === 1;
+    const keyWithPrefix = isFeatureColumn ? node.featureKey : nodeKey;
+    const isNowChecked = !checkedKeys.includes(keyWithPrefix);
+    const nodeAndChildren = Array.from(flattenNode(node));
+    const nodeAndChildrenKeys = nodeAndChildren.map((item) => (isFeatureColumn ? item.featureKey : item.key));
+    const topicNames = nodeAndChildren.map((item) => (item.type === "topic" ? item.topicName : null)).filter(Boolean);
+    const namespaceChildrenKeys = flatten(
+      topicNames.map((topicName) =>
+        (availableNamespacesByTopic[isFeatureColumn ? `${SECOND_SOURCE_PREFIX}${topicName}` : topicName] || []).map(
+          (namespace) => generateNodeKey({ topicName, namespace, isFeatureColumn })
+        )
+      )
+    );
 
-      let newModififiedNamespaceTopics = modifiedNamespaceTopics;
-      if (namespaceParentTopicName && prefixedTopicName) {
-        if (!modifiedNamespaceTopics.includes(prefixedTopicName)) {
-          newModififiedNamespaceTopics = [...modifiedNamespaceTopics, prefixedTopicName];
-        }
-        const namespace = nodeKey.split(":").pop();
-        keyWithPrefix = generateNodeKey({ topicName: namespaceParentTopicName, namespace, isFeatureColumn });
+    let newModififiedNamespaceTopics = [...modifiedNamespaceTopics];
+    topicNames.forEach((topicName) => {
+      const prefixedTopicName = isFeatureColumn ? `${SECOND_SOURCE_PREFIX}${topicName}` : topicName;
+      if (availableNamespacesByTopic[prefixedTopicName]) {
+        newModififiedNamespaceTopics.push(prefixedTopicName);
       }
+    });
+    newModififiedNamespaceTopics = isEqual(newModififiedNamespaceTopics, modifiedNamespaceTopics)
+      ? modifiedNamespaceTopics
+      : uniq(newModififiedNamespaceTopics);
 
-      let prevChecked = checkedKeys.includes(keyWithPrefix);
-      let newCheckedKeys = [...checkedKeys];
-      if (!prevChecked && namespaceParentTopicName) {
-        prevChecked = getIsNamespaceCheckedByDefault(namespaceParentTopicName, columnIndex);
-        if (prevChecked && prefixedTopicName) {
-          // Add all namespaces under the topic if it's checked by default.
-          const allNsKeys = (availableNamespacesByTopic[prefixedTopicName] || []).map((ns) =>
-            generateNodeKey({ topicName: namespaceParentTopicName, namespace: ns, isFeatureColumn })
-          );
-          newCheckedKeys = [...checkedKeys, ...allNsKeys];
-        }
+    const nodeKeysToToggle = [...nodeAndChildrenKeys, ...namespaceChildrenKeys];
+    // Toggle all children nodes' checked state to be the same as the new checked state for the node.
+    saveConfig({
+      modifiedNamespaceTopics: newModififiedNamespaceTopics,
+      checkedKeys: isNowChecked
+        ? uniq([...checkedKeys, ...nodeKeysToToggle])
+        : difference(checkedKeys, nodeKeysToToggle),
+    });
+  }, [availableNamespacesByTopic, checkedKeys, modifiedNamespaceTopics, nodesByKey, saveConfig]);
+
+  const toggleCheckAllAncestors = useCallback((
+    nodeKey: string,
+    columnIndex: number,
+    namespaceParentTopicName?: string
+  ) => {
+    const isFeatureColumn = columnIndex === 1;
+    const node = nodesByKey[nodeKey];
+    let keyWithPrefix = isFeatureColumn && node ? node.featureKey : nodeKey;
+    const prefixedTopicName =
+      isFeatureColumn && namespaceParentTopicName
+        ? `${SECOND_SOURCE_PREFIX}${namespaceParentTopicName}`
+        : namespaceParentTopicName;
+
+    let newModififiedNamespaceTopics = modifiedNamespaceTopics;
+    if (namespaceParentTopicName && prefixedTopicName) {
+      if (!modifiedNamespaceTopics.includes(prefixedTopicName)) {
+        newModififiedNamespaceTopics = [...modifiedNamespaceTopics, prefixedTopicName];
       }
-      const isNowChecked = !prevChecked;
+      const namespace = nodeKey.split(":").pop();
+      keyWithPrefix = generateNodeKey({ topicName: namespaceParentTopicName, namespace, isFeatureColumn });
+    }
 
-      const nodeAndAncestorKeys: string[] = [keyWithPrefix];
-      let parentKey = namespaceParentTopicName
-        ? generateNodeKey({ topicName: namespaceParentTopicName })
-        : node?.parentKey;
-
-      while (parentKey) {
-        const keyToToggle = isFeatureColumn ? nodesByKey[parentKey]?.featureKey : parentKey;
-        if (keyToToggle) {
-          nodeAndAncestorKeys.push(keyToToggle);
-        }
-        parentKey = nodesByKey[parentKey]?.parentKey;
+    let prevChecked = checkedKeys.includes(keyWithPrefix);
+    let newCheckedKeys = [...checkedKeys];
+    if (!prevChecked && namespaceParentTopicName) {
+      prevChecked = getIsNamespaceCheckedByDefault(namespaceParentTopicName, columnIndex);
+      if (prevChecked && prefixedTopicName) {
+        // Add all namespaces under the topic if it's checked by default.
+        const allNsKeys = (availableNamespacesByTopic[prefixedTopicName] || []).map((ns) =>
+          generateNodeKey({ topicName: namespaceParentTopicName, namespace: ns, isFeatureColumn })
+        );
+        newCheckedKeys = [...checkedKeys, ...allNsKeys];
       }
-      // Toggle all ancestor nodes' checked state to be the same as the new checked state for the node.
-      saveConfig({
-        modifiedNamespaceTopics: newModififiedNamespaceTopics,
-        checkedKeys: isNowChecked
-          ? uniq([...newCheckedKeys, ...nodeAndAncestorKeys])
-          : difference(newCheckedKeys, nodeAndAncestorKeys),
-      });
-    },
-    [
-      availableNamespacesByTopic,
-      checkedKeys,
-      getIsNamespaceCheckedByDefault,
-      modifiedNamespaceTopics,
-      nodesByKey,
-      saveConfig,
-    ]
-  );
+    }
+    const isNowChecked = !prevChecked;
+
+    const nodeAndAncestorKeys: string[] = [keyWithPrefix];
+    let parentKey = namespaceParentTopicName
+      ? generateNodeKey({ topicName: namespaceParentTopicName })
+      : node?.parentKey;
+
+    while (parentKey) {
+      const keyToToggle = isFeatureColumn ? nodesByKey[parentKey]?.featureKey : parentKey;
+      if (keyToToggle) {
+        nodeAndAncestorKeys.push(keyToToggle);
+      }
+      parentKey = nodesByKey[parentKey]?.parentKey;
+    }
+    // Toggle all ancestor nodes' checked state to be the same as the new checked state for the node.
+    saveConfig({
+      modifiedNamespaceTopics: newModififiedNamespaceTopics,
+      checkedKeys: isNowChecked
+        ? uniq([...newCheckedKeys, ...nodeAndAncestorKeys])
+        : difference(newCheckedKeys, nodeAndAncestorKeys),
+    });
+  }, [
+    availableNamespacesByTopic,
+    checkedKeys,
+    getIsNamespaceCheckedByDefault,
+    modifiedNamespaceTopics,
+    nodesByKey,
+    saveConfig,
+  ]);
 
   const filterTextRef = useRef(filterText);
   filterTextRef.current = filterText;
-  const toggleNodeExpanded = useCallback(
-    (nodeKey: string) => {
-      // Don't allow any toggling expansion when filtering because we automatically expand all nodes.
-      if (!filterTextRef.current) {
-        saveConfig({ expandedKeys: xor(expandedKeys, [nodeKey]) });
-      }
-    },
-    [expandedKeys, saveConfig]
-  );
+  const toggleNodeExpanded = useCallback((nodeKey: string) => {
+    // Don't allow any toggling expansion when filtering because we automatically expand all nodes.
+    if (!filterTextRef.current) {
+      saveConfig({ expandedKeys: xor(expandedKeys, [nodeKey]) });
+    }
+  }, [expandedKeys, saveConfig]);
 
-  const sceneErrorsByKey = useMemo(
-    () => {
-      const result = {};
+  const sceneErrorsByKey = useMemo(() => {
+    const result = {};
 
-      function collectGroupErrors(groupKey: ?string, errors: string[]) {
-        if (!groupKey) {
-          return;
-        }
-        let nodeKey: ?string = groupKey;
-        while (nodeKey && nodesByKey[nodeKey]) {
-          if (!result[nodeKey]) {
-            result[nodeKey] = [];
-          }
-          result[nodeKey].push(...errors);
-          nodeKey = nodesByKey[nodeKey].parentKey;
-        }
+    function collectGroupErrors(groupKey: ?string, errors: string[]) {
+      if (!groupKey) {
+        return;
       }
+      let nodeKey: ?string = groupKey;
+      while (nodeKey && nodesByKey[nodeKey]) {
+        if (!result[nodeKey]) {
+          result[nodeKey] = [];
+        }
+        result[nodeKey].push(...errors);
+        nodeKey = nodesByKey[nodeKey].parentKey;
+      }
+    }
 
-      for (const [topicKey, errors] of Object.entries(sceneErrorsByTopicKey)) {
-        const baseKey = getBaseKey(topicKey);
-        if (!result[baseKey]) {
-          result[baseKey] = [];
-        }
-        const errorsWithTopicName = ((errors: any): string[]).map((err) => `${topicKey.substr("t:".length)}: ${err}`);
-        result[baseKey].push(...(hasFeatureColumn ? errorsWithTopicName : errors));
-        const topicNode = nodesByKey[baseKey];
-        collectGroupErrors(topicNode?.parentKey, errorsWithTopicName);
+    for (const [topicKey, errors] of Object.entries(sceneErrorsByTopicKey)) {
+      const baseKey = getBaseKey(topicKey);
+      if (!result[baseKey]) {
+        result[baseKey] = [];
       }
-      return result;
-    },
-    [hasFeatureColumn, nodesByKey, sceneErrorsByTopicKey]
-  );
+      const errorsWithTopicName = ((errors: any): string[]).map((err) => `${topicKey.substr("t:".length)}: ${err}`);
+      result[baseKey].push(...(hasFeatureColumn ? errorsWithTopicName : errors));
+      const topicNode = nodesByKey[baseKey];
+      collectGroupErrors(topicNode?.parentKey, errorsWithTopicName);
+    }
+    return result;
+  }, [hasFeatureColumn, nodesByKey, sceneErrorsByTopicKey]);
 
   const [debouncedFilterText] = useDebounce(filterText, 150);
-  const { getIsTreeNodeVisibleInTree } = useMemo(
-    () => {
-      const showVisible = topicDisplayMode === TOPIC_DISPLAY_MODES.SHOW_SELECTED.value;
-      const showAvailable = topicDisplayMode === TOPIC_DISPLAY_MODES.SHOW_AVAILABLE.value;
-      const providerAvailable = providerTopics.length > 0;
+  const { getIsTreeNodeVisibleInTree } = useMemo(() => {
+    const showVisible = topicDisplayMode === TOPIC_DISPLAY_MODES.SHOW_SELECTED.value;
+    const showAvailable = topicDisplayMode === TOPIC_DISPLAY_MODES.SHOW_AVAILABLE.value;
+    const providerAvailable = providerTopics.length > 0;
 
-      let hasCalculatedVisibility = false;
-      // This stores whether the row has been marked as visible, so that we don't do extra work.
-      const isVisibleByKey: { [string]: boolean } = {};
+    let hasCalculatedVisibility = false;
+    // This stores whether the row has been marked as visible, so that we don't do extra work.
+    const isVisibleByKey: { [string]: boolean } = {};
 
-      const searchText = debouncedFilterText.toLowerCase().trim();
-      function getIfTextMatches(node: TreeNode): boolean {
-        // Never match the root node.
-        if (node.name === "root") {
+    const searchText = debouncedFilterText.toLowerCase().trim();
+    function getIfTextMatches(node: TreeNode): boolean {
+      // Never match the root node.
+      if (node.name === "root") {
+        return false;
+      } else if (node.type === "group") {
+        // Group node
+        return node.name != null && node.name.toLowerCase().includes(searchText);
+      }
+      // Topic node, without namespace
+      return (
+        node.topicName.toLowerCase().includes(searchText) ||
+        (node.name != null && node.name.toLowerCase().includes(searchText)) ||
+        (hasFeatureColumn && `${SECOND_SOURCE_PREFIX}${node.topicName}`.toLowerCase().includes(searchText))
+      );
+    }
+
+    // Calculates whether a node is visible. This is a recursive function intended to be run on the root node.
+    function calculateIsVisible(node: TreeNode, isAncestorVisible: boolean): boolean {
+      // When the user is viewing available/visible nodes, we can skip setting the visibility for the children of
+      // unavailable/invisible nodes since they are not going to be rendered.
+      if (providerAvailable && node.name !== "root") {
+        const unavailable = hasFeatureColumn
+          ? !node.availableByColumn[0] && !node.availableByColumn[1]
+          : !node.availableByColumn[0];
+        const invisibleInScene = hasFeatureColumn
+          ? !getIsTreeNodeVisibleInScene(node, 0) && !getIsTreeNodeVisibleInScene(node, 1)
+          : !getIsTreeNodeVisibleInScene(node, 0);
+
+        if ((showAvailable && unavailable) || (showVisible && invisibleInScene)) {
+          isVisibleByKey[node.key] = false;
           return false;
-        } else if (node.type === "group") {
-          // Group node
-          return node.name != null && node.name.toLowerCase().includes(searchText);
         }
-        // Topic node, without namespace
-        return (
-          node.topicName.toLowerCase().includes(searchText) ||
-          (node.name != null && node.name.toLowerCase().includes(searchText)) ||
-          (hasFeatureColumn && `${SECOND_SOURCE_PREFIX}${node.topicName}`.toLowerCase().includes(searchText))
-        );
+      }
+      // Whether the ancestor is visible, or the current node matches the search text.
+      const isAncestorOrCurrentVisible = isAncestorVisible || getIfTextMatches(node);
+      let isChildVisible = false;
+
+      if (node.type === "topic") {
+        // Topic node: check if any namespace matches.
+        const namespaces =
+          availableNamespacesByTopic[node.topicName] ||
+          (hasFeatureColumn && availableNamespacesByTopic[`${SECOND_SOURCE_PREFIX}${node.topicName}`]) ||
+          [];
+
+        for (const namespace of namespaces) {
+          const thisNamespacesMatches = namespace.toLowerCase().includes(searchText);
+          isVisibleByKey[generateNodeKey({ topicName: node.topicName, namespace })] =
+            isAncestorOrCurrentVisible || thisNamespacesMatches;
+          isChildVisible = thisNamespacesMatches || isChildVisible;
+        }
+      } else {
+        // Group node: recurse and check if any children are visible.
+        for (const child of node.children) {
+          isChildVisible = calculateIsVisible(child, isAncestorOrCurrentVisible) || isChildVisible;
+        }
+      }
+      const isVisible = isAncestorOrCurrentVisible || isChildVisible;
+      isVisibleByKey[node.key] = isVisible;
+      return isVisible;
+    }
+
+    function getIsTreeNodeVisible(key: string): boolean {
+      if (!searchText) {
+        return true;
       }
 
-      // Calculates whether a node is visible. This is a recursive function intended to be run on the root node.
-      function calculateIsVisible(node: TreeNode, isAncestorVisible: boolean): boolean {
-        // When the user is viewing available/visible nodes, we can skip setting the visibility for the children of
-        // unavailable/invisible nodes since they are not going to be rendered.
-        if (providerAvailable && node.name !== "root") {
-          const unavailable = hasFeatureColumn
-            ? !node.availableByColumn[0] && !node.availableByColumn[1]
-            : !node.availableByColumn[0];
-          const invisibleInScene = hasFeatureColumn
-            ? !getIsTreeNodeVisibleInScene(node, 0) && !getIsTreeNodeVisibleInScene(node, 1)
-            : !getIsTreeNodeVisibleInScene(node, 0);
-
-          if ((showAvailable && unavailable) || (showVisible && invisibleInScene)) {
-            isVisibleByKey[node.key] = false;
-            return false;
-          }
-        }
-        // Whether the ancestor is visible, or the current node matches the search text.
-        const isAncestorOrCurrentVisible = isAncestorVisible || getIfTextMatches(node);
-        let isChildVisible = false;
-
-        if (node.type === "topic") {
-          // Topic node: check if any namespace matches.
-          const namespaces =
-            availableNamespacesByTopic[node.topicName] ||
-            (hasFeatureColumn && availableNamespacesByTopic[`${SECOND_SOURCE_PREFIX}${node.topicName}`]) ||
-            [];
-
-          for (const namespace of namespaces) {
-            const thisNamespacesMatches = namespace.toLowerCase().includes(searchText);
-            isVisibleByKey[generateNodeKey({ topicName: node.topicName, namespace })] =
-              isAncestorOrCurrentVisible || thisNamespacesMatches;
-            isChildVisible = thisNamespacesMatches || isChildVisible;
-          }
-        } else {
-          // Group node: recurse and check if any children are visible.
-          for (const child of node.children) {
-            isChildVisible = calculateIsVisible(child, isAncestorOrCurrentVisible) || isChildVisible;
-          }
-        }
-        const isVisible = isAncestorOrCurrentVisible || isChildVisible;
-        isVisibleByKey[node.key] = isVisible;
-        return isVisible;
+      // Calculate the row visibility for all rows if we don't already have it stored.
+      if (!hasCalculatedVisibility) {
+        calculateIsVisible(rootTreeNode, false);
+        hasCalculatedVisibility = true;
       }
 
-      function getIsTreeNodeVisible(key: string): boolean {
-        if (!searchText) {
-          return true;
-        }
+      return !!isVisibleByKey[key];
+    }
 
-        // Calculate the row visibility for all rows if we don't already have it stored.
-        if (!hasCalculatedVisibility) {
-          calculateIsVisible(rootTreeNode, false);
-          hasCalculatedVisibility = true;
-        }
+    return { getIsTreeNodeVisibleInTree: getIsTreeNodeVisible };
+  }, [
+    topicDisplayMode,
+    providerTopics.length,
+    debouncedFilterText,
+    getIsTreeNodeVisibleInScene,
+    availableNamespacesByTopic,
+    rootTreeNode,
+    hasFeatureColumn,
+  ]);
 
-        return !!isVisibleByKey[key];
-      }
-
-      return { getIsTreeNodeVisibleInTree: getIsTreeNodeVisible };
-    },
-    [
-      topicDisplayMode,
-      providerTopics.length,
-      debouncedFilterText,
-      getIsTreeNodeVisibleInScene,
-      availableNamespacesByTopic,
-      rootTreeNode,
-      hasFeatureColumn,
-    ]
-  );
-
-  const { allKeys, shouldExpandAllKeys } = useMemo(
-    () => {
-      return {
-        allKeys: Object.keys(nodesByKey),
-        shouldExpandAllKeys: !!debouncedFilterText,
-      };
-    },
-    [debouncedFilterText, nodesByKey]
-  );
+  const { allKeys, shouldExpandAllKeys } = useMemo(() => {
+    return {
+      allKeys: Object.keys(nodesByKey),
+      shouldExpandAllKeys: !!debouncedFilterText,
+    };
+  }, [debouncedFilterText, nodesByKey]);
 
   return {
     allKeys,

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/index.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/index.js
@@ -102,17 +102,14 @@ const BaseRenderer = (props: Props, ref) => {
     transforms,
   });
 
-  const onSetSubscriptions = useCallback(
-    (subscriptions: string[]) => {
-      setSubscriptions([
-        ...getGlobalHooks().perPanelHooks().ThreeDimensionalViz.topics,
-        TRANSFORM_TOPIC,
-        TRANSFORM_STATIC_TOPIC,
-        ...subscriptions,
-      ]);
-    },
-    [setSubscriptions]
-  );
+  const onSetSubscriptions = useCallback((subscriptions: string[]) => {
+    setSubscriptions([
+      ...getGlobalHooks().perPanelHooks().ThreeDimensionalViz.topics,
+      TRANSFORM_TOPIC,
+      TRANSFORM_STATIC_TOPIC,
+      ...subscriptions,
+    ]);
+  }, [setSubscriptions]);
 
   // use callbackInputsRef to make sure the input changes don't trigger `onFollowChange` or `onAlignXYAxis` to change
   const callbackInputsRef = useRef({
@@ -129,26 +126,23 @@ const BaseRenderer = (props: Props, ref) => {
     configFollowOrientation: config.followOrientation,
     configFollowTf: config.followTf,
   };
-  const onFollowChange = useCallback(
-    (newFollowTf?: string | false, newFollowOrientation?: boolean) => {
-      const {
-        configCameraState: prevCameraState,
-        configFollowOrientation: prevFollowOrientation,
-        configFollowTf: prevFollowTf,
-        targetPose: prevTargetPose,
-      } = callbackInputsRef.current;
-      const newCameraState = getNewCameraStateOnFollowChange({
-        prevCameraState,
-        prevTargetPose,
-        prevFollowTf,
-        prevFollowOrientation,
-        newFollowTf,
-        newFollowOrientation,
-      });
-      saveConfig({ followTf: newFollowTf, followOrientation: newFollowOrientation, cameraState: newCameraState });
-    },
-    [saveConfig]
-  );
+  const onFollowChange = useCallback((newFollowTf?: string | false, newFollowOrientation?: boolean) => {
+    const {
+      configCameraState: prevCameraState,
+      configFollowOrientation: prevFollowOrientation,
+      configFollowTf: prevFollowTf,
+      targetPose: prevTargetPose,
+    } = callbackInputsRef.current;
+    const newCameraState = getNewCameraStateOnFollowChange({
+      prevCameraState,
+      prevTargetPose,
+      prevFollowTf,
+      prevFollowOrientation,
+      newFollowTf,
+      newFollowOrientation,
+    });
+    saveConfig({ followTf: newFollowTf, followOrientation: newFollowOrientation, cameraState: newCameraState });
+  }, [saveConfig]);
 
   const onAlignXYAxis = useCallback(
     () =>
@@ -169,20 +163,17 @@ const BaseRenderer = (props: Props, ref) => {
     saveCameraState,
   ]);
 
-  const onCameraStateChange = useCallback(
-    (newCameraState) => {
-      const newCurrentCameraState = omit(newCameraState, ["target", "targetOrientation"]);
-      setConfigCameraState(newCurrentCameraState);
+  const onCameraStateChange = useCallback((newCameraState) => {
+    const newCurrentCameraState = omit(newCameraState, ["target", "targetOrientation"]);
+    setConfigCameraState(newCurrentCameraState);
 
-      // If autoSyncCameraState is enabled, we can't wait for the debounce and need to call updatePanelConfig right away
-      if (autoSyncCameraState) {
-        updatePanelConfig("3D Panel", (oldConfig) => ({ ...oldConfig, cameraState: newCurrentCameraState }));
-      } else {
-        saveCameraStateDebounced(newCurrentCameraState);
-      }
-    },
-    [autoSyncCameraState, saveCameraStateDebounced, updatePanelConfig]
-  );
+    // If autoSyncCameraState is enabled, we can't wait for the debounce and need to call updatePanelConfig right away
+    if (autoSyncCameraState) {
+      updatePanelConfig("3D Panel", (oldConfig) => ({ ...oldConfig, cameraState: newCurrentCameraState }));
+    } else {
+      saveCameraStateDebounced(newCurrentCameraState);
+    }
+  }, [autoSyncCameraState, saveCameraStateDebounced, updatePanelConfig]);
 
   // useImperativeHandle so consumer component (e.g.Follow stories) can call onFollowChange directly.
   React.useImperativeHandle(ref, (): any => ({ onFollowChange }));

--- a/packages/webviz-core/src/stories/PanelSetupWithBag.js
+++ b/packages/webviz-core/src/stories/PanelSetupWithBag.js
@@ -57,45 +57,39 @@ export default function PanelSetupWithBag({
   // 3D Panel hack that resets fixture in order to get around MessageHistory
   // behavior where the existing frame is not re-processed when the set of
   // topics changes.
-  useEffect(
-    () => {
-      if (!hasResetFixture.current && fixture && frameHistoryCompatibility) {
-        setImmediate(() => {
-          hasResetFixture.current = true;
-          setFixture({ ...fixture });
-        });
-      }
-    },
-    [fixture, frameHistoryCompatibility]
-  );
+  useEffect(() => {
+    if (!hasResetFixture.current && fixture && frameHistoryCompatibility) {
+      setImmediate(() => {
+        hasResetFixture.current = true;
+        setFixture({ ...fixture });
+      });
+    }
+  }, [fixture, frameHistoryCompatibility]);
 
-  useEffect(
-    () => {
-      (async () => {
-        const player = new NodePlayer(new StoryPlayer([bag, bag2].filter(Boolean)));
-        const formattedSubscriptions = flatten(
-          (subscriptions || []).map((topic) => [{ topic, format: "parsedMessages" }, { topic, format: "bobjects" }])
-        );
-        player.setSubscriptions(formattedSubscriptions);
+  useEffect(() => {
+    (async () => {
+      const player = new NodePlayer(new StoryPlayer([bag, bag2].filter(Boolean)));
+      const formattedSubscriptions = flatten(
+        (subscriptions || []).map((topic) => [{ topic, format: "parsedMessages" }, { topic, format: "bobjects" }])
+      );
+      player.setSubscriptions(formattedSubscriptions);
 
-        player.setListener(({ activeData }: PlayerState) => {
-          if (!activeData) {
-            return Promise.resolve();
-          }
-          const { messages, bobjects, topics } = activeData;
-          const frame = groupBy([...messages, ...bobjects], "topic");
-          setFixture(
-            getMergedFixture({
-              frame,
-              topics,
-            })
-          );
+      player.setListener(({ activeData }: PlayerState) => {
+        if (!activeData) {
           return Promise.resolve();
-        });
-      })();
-    },
-    [bag, bag2, getMergedFixture, subscriptions]
-  );
+        }
+        const { messages, bobjects, topics } = activeData;
+        const frame = groupBy([...messages, ...bobjects], "topic");
+        setFixture(
+          getMergedFixture({
+            frame,
+            topics,
+          })
+        );
+        return Promise.resolve();
+      });
+    })();
+  }, [bag, bag2, getMergedFixture, subscriptions]);
 
   return fixture ? (
     <PanelSetup fixture={fixture} onMount={onMount} onFirstMount={onFirstMount} store={store}>

--- a/packages/webviz-core/src/util/hooks.js
+++ b/packages/webviz-core/src/util/hooks.js
@@ -215,25 +215,22 @@ export function useContextSelector<T, U>(context: SelectableContext<T>, selector
   });
 
   // Subscribe to context updates, and setSelectedValue() only when the selected value changes.
-  useLayoutEffect(
-    () => {
-      const sub = (newValue) => {
-        const newSelectedValue = selector(newValue);
-        if (isBailout(newSelectedValue)) {
-          return;
-        }
-        if (newSelectedValue !== latestSelectedValue.current) {
-          // Because newSelectedValue might be a function, we have to always use the reducer form of setState.
-          setSelectedValue(() => newSelectedValue);
-        }
-      };
-      handle.addSubscriber(sub);
-      return () => {
-        handle.removeSubscriber(sub);
-      };
-    },
-    [handle, selector]
-  );
+  useLayoutEffect(() => {
+    const sub = (newValue) => {
+      const newSelectedValue = selector(newValue);
+      if (isBailout(newSelectedValue)) {
+        return;
+      }
+      if (newSelectedValue !== latestSelectedValue.current) {
+        // Because newSelectedValue might be a function, we have to always use the reducer form of setState.
+        setSelectedValue(() => newSelectedValue);
+      }
+    };
+    handle.addSubscriber(sub);
+    return () => {
+      handle.removeSubscriber(sub);
+    };
+  }, [handle, selector]);
 
   return selectedValue;
 }

--- a/packages/webviz-core/src/util/topicUtils.js
+++ b/packages/webviz-core/src/util/topicUtils.js
@@ -29,16 +29,13 @@ export const makeTopicCombos = (...topicGroups: string[][]): string[] => {
 // Inspired by https://gist.github.com/tansongyang/9695563ad9f1fa5309b0af8aa6b3e7e3
 // ["foo", "bar"], ["cool", "beans"]] => [["foo", "cool"],["foo", "beans"],["bar", "cool"],["bar", "beans"],]
 export function cartesianProduct<T>(arrays: T[][]): T[][] {
-  return arrays.reduce(
-    (a, b) => {
-      return flatten<T[], T[]>(
-        a.map((x) => {
-          return b.map((y) => {
-            return x.concat([y]);
-          });
-        })
-      );
-    },
-    [[]]
-  );
+  return arrays.reduce((a, b) => {
+    return flatten<T[], T[]>(
+      a.map((x) => {
+        return b.map((y) => {
+          return x.concat([y]);
+        });
+      })
+    );
+  }, [[]]);
 }

--- a/stories/withStateReset.js
+++ b/stories/withStateReset.js
@@ -7,27 +7,24 @@ const StoryWrapper = (props) => {
   const [showStory, setShowStory] = useState(false);
 
   // Reset the state before rendering the next story
-  useEffect(
-    () => {
-      // Remove leftover modals from the previous story
-      document.querySelectorAll("[data-modalcontainer]").forEach((el) => el.remove());
-      localStorage.clear();
+  useEffect(() => {
+    // Remove leftover modals from the previous story
+    document.querySelectorAll("[data-modalcontainer]").forEach((el) => el.remove());
+    localStorage.clear();
 
-      // Reset the renderCounts for the NumberOfRenders panel
-      resetRenderCountsForTests();
+    // Reset the renderCounts for the NumberOfRenders panel
+    resetRenderCountsForTests();
 
-      // Reset cached monacoApi state
-      monacoApi.editor.getModels().forEach((model) => model.dispose());
+    // Reset cached monacoApi state
+    monacoApi.editor.getModels().forEach((model) => model.dispose());
 
-      // Unmount the old story before rendering the next one to clear out any stored state
-      setShowStory(false);
-      const timer = setImmediate(() => {
-        setShowStory(true);
-      });
-      return () => clearTimeout(timer);
-    },
-    [props]
-  );
+    // Unmount the old story before rendering the next one to clear out any stored state
+    setShowStory(false);
+    const timer = setImmediate(() => {
+      setShowStory(true);
+    });
+    return () => clearTimeout(timer);
+  }, [props]);
 
   return (showStory && React.createElement(props.storyComponent)) || null;
 };


### PR DESCRIPTION
This includes the `eslint --fix` for all the files to match prettier's new format. The main change is react callbacks now take up less lines than they did before.

![image](https://user-images.githubusercontent.com/5104925/102926693-5177b380-444a-11eb-9f95-1dbbc03c7566.png)

https://prettier.io/blog/2019/01/20/1.16.0.html

Using "hide whitespace changes" makes the diff much nicer:
![image](https://user-images.githubusercontent.com/5104925/102926409-c72f4f80-4449-11eb-8e7c-f0f83582f382.png)
