### PR TITLE
Add prepack for regl-worldview and fix rollup errors

### DIFF
--- a/common/rollup.config.js
+++ b/common/rollup.config.js
@@ -47,7 +47,7 @@ export default function(pkg) {
           browser: true,
         }),
         babel(getBabelOptions({ useESModules: true })),
-        commonjs({ include: "node_modules/**" }),
+        commonjs({ include: /node_modules/ }),
         replace({ "process.env.NODE_ENV": JSON.stringify("development") }),
         terser(),
       ],

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -16,6 +16,7 @@
     "package.json"
   ],
   "scripts": {
+    "prepack": "npm run build",
     "build": "rollup -c",
     "build:watch": "rollup -c --watch",
     "clean": "rimraf dist",


### PR DESCRIPTION
## Summary

Add a `prepack` command to worldview's `package.json` file. This allows it to be installed from source and correctly compiled.

## Test plan

I installed it from source in another repo and it works now.

## Versioning impact

None