### PR TITLE
Support non-standard ImageMarkerArray message

### DIFF
--- a/packages/webviz-core/src/hooksImporter.js
+++ b/packages/webviz-core/src/hooksImporter.js
@@ -145,7 +145,7 @@ export function perPanelHooks() {
         zoomPercentage: 100,
         offset: [0, 0],
       },
-      imageMarkerDatatypes: ["visualization_msgs/ImageMarker"],
+      imageMarkerDatatypes: ["visualization_msgs/ImageMarker", "visualization_msgs/ImageMarkerArray"],
       canTransformMarkersByTopic: (topic) => !topic.includes("rect"),
     },
     GlobalVariableSlider: {

--- a/packages/webviz-core/src/hooksImporter.js
+++ b/packages/webviz-core/src/hooksImporter.js
@@ -145,7 +145,7 @@ export function perPanelHooks() {
         zoomPercentage: 100,
         offset: [0, 0],
       },
-      imageMarkerDatatypes: ["visualization_msgs/ImageMarker", "visualization_msgs/ImageMarkerArray"],
+      imageMarkerDatatypes: ["visualization_msgs/ImageMarker", "webviz_msgs/ImageMarkerArray"],
       canTransformMarkersByTopic: (topic) => !topic.includes("rect"),
     },
     GlobalVariableSlider: {


### PR DESCRIPTION
The rendering code at https://github.com/cruise-automation/webviz/blob/master/packages/webviz-core/src/panels/ImageView/renderImage.js#L174-L177 already supports this message.

<!-- Thanks for contributing to Webviz! To help us understand and review your PR, please fill out the following sections: -->

## Summary

Explicitly support a message named `webviz_msgs/ImageMarkerArray` that is already implicitly supported by the marker painting code.

## Test plan

Untested

## Versioning impact

This would be a minor version bump under semver.