### PR TITLE
Add support for rendering Worldview in an offscreen canvas

### DIFF
--- a/packages/regl-worldview/package-lock.json
+++ b/packages/regl-worldview/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "regl-worldview",
-	"version": "0.15.1",
+	"version": "0.16.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "license": "Apache-2.0",
   "repository": "cruise-automation/webviz/tree/master/packages/regl-worldview",

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -65,7 +65,7 @@ export type BaseProps = {|
 
   // Context attributes passed into canvas.getContext.
   contextAttributes?: ?{ [string]: any },
-  offscreenCanvas?: HTMLCanvasElement,
+  canvas?: HTMLCanvasElement,
 |};
 
 type State = {|
@@ -116,10 +116,10 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
       defaultCameraState,
       hitmapOnMouseMove,
       disableHitmapForEvents,
-      offscreenCanvas,
+      canvas,
     } = props;
-    if (offscreenCanvas) {
-      this._canvas.current = offscreenCanvas;
+    if (canvas) {
+      this._canvas.current = canvas;
     }
     if (onCameraStateChange) {
       if (!cameraState) {
@@ -215,27 +215,27 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
   };
 
   _onDoubleClick = (e: SyntheticMouseEvent<HTMLCanvasElement>, fromOffscreenTarget: boolean) => {
-    this._onMouseInteraction(e, "onDoubleClick", !!fromOffscreenTarget);
+    this._onMouseInteraction(e, "onDoubleClick", fromOffscreenTarget);
   };
 
   _onMouseDown = (e: SyntheticMouseEvent<HTMLCanvasElement>, fromOffscreenTarget: boolean) => {
     this._dragStartPos = { x: e.clientX, y: e.clientY };
-    this._onMouseInteraction(e, "onMouseDown", !!fromOffscreenTarget);
+    this._onMouseInteraction(e, "onMouseDown", fromOffscreenTarget);
   };
 
   _onMouseMove = (e: SyntheticMouseEvent<HTMLCanvasElement>, fromOffscreenTarget: boolean) => {
-    this._onMouseInteraction(e, "onMouseMove", !!fromOffscreenTarget);
+    this._onMouseInteraction(e, "onMouseMove", fromOffscreenTarget);
   };
 
   _onMouseUp = (e: SyntheticMouseEvent<HTMLCanvasElement>, fromOffscreenTarget: boolean) => {
-    this._onMouseInteraction(e, "onMouseUp", !!fromOffscreenTarget);
+    this._onMouseInteraction(e, "onMouseUp", fromOffscreenTarget);
     const { _dragStartPos } = this;
     if (_dragStartPos) {
       const deltaX = e.clientX - _dragStartPos.x;
       const deltaY = e.clientY - _dragStartPos.y;
       const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
       if (distance < DEFAULT_MOUSE_CLICK_RADIUS) {
-        this._onMouseInteraction(e, "onClick", !!fromOffscreenTarget);
+        this._onMouseInteraction(e, "onClick", fromOffscreenTarget);
       }
       this._dragStartPos = null;
     }
@@ -354,16 +354,14 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
       cameraState,
       onCameraStateChange,
       resolutionScale,
-      offscreenCanvas,
+      canvas,
     } = this.props;
     const { worldviewContext } = this.state;
     // If we are supplied controlled camera state and no onCameraStateChange callback
     // then there is a 'fixed' camera from outside of worldview itself.
     const isFixedCamera = cameraState && !onCameraStateChange;
     const canvasScale = resolutionScale || 1;
-    const canvasHtml = offscreenCanvas ? (
-      <React.Fragment />
-    ) : (
+    const canvasHtml = canvas ? null : (
       <React.Fragment>
         <canvas
           style={{ width, height, maxWidth: "100%", maxHeight: "100%" }}

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -65,7 +65,7 @@ export type BaseProps = {|
 
   // Context attributes passed into canvas.getContext.
   contextAttributes?: ?{ [string]: any },
-  offscreenCanvas: HTMLCanvasElement,
+  offscreenCanvas?: HTMLCanvasElement,
 |};
 
 type State = {|
@@ -118,7 +118,9 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
       disableHitmapForEvents,
       offscreenCanvas,
     } = props;
-    this._canvas.current = offscreenCanvas;
+    if (offscreenCanvas) {
+      this._canvas.current = offscreenCanvas;
+    }
     if (onCameraStateChange) {
       if (!cameraState) {
         console.warn(
@@ -251,6 +253,7 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
       return;
     }
 
+    // $FlowFixMe: Because of `fromOffscreenTarget`, target might not be an actual HTMLElement instance but still needs to implement `getBoundingClientRect`
     const { top: clientTop, left: clientLeft } = e.target.getBoundingClientRect();
     const { clientX, clientY } = e;
 

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -249,6 +249,9 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     const { worldviewContext } = this.state;
     const worldviewHandler = this.props[mouseEventName];
 
+    // When working with offscreen canvases, window is not defined and the target
+    // might not be a valid HTMLElement. If so, we can asume any event coming
+    // from an offscreen canvas already has a relevant target.
     if (!fromOffscreenTarget && (!(e.target instanceof window.HTMLElement) || e.button !== 0)) {
       return;
     }

--- a/packages/regl-worldview/src/index.js
+++ b/packages/regl-worldview/src/index.js
@@ -6,7 +6,7 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 
-import Worldview from "./Worldview";
+import Worldview, { WorldviewBase as OffscreenWorldview } from "./Worldview";
 
 export { default as Bounds } from "./utils/Bounds";
 export {
@@ -25,5 +25,5 @@ export * from "./commands/index";
 export * from "./types/index";
 export * from "./utils/getChildrenForHitmapDefaults";
 export { default as WorldviewReactContext } from "./WorldviewReactContext";
-export { Worldview };
+export { Worldview, OffscreenWorldview };
 export default Worldview;


### PR DESCRIPTION
## Summary

In this PR I'm modifying Worldview so it can use an offscreen `<canvas />` that is managed by the client application. If an offscreen canvas is used, clients must use the `<OffscreenWorldview />` component instead of `<Worldview />` one since dimensions are handled externally.

Additional changes are required to forward mouse events to rendering components, since they're now initiated in an external element. 

## Test plan

Handled by existing tests in Webviz. 

## Versioning impact

Minor. These changes are backward compatible. 