### PR TITLE
Worldview: Paint again if onDirty was called during paint

### DIFF
--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "license": "Apache-2.0",
   "repository": "cruise-automation/webviz/tree/master/packages/regl-worldview",


### PR DESCRIPTION
<!-- Thanks for contributing to Webviz! To help us understand and review your PR, please fill out the following sections: -->

## Summary

In some cases, painting may trigger a React state update (since components can register arbitrary functions to be called during `paint()`) which causes us to call `onDirty` again. But since a paint is currently in progress, we just ignore the `onDirty` call, which means that the new state never gets drawn until another paint is triggered in the future.

Fix this by keeping track of whether onDirty is called during paint, and if so just queue up another frame.

## Test plan

Tested locally by toggling perspective mode, and verifying that the change happens immediately instead of on the next render.

I'm not sure why this doesn't cause an issue on webviz.io, but I was testing in Foxglove Studio which is on React 17, which may make some difference in how/when updates are dispatched. There was a state update happening during paint in `Overlay`, and I think the World component's state update might have been batched with this: https://github.com/cruise-automation/webviz/blob/d82468c05fb2d3aeca670ff37999faeafa4d7ffc/packages/regl-worldview/src/commands/Overlay.js#L61

## Versioning impact

Should be a patch. I guess there is some risk of an infinite render loop, but I think someone would have to be doing some pretty weird things in their component for this to be a problem.