### PR TITLE
Fix <Points /> optional world size argument

### DIFF
--- a/packages/regl-worldview/package-lock.json
+++ b/packages/regl-worldview/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "regl-worldview",
-	"version": "0.15.0",
+	"version": "0.15.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "license": "Apache-2.0",
   "repository": "cruise-automation/webviz/tree/master/packages/regl-worldview",

--- a/packages/regl-worldview/src/commands/Points.js
+++ b/packages/regl-worldview/src/commands/Points.js
@@ -97,7 +97,7 @@ export const makePointsCommand = ({ useWorldSpaceSize }: PointsProps) => {
         pointSize: (context, props) => {
           return props.scale.x || 1;
         },
-        useWorldSpaceSize,
+        useWorldSpaceSize: !!useWorldSpaceSize,
         viewportWidth: regl.context("viewportWidth"),
         viewportHeight: regl.context("viewportHeight"),
         minPointSize: minLimitPointSize,


### PR DESCRIPTION
## Summary

`useWorldSpaceSize` must be optional for `<Points />`

## Test plan

Covered by existing tests. Manual test too.

## Versioning impact

Patch to v0.15.0

