### PR TITLE
Only set texture.min/mag/wrapS/wrapT if they are set in the sampler

### DIFF
--- a/packages/regl-worldview/src/commands/GLTFScene.js
+++ b/packages/regl-worldview/src/commands/GLTFScene.js
@@ -134,14 +134,20 @@ const drawModel = (regl) => {
       model.json.textures.map((textureInfo) => {
         const sampler = model.json.samplers[textureInfo.sampler];
         const bitmap = model.images && model.images[textureInfo.source];
-        const texture = regl.texture({
-          data: bitmap,
-          min: glConstantToRegl(sampler.minFilter),
-          mag: glConstantToRegl(sampler.magFilter),
-          wrapS: glConstantToRegl(sampler.wrapS),
-          wrapT: glConstantToRegl(sampler.wrapT),
-        });
-        return texture;
+        const textureProps = { data: bitmap };
+        if (sampler.minFilter) {
+          textureProps.min = glConstantToRegl(sampler.minFilter);
+        }
+        if (sampler.magFilter) {
+          textureProps.mag = glConstantToRegl(sampler.magFilter);
+        }
+        if (sampler.wrapS) {
+          textureProps.wrapS = glConstantToRegl(sampler.wrapS);
+        }
+        if (sampler.wrapT) {
+          textureProps.wrapT = glConstantToRegl(sampler.wrapT);
+        }
+        return regl.texture(textureProps);
       });
     if (model.images) {
       model.images.forEach((bitmap: ImageBitmap) => bitmap.close());


### PR DESCRIPTION
It's valid for a sampler not to contain any of these properties, so let's only set them if they are present.
This should fix an issue that was recently reported:
https://github.com/cruise-automation/webviz/issues/573
