### PR TITLE
Remove engine constraints in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "root",
   "private": true,
-  "engines": {
-    "node": ">=10.0.0 <12.0.0",
-    "npm": ">=6.0.0"
-  },
   "devDependencies": {
     "@babel/cli": "^7.1.5",
     "@babel/core": "^7.2.0",

--- a/packages/webviz-core/package.json
+++ b/packages/webviz-core/package.json
@@ -3,9 +3,6 @@
   "version": "0.0.1",
   "description": "rosbag analysis tool",
   "license": "Apache-2.0",
-  "engines": {
-    "node": ">=10.22.0 <12"
-  },
   "dependencies": {
     "@cruise-automation/button": "0.0.7",
     "@cruise-automation/hooks": "0.0.1",


### PR DESCRIPTION
<!-- Thanks for contributing to Webviz! To help us understand and review your PR, please fill out the following sections: -->

## Summary

Removed engine constraints in `package.json` files.

Since webviz is using npm, these aren't actually being checked when you run `npm install` anyway. They only apply to people importing this repo as a library (and more specifically, since this is only referenced at the top level `package.json`, it only affects people who are trying to import the git source directly). In our case, we are importing as a library from source, and using a newer version of node.js. Therefore, these are getting in the way.

In short: these constraints aren't doing what they were intended to do, and they are blocking other use cases.

An alternative approach would be to relax the constraint, if you would prefer to do that let me know, but I would suggest removing altogether.

Note: The version of `node-sass` you are using is not compatible with newer versions of node.js either. You should fix that too (see https://github.com/cruise-automation/webviz/pull/585).

## Test plan

It's pretty much a no-op, if CI passes then this is safe to merge.

## Versioning impact

None

