### PR TITLE
Fix TwoDimensionalPlotLine data type so the pointStyle member is not …

### DIFF
--- a/packages/webviz-core/src/panels/TwoDimensionalPlot/index.js
+++ b/packages/webviz-core/src/panels/TwoDimensionalPlot/index.js
@@ -99,17 +99,7 @@ export type Line = {
   pointBorderColor?: string,
   pointBorderWidth?: number,
   pointRadius?: number,
-  pointStyle?:
-    | "circle"
-    | "cross"
-    | "crossRot"
-    | "dash"
-    | "line"
-    | "rect"
-    | "rectRounded"
-    | "rectRot"
-    | "star"
-    | "triangle",
+  pointStyle?: string,
   lineTension?: number,
   data: { x: number, y: number }[],
 };

--- a/packages/webviz-core/src/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/types.ts
+++ b/packages/webviz-core/src/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/types.ts
@@ -57,18 +57,6 @@ export type Transform = {
   };
 };
 
-export type PointStyle =
-  | "circle"
-  | "cross"
-  | "crossRot"
-  | "dash"
-  | "line"
-  | "rect"
-  | "rectRounded"
-  | "rectRot"
-  | "star"
-  | "triangle";
-
 export type TwoDimensionalPlotLine = {
   order?: number;
   label: string;
@@ -80,7 +68,7 @@ export type TwoDimensionalPlotLine = {
   pointBorderColor?: string;
   pointBorderWidth?: number;
   pointRadius?: number;
-  pointStyle?: PointStyle;
+  pointStyle?: string;
   lineTension?: number;
   data: { x: number; y: number }[];
 };


### PR DESCRIPTION
…a union. Resolve #613

This is my first contribution to Webviz, so please let me know if I'm missing anything and/or if there's anything I should seek to do better in the future!

## Summary

This is a very small pull request aimed to resolve issue #613. 
As pointed out in the issue, the 2D Plot Template for Node Playground does not presently compile. This is because the return value is a TwoDimensionalPlot object. A TwoDimensionalPlot contains multiple TwoDimensionalPlotLine objects, which each have an optional member called pointStyle. Prior to my change, pointStyle was a union data type. The AST parser throws an error when we try to return an object that contains a union, so the template wasn't compiling. 

I observed that there's no need for pointStyle to be a union type. In Typescript, a union type allows us to say pointStyle may be type X or type Y, but pointStyle is actually always a string. Thus, I simply changed each instance of pointStyle in the code so that instead of being a unique union data type, it would simply be a string.

In fact, I checked the GitHub blame feature for the relevant files and observed that pointStyle was actually previously a string (it was changed to a union 6 months ago, which is presumably what broke the template).

## Test plan

I ran npm test to ensure that I didn't break anything. I observed that the current master branch does not actually pass all the tests, but my code passes the exact same number of tests as the master branch. Thus I concluded I did not break any tests.

I opened the 2D plot template. I no longer receive a compile error, and the template works as intended, so I believe I successfully addressed the issue in #613. 

Next, I wrote a custom NodePlayground node that returns a TwoDimensionalPlot:
<img width="818" alt="Screen Shot 2021-04-22 at 11 58 13 PM" src="https://user-images.githubusercontent.com/7524265/115816376-c4784300-a3c6-11eb-9b9d-b13578a33604.png">

My goal here was to determine whether changing pointStyle to a string broke the intended functionality of pointStyle (i.e. am I still able to change the points on my plot to be stars, rectangles, etc). The above code resulted in a 2D plot with star indicators at (1,2) and (3,5) and a line between. I tested other point styles as well, such as "rect", and they worked correctly. Thus I concluded that the pointStyle functionality was working as intended.

<img width="429" alt="Screen Shot 2021-04-22 at 11 57 06 PM" src="https://user-images.githubusercontent.com/7524265/115816229-7cf1b700-a3c6-11eb-87b9-a0cc7b01ff6a.png">
 
## Versioning impact

N/A
