### PR TITLE
Add fallback for FinalizationRegistry in stories

### DIFF
--- a/stories/config.js
+++ b/stories/config.js
@@ -16,6 +16,12 @@ import storiesSetup from "webviz-core/src/stories/setup";
 import waitForFonts from "webviz-core/src/styles/waitForFonts";
 import installChartjs from "webviz-core/src/util/installChartjs";
 
+if (global.FinalizationRegistry == null) {
+  global.FinalizationRegistry = class {
+    register() {}
+  };
+}
+
 export const SCREENSHOT_VIEWPORT = {
   width: 1001,
   height: 745,


### PR DESCRIPTION
## Summary

We're currently working on supporting web workers in 3D Panel, which requires to send binary objects across worker boundaries. The `FinalizationRegistry` is used to release those objects when they're no longer used in main thread. But `FinalizationRegistry` is not present in the test environment.

## Test plan

Manually tested so far since workers are experimental.

## Versioning impact

Patch