### PR TITLE
GLTFScene: basic support for KHR_materials_pbrSpecularGlossiness extension

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+common/fixtures/SpecGlossVsMetalRough.glb filter=lfs diff=lfs merge=lfs -text

--- a/common/fixtures/SpecGlossVsMetalRough.glb
+++ b/common/fixtures/SpecGlossVsMetalRough.glb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3eec53f92ae3956c0d49db86f18c133e05a2bf42db953424749c4bf4281afad
+size 15465324

--- a/packages/regl-worldview/src/stories/GLTFScene.stories.js
+++ b/packages/regl-worldview/src/stories/GLTFScene.stories.js
@@ -53,4 +53,28 @@ storiesOf("Worldview/GLTFScene", module)
         </GLTFScene>
       </Worldview>
     );
+  })
+  .add("Support for KHR_materials_pbrSpecularGlossiness extension", () => {
+    const model = require("common/fixtures/SpecGlossVsMetalRough.glb");
+    return (
+      <Worldview
+        defaultCameraState={{
+          distance: 4,
+          thetaOffset: (-3 * Math.PI) / 4,
+          phi: Math.PI / 3,
+          targetOffset: [0, 3, 0],
+        }}>
+        <Axes />
+        <Grid />
+        <GLTFScene model={model}>
+          {{
+            pose: {
+              position: { x: 0, y: 3, z: 0 },
+              orientation: { x: 0, y: 0, z: 1, w: 0 },
+            },
+            scale: { x: 7, y: 7, z: 7 },
+          }}
+        </GLTFScene>
+      </Worldview>
+    );
   });

--- a/packages/regl-worldview/src/utils/parseGLB.js
+++ b/packages/regl-worldview/src/utils/parseGLB.js
@@ -122,7 +122,11 @@ export default async function parseGLB(arrayBuffer: ArrayBuffer): Promise<GLBMod
     (await Promise.all(
       json.images.map((imgInfo) => {
         const bufferView = json.bufferViews[imgInfo.bufferView];
-        const data = new DataView(binary.buffer, binary.byteOffset + bufferView.byteOffset, bufferView.byteLength);
+        const data = new DataView(
+          binary.buffer,
+          binary.byteOffset + (bufferView.byteOffset || 0),
+          bufferView.byteLength
+        );
         return self.createImageBitmap(new Blob([data], { type: imgInfo.mimeType }));
       })
     ));


### PR DESCRIPTION
Handle `material.extensions.KHR_materials_pbrSpecularGlossiness` by using the `diffuseTexture` in place of the `pbrMetallicRoughness.baseColorTexture`. This is not a perfect/complete implementation, however, it's better than having no support at all for pbrSpecularGlossiness!

Other small fixes:
- Set `wrapS` and `wrapT` defaults to REPEAT as described in https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#sampler
- Set `byteOffset` default to 0 as described in https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#accessor

Example model from: [SpecGlossVsMetalRough](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/SpecGlossVsMetalRough)

The two bottles are supposed to look identical, so obviously this is not a complete rendering implementation.

<img width="637" alt="image" src="https://user-images.githubusercontent.com/14237/116641757-165e2300-a909-11eb-971e-8b25299634d3.png">
