### PR TITLE
Hernan/check regl instance

### DIFF
--- a/packages/regl-worldview/package-lock.json
+++ b/packages/regl-worldview/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "regl-worldview",
-	"version": "0.16.0",
+	"version": "0.16.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "license": "Apache-2.0",
   "repository": "cruise-automation/webviz/tree/master/packages/regl-worldview",

--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -141,6 +141,11 @@ export class WorldviewContext {
         profile: getNodeEnv() !== "production",
       })
     );
+
+    if (!regl) {
+      throw new Error("Cannot initialize regl");
+    }
+
     // compile any components which mounted before regl is initialized
     this._commands.forEach((uncompiledCommand) => {
       const compiledCommand = compile(regl, uncompiledCommand);

--- a/packages/regl-worldview/src/camera/camera.js
+++ b/packages/regl-worldview/src/camera/camera.js
@@ -18,6 +18,10 @@ const TEMP_MAT = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 // This is the regl command which encapsulates the camera projection and view matrices.
 // It adds the matrices to the regl context so they can be used by other commands.
 export default (regl: any) => {
+  if (!regl) {
+    throw new Error("Invalid regl instance");
+  }
+
   return class Camera implements CameraCommand {
     viewportWidth: number = 0;
     viewportHeight: number = 0;

--- a/packages/regl-worldview/src/commands/GLTFScene.js
+++ b/packages/regl-worldview/src/commands/GLTFScene.js
@@ -60,6 +60,10 @@ const getSceneToDraw = ({ json }) => {
 };
 
 const drawModel = (regl) => {
+  if (!regl) {
+    throw new Error("Invalid regl instance");
+  }
+
   const command = regl({
     primitive: "triangles",
     blend: defaultBlend,

--- a/packages/regl-worldview/src/commands/GLText.js
+++ b/packages/regl-worldview/src/commands/GLText.js
@@ -344,6 +344,10 @@ function makeTextCommand(alphabet?: string[]) {
   const memoizedDrawAtlasTexture = createMemoizedDrawAtlasTexture();
 
   const command = (regl: any) => {
+    if (!regl) {
+      throw new Error("Invalid regl instance");
+    }
+
     const atlasTexture = regl.texture();
 
     const drawText = regl({

--- a/packages/regl-worldview/src/commands/Lines.js
+++ b/packages/regl-worldview/src/commands/Lines.js
@@ -243,6 +243,10 @@ function pointsEqual(a, b) {
 }
 
 export const lines = (regl: any) => {
+  if (!regl) {
+    throw new Error("Invalid regl instance");
+  }
+
   // The point type attribute, reused for each instance
   const pointTypeBuffer = regl.buffer({
     type: "uint16",

--- a/packages/regl-worldview/src/commands/Points.js
+++ b/packages/regl-worldview/src/commands/Points.js
@@ -26,6 +26,10 @@ type Props = {
 
 export const makePointsCommand = ({ useWorldSpaceSize }: PointsProps) => {
   return (regl: Regl) => {
+    if (!regl) {
+      throw new Error("Invalid regl instance");
+    }
+
     const [minLimitPointSize, maxLimitPointSize] = regl.limits.pointSizeDims;
     return withPose({
       primitive: "points",


### PR DESCRIPTION
## Summary

There have been some reports of errors during Worldview initialization:

`cannot read property 'context' of null` in `WorldviewContext.initialize`

This PR does not solve that problem, but in an attempt to better understand it, I'm adding extra checks when creating the `regl` instance and each of the rendering commands. 

## Versioning impact

Patch