### PR TITLE
Fix withTransforms() breaks the rules of hooks

### DIFF
--- a/packages/webviz-core/package-lock.json
+++ b/packages/webviz-core/package-lock.json
@@ -32,10 +32,27 @@
         }
       }
     },
+    "@cruise-automation/button": {
+      "version": "0.0.7",
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/@cruise-automation/button/-/button-0.0.7.tgz",
+      "integrity": "sha1-OTe0PO3gc/Rx+5jMYzBwMWKQezM=",
+      "requires": {
+        "classnames": "^2.2.5",
+        "styled-components": "^3.3.0"
+      }
+    },
     "@cruise-automation/hooks": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@cruise-automation/hooks/-/hooks-0.0.1.tgz",
-      "integrity": "sha512-sUwYShqRJAyg2XS7+uc9ZwdNkRArLdyjPTF6Ebl1GphXHX5QYU14aMt3SO3QtVg0fd/KSWM4FinRosxZDq5uZg=="
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/@cruise-automation/hooks/-/hooks-0.0.1.tgz",
+      "integrity": "sha1-qOF4j3/IQ0MKD/iN1me0bmqn7cE="
+    },
+    "@cruise-automation/tooltip": {
+      "version": "0.0.7",
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/@cruise-automation/tooltip/-/tooltip-0.0.7.tgz",
+      "integrity": "sha1-q8ZB/ZWDK/hZjtxQRC9yxZVctQE=",
+      "requires": {
+        "react-popper": "1.0.0"
+      }
     },
     "@mdi/svg": {
       "version": "5.7.55",
@@ -466,6 +483,11 @@
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
     },
+    "camelize": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
+    },
     "cbor-js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/cbor-js/-/cbor-js-0.1.0.tgz",
@@ -682,6 +704,15 @@
         "object-assign": "^4.1.1"
       }
     },
+    "create-react-context": {
+      "version": "0.2.3",
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/create-react-context/-/create-react-context-0.2.3.tgz",
+      "integrity": "sha1-nsFAppFKIu8EuLCbd3HeiVZ8tvM=",
+      "requires": {
+        "fbjs": "^0.8.0",
+        "gud": "^1.0.0"
+      }
+    },
     "css-animation": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/css-animation/-/css-animation-1.6.1.tgz",
@@ -689,6 +720,21 @@
       "requires": {
         "babel-runtime": "6.x",
         "component-classes": "^1.2.5"
+      }
+    },
+    "css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
+    },
+    "css-to-react-native": {
+      "version": "2.3.2",
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
+      "integrity": "sha1-514vj3qjhbTDYRxSsHS3CgAvLn0=",
+      "requires": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^3.3.0"
       }
     },
     "csstype": {
@@ -2023,6 +2069,11 @@
       "resolved": "https://registry.npmjs.org/pngparse/-/pngparse-2.0.1.tgz",
       "integrity": "sha1-hoUt5N40n077HoUudSVlXlrF37g="
     },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha1-KiI8s9x7YhPXQOQDcr5A3kPmWxs="
+    },
     "postcss": {
       "version": "7.0.29",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.29.tgz",
@@ -2047,6 +2098,11 @@
           }
         }
       }
+    },
+    "postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
     },
     "prettier": {
       "version": "1.16.0",
@@ -2419,8 +2475,8 @@
     },
     "react": {
       "version": "16.10.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.10.2.tgz",
-      "integrity": "sha512-MFVIq0DpIhrHFyqLU0S3+4dIcBhhOvBE8bJ/5kHPVOVaGdo0KuiQzpcjCPsf585WvhypqtrMILyoE2th6dT+Lw==",
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/react/-/react-16.10.2.tgz",
+      "integrity": "sha1-pe3lzdXFNvdFFzyNpHvaZHl6TPA=",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -2532,8 +2588,8 @@
     },
     "react-dom": {
       "version": "16.10.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.10.2.tgz",
-      "integrity": "sha512-kWGDcH3ItJK4+6Pl9DZB16BXYAZyrYQItU4OMy0jAkv5aNqc+mAKb4TpFtAteI6TJZu+9ZlNhaeNQSVQDHJzkw==",
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/react-dom/-/react-dom-16.10.2.tgz",
+      "integrity": "sha1-SEC85UCRdrw6HyvYyxC5LbRS/aY=",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -2688,6 +2744,19 @@
         }
       }
     },
+    "react-popper": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/react-popper/-/react-popper-1.0.0.tgz",
+      "integrity": "sha1-uZRSFE6P5KzHf6PZWajHngemUIQ=",
+      "requires": {
+        "babel-runtime": "6.x.x",
+        "create-react-context": "^0.2.1",
+        "popper.js": "^1.14.1",
+        "prop-types": "^15.6.1",
+        "typed-styles": "^0.0.5",
+        "warning": "^3.0.0"
+      }
+    },
     "react-range": {
       "version": "1.8.6",
       "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/react-range/-/react-range-1.8.6.tgz",
@@ -2695,8 +2764,8 @@
     },
     "react-reconciler": {
       "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.26.1.tgz",
-      "integrity": "sha512-6E/CvH9zcDmHjhiNJlP0qJ8+3ufnY2b5RWs774Uy8XKWN0l6qfnlkz0XnDacxqj2rbJdq76w9dlFXjPPOQrmqA==",
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/react-reconciler/-/react-reconciler-0.26.1.tgz",
+      "integrity": "sha1-hglS3TWf2HD5SJXCVCceOp3jstY=",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -2705,8 +2774,8 @@
       "dependencies": {
         "scheduler": {
           "version": "0.20.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
-          "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
+          "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/scheduler/-/scheduler-0.20.1.tgz",
+          "integrity": "sha1-2guQfiQCawEYHsvHXv3H8ntaAAw=",
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1"
@@ -3369,6 +3438,52 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "styled-components": {
+      "version": "3.4.10",
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/styled-components/-/styled-components-3.4.10.tgz",
+      "integrity": "sha1-mmVMUOorUWw2reV93Popa/hcluE=",
+      "requires": {
+        "buffer": "^5.0.3",
+        "css-to-react-native": "^2.0.3",
+        "fbjs": "^0.8.16",
+        "hoist-non-react-statics": "^2.5.0",
+        "prop-types": "^15.5.4",
+        "react-is": "^16.3.1",
+        "stylis": "^3.5.0",
+        "stylis-rule-sheet": "^0.0.10",
+        "supports-color": "^3.2.3"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha1-xZA89AnA39kI84jmGdhrnBF0y0c="
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
+      }
+    },
+    "stylis": {
+      "version": "3.5.4",
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/stylis/-/stylis-3.5.4.tgz",
+      "integrity": "sha1-9mXyX14pnPPWRlSrlJpXx2i3P74="
+    },
+    "stylis-rule-sheet": {
+      "version": "0.0.10",
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
+      "integrity": "sha1-ROZKKwdmQ/S1Ll/3HvwE2MPEpDA="
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -3438,6 +3553,11 @@
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
       "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
+    },
+    "typed-styles": {
+      "version": "0.0.5",
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/typed-styles/-/typed-styles-0.0.5.tgz",
+      "integrity": "sha1-pg3yRdSCqbGt+cBsB40PBghe0c8="
     },
     "typescript": {
       "version": "3.5.3",
@@ -3595,6 +3715,14 @@
       "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
       "requires": {
         "unist-util-stringify-position": "^1.1.1"
+      }
+    },
+    "warning": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "wasm-lz4": {

--- a/packages/webviz-core/package.json
+++ b/packages/webviz-core/package.json
@@ -7,7 +7,9 @@
     "node": ">=10.22.0 <12"
   },
   "dependencies": {
+    "@cruise-automation/button": "0.0.7",
     "@cruise-automation/hooks": "0.0.1",
+    "@cruise-automation/tooltip": "0.0.7",
     "@mdi/svg": "5.7.55",
     "@sentry/browser": "5.11.0",
     "async-retry": "1.2.3",

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/withTransforms.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/withTransforms.js
@@ -14,29 +14,35 @@ import Transforms from "webviz-core/src/panels/ThreeDimensionalViz/Transforms";
 import { updateTransforms } from "webviz-core/src/panels/ThreeDimensionalViz/utils/transformsUtils";
 import type { Frame } from "webviz-core/src/players/types";
 
+type State = {| transforms: Transforms |};
+
 function withTransforms<Props: *>(ChildComponent: React.ComponentType<Props>) {
-  function Component(props: { frame: Frame, cleared: boolean, forwardedRef: any }) {
-    const transforms = React.useRef(new Transforms());
+  class Component extends React.PureComponent<$Shape<{| frame: Frame, cleared: boolean, forwardedRef: any |}>, State> {
+    static displayName = `withTransforms(${ChildComponent.displayName || ChildComponent.name || ""})`;
+    static contextTypes = { store: PropTypes.any };
 
-    const { frame, cleared } = props;
-    transforms.current = updateTransforms(
-      transforms.current,
-      frame,
-      cleared,
-      getGlobalHooks().perPanelHooks().ThreeDimensionalViz.skipTransformFrame?.frameId,
-      getGlobalHooks().perPanelHooks().ThreeDimensionalViz.consumePose
-    );
+    state: State = { transforms: new Transforms() };
 
-    // $FlowFixMe - can't seem to figure out how to properly type this.
-    return <ChildComponent {...props} ref={props.forwardedRef} transforms={transforms.current} />;
+    static getDerivedStateFromProps(nextProps: Props, prevState: State): ?$Shape<State> {
+      const { frame, cleared } = nextProps;
+      const updatedTransforms = updateTransforms(
+        prevState.transforms,
+        frame,
+        cleared,
+        getGlobalHooks().perPanelHooks().ThreeDimensionalViz.skipTransformFrame?.frameId,
+        getGlobalHooks().perPanelHooks().ThreeDimensionalViz.consumePose
+      );
+      return { transforms: updatedTransforms };
+    }
+
+    render() {
+      // $FlowFixMe - can't seem to figure out how to properly type this.
+      return <ChildComponent {...this.props} ref={this.props.forwardedRef} transforms={this.state.transforms} />;
+    }
   }
-  Component.displayName = `withTransforms(${ChildComponent.displayName || ChildComponent.name || ""})`;
-  Component.contextTypes = { store: PropTypes.any };
 
   return hoistNonReactStatics(
-    React.forwardRef((props, ref) => {
-      return <Component {...props} forwardedRef={ref} />;
-    }),
+    React.forwardRef((props, ref) => <Component {...props} forwardedRef={ref} />),
     ChildComponent
   );
 }


### PR DESCRIPTION
Fix this issue where `withTransforms` seems to violate the rules of hooks: https://github.com/cruise-automation/webviz/issues/600

React is complaining that returning a function component here breaks the "rules of hooks".
I tried setting `Component.prototype = React.Component.Prototype` like the warning suggests, but it didn't seem to help.

I messed with it for a while trying to get it to work, but couldn't figure out why React is fine with this approach in `FrameCompatibilityDEPRECATED`, but doesn't like it in `withTransforms`. It might be due to the double layer of `hoistNonReactStatics`/`React.forwardRef` in both `FrameCompatibilityDEPRECATED` and `withTransforms`? I'm not entirely sure, but switching it back to a class component fixes the problem in the short-term.
