### PR TITLE
Fix rollup config on Windows

### DIFF
--- a/common/rollup.config.js
+++ b/common/rollup.config.js
@@ -26,7 +26,16 @@ const input = "src/index.js";
 const libraryName = "ReglWorldview";
 
 const globals = { react: "React", "react-dom": "ReactDOM" };
-const isExternal = (id) => !id.startsWith(".") && !id.startsWith("/");
+const isExternal = (id) => {
+  if (id.startsWith(".")) {
+    return false;
+  }
+  if (id.startsWith(__dirname)) {
+    return false;
+  }
+
+  return true;
+};
 
 export default function(pkg) {
   return [


### PR DESCRIPTION
<!-- Thanks for contributing to Webviz! To help us understand and review your PR, please fill out the following sections: -->

## Summary

This is the final issue preventing us from building worldview from source on Windows (allowing us to import worldview from source into Foxglove where we require Windows compatibility).

When running rollup on windows, the dist bundle was nearly empty (<1kb). After much debugging, I found the cause to be this `isExternal` function, which was treating paths like `C:\foo\bar.js` as external (and thus not bundling them). The solution was pretty easy after many hours of debugging.

## Test plan

Tested rollup on macos, linux, and windows, and they now produce identical output.

## Versioning impact

n/a

<!-- Feel free to also ping us on Slack about your PR. See the README on how to join our Slack workspace. -->
