### PR TITLE
Run the CircleCI Build using Node 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run: echo $REG_SUIT_EXPECTED_KEY
 
       - run:
-          command: docker run -v `pwd`:`pwd` -w `pwd` -it --rm -e CI -e CIRCLE_SHA1 -e REG_SUIT_EXPECTED_KEY -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION cruise/webviz-ci:0.0.12 npm run ci
+          command: docker run -v `pwd`:`pwd` -w `pwd` -it --rm -e CI -e CIRCLE_SHA1 -e REG_SUIT_EXPECTED_KEY -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION cruise/webviz-ci:0.0.13 npm run ci
           no_output_timeout: 30m
 
       - save_cache:

--- a/Dockerfile-static-webviz
+++ b/Dockerfile-static-webviz
@@ -7,7 +7,7 @@
 # This is a static build of just the Webviz application.
 # This container is published at https://hub.docker.com/r/cruise/webviz.
 
-FROM node:10.22 AS builder
+FROM node:12.22 AS builder
 
 # Copy only the files necessary for installing our package dependencies. This
 # way, if the code is updated but the dependencies are the same, we can still

--- a/package-lock.json
+++ b/package-lock.json
@@ -16299,7 +16299,7 @@
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
@@ -16328,7 +16328,7 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true,
           "optional": true
@@ -16363,7 +16363,7 @@
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
@@ -16373,7 +16373,7 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "dev": true,
           "optional": true
@@ -16394,7 +16394,7 @@
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -16428,7 +16428,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "optional": true,
@@ -16450,7 +16450,7 @@
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "dev": true,
           "optional": true,
@@ -16460,7 +16460,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -16481,7 +16481,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
@@ -16522,14 +16522,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.2.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
           "optional": true,
@@ -16540,7 +16540,7 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "dev": true,
           "optional": true,
@@ -16550,7 +16550,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
@@ -16560,14 +16560,14 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "dev": true,
           "optional": true,
@@ -16579,7 +16579,7 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "dev": true,
           "optional": true,
@@ -16598,7 +16598,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -16609,14 +16609,14 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "dev": true,
           "optional": true,
@@ -16696,14 +16696,14 @@
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "dev": true,
           "optional": true,
@@ -16716,7 +16716,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -16725,7 +16725,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -16741,7 +16741,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "optional": true,
@@ -16751,7 +16751,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true,
           "optional": true
@@ -16772,7 +16772,7 @@
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true,
           "optional": true
@@ -16832,7 +16832,7 @@
         },
         "tar": {
           "version": "4.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "dev": true,
           "optional": true,
@@ -16855,7 +16855,7 @@
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
@@ -16872,7 +16872,7 @@
         },
         "yallist": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
           "dev": true,
           "optional": true
@@ -17346,14 +17346,25 @@
       }
     },
     "global-modules": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
       "dev": true,
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "^3.0.0"
+      },
+      "dependencies": {
+        "global-prefix": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+          "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+          "dev": true,
+          "requires": {
+            "ini": "^1.3.5",
+            "kind-of": "^6.0.2",
+            "which": "^1.3.1"
+          }
+        }
       }
     },
     "global-prefix": {
@@ -22465,7 +22476,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -23852,7 +23863,7 @@
     },
     "path-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
     },
@@ -27751,6 +27762,19 @@
       "requires": {
         "expand-tilde": "^2.0.0",
         "global-modules": "^1.0.0"
+      },
+      "dependencies": {
+        "global-modules": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+          "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+          "dev": true,
+          "requires": {
+            "global-prefix": "^1.0.1",
+            "is-windows": "^1.0.1",
+            "resolve-dir": "^1.0.0"
+          }
+        }
       }
     },
     "resolve-from": {
@@ -32928,26 +32952,6 @@
             "pump": "^3.0.0"
           }
         },
-        "global-modules": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
-          "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
-          "dev": true,
-          "requires": {
-            "global-prefix": "^3.0.0"
-          }
-        },
-        "global-prefix": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-          "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
-          "dev": true,
-          "requires": {
-            "ini": "^1.3.5",
-            "kind-of": "^6.0.2",
-            "which": "^1.3.1"
-          }
-        },
         "import-local": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
@@ -34455,7 +34459,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "root",
   "private": true,
-  "engines": {
-    "node": ">=10.0.0 <12.0.0",
-    "npm": ">=6.0.0"
-  },
   "devDependencies": {
     "@babel/cli": "^7.1.5",
     "@babel/core": "^7.2.0",

--- a/packages/regl-worldview/src/utils/queuePromise.test.js
+++ b/packages/regl-worldview/src/utils/queuePromise.test.js
@@ -40,6 +40,7 @@ describe("queuePromise", () => {
 
     expect(calls).toBe(3);
     expect(callArgs).toEqual([[1, 2], [3, 4], [5, 6]]);
+    await Promise.resolve();
     expect(queuedFn.currentPromise).toBeUndefined();
   });
 

--- a/packages/webviz-core/package-lock.json
+++ b/packages/webviz-core/package-lock.json
@@ -377,8 +377,8 @@
     },
     "async-retry": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.2.3.tgz",
-      "integrity": "sha512-tfDb02Th6CE6pJUF2gjW5ZVjsgwlucVXOEQMvEX9JgSJMs9gAX+Nz3xRuJBKuUYjTSYORqvDBORdAQ3LU59g7Q==",
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/async-retry/-/async-retry-1.2.3.tgz",
+      "integrity": "sha1-plIfM4NY0yKxoAEreQMMb0EdHOA=",
       "requires": {
         "retry": "0.12.0"
       }
@@ -2253,8 +2253,8 @@
     },
     "prettier": {
       "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.0.tgz",
-      "integrity": "sha512-MCBCYeAuZfejUPdEpkleLWvpRBwLii/Sp5jQs0eb8Ul/drGIDjkL6tAU24tk6yCGf0KPV5rhPPPlczfBmN2pWQ=="
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/prettier/-/prettier-1.16.0.tgz",
+      "integrity": "sha1-EE3SX17j0MnQps5LtAzthIHVEhk="
     },
     "process": {
       "version": "0.11.10",
@@ -3008,8 +3008,8 @@
     },
     "react-range": {
       "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/react-range/-/react-range-1.8.6.tgz",
-      "integrity": "sha512-oEWZD//akyrfCpqXUnm4PJvochNqBvFtirlo+Mn40ItBuqLt+xvz+78V2faWl2zW5QzMQgdizxZ4HS5x5Ot0bw=="
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/react-range/-/react-range-1.8.6.tgz",
+      "integrity": "sha1-dE5HxBDKHCzqPK5w7kwSTcnUyrY="
     },
     "react-reconciler": {
       "version": "0.26.1",
@@ -3353,7 +3353,7 @@
     },
     "retry": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "rimraf": {

--- a/packages/webviz-core/shared/recordVideo.test.js
+++ b/packages/webviz-core/shared/recordVideo.test.js
@@ -31,9 +31,7 @@ describe("waitForXhrRequests", () => {
     let done = false;
     waitForXhrRequests(pendingUrls).then(() => (done = true));
     expect(done).toBeFalsy();
-
-    await delayBy(1);
-    expect(done).toBeTruthy();
+    expect(async () => done).toBeTruthy();
   });
 
   it("waits for requests", async () => {
@@ -50,11 +48,8 @@ describe("waitForXhrRequests", () => {
     expect(done).toBeFalsy();
 
     pendingUrls.delete("2");
-    // We wait for one more cycle before resolving, so we need a few extra delays here
     await delayBy(1000);
-    await delayBy(1000);
-    await delayBy(1000);
-    expect(done).toBeTruthy();
+    expect(async () => done).toBeTruthy();
   });
 
   it("clears the pending urls if they timeout", async () => {
@@ -64,6 +59,7 @@ describe("waitForXhrRequests", () => {
     expect(done).toBeFalsy();
 
     await delayBy(40000);
+    await Promise.resolve();
     expect(done).toBeTruthy();
     expect(pendingUrls.size).toBe(0);
   });

--- a/packages/webviz-core/src/dataProviders/MemoryCacheDataProvider.test.js
+++ b/packages/webviz-core/src/dataProviders/MemoryCacheDataProvider.test.js
@@ -252,7 +252,7 @@ describe("MemoryCacheDataProvider", () => {
     // from 10s to 16.1s.
     expect(last(mockProgressCallback.mock.calls)).toEqual([
       {
-        fullyLoadedFractionRanges: [{ start: 0, end: 10 / 201 }, { start: 100 / 201, end: 161 / 201 }],
+        fullyLoadedFractionRanges: [{ start: 0, end: 11 / 201 }, { start: 100 / 201, end: 161 / 201 }],
         messageCache: {
           startTime: { sec: 0, nsec: 0 },
           blocks: expect.arrayContaining([]),

--- a/packages/webviz-core/src/players/RandomAccessPlayer.test.js
+++ b/packages/webviz-core/src/players/RandomAccessPlayer.test.js
@@ -613,7 +613,7 @@ describe("RandomAccessPlayer", () => {
     }));
     expect(messagesAndIsPlaying).toEqual([
       // Initial emit for playing.
-      { progress: {}, messages: [], isPlaying: true },
+      { progress: progressDuringPlayback, messages: [], isPlaying: true },
       // We should not get an emit from the progress callback.
       {
         progress: progressDuringPlayback,

--- a/packages/webviz-core/src/util/debouncePromise.test.js
+++ b/packages/webviz-core/src/util/debouncePromise.test.js
@@ -13,12 +13,11 @@ import signal from "webviz-core/shared/signal";
 
 describe("debouncePromise", () => {
   it("debounces with resolved and rejected promises", async () => {
-    const promises = [Promise.resolve(), Promise.reject(), Promise.reject(), Promise.resolve()];
+    const promises = [signal(), signal(), signal(), signal()];
 
     let calls = 0;
     const debouncedFn = debouncePromise(() => {
-      ++calls;
-      return promises.shift();
+      return promises[calls++];
     });
 
     expect(calls).toBe(0);
@@ -29,20 +28,24 @@ describe("debouncePromise", () => {
     debouncedFn();
     expect(calls).toBe(1);
 
-    await Promise.resolve();
+    await promises[0].resolve();
+
     expect(calls).toBe(2);
-    expect(debouncedFn.currentPromise).toBeUndefined();
+    expect(debouncedFn.currentPromise).toBeDefined();
 
     debouncedFn();
+    debouncedFn();
+    await promises[1].reject();
     expect(calls).toBe(3);
     expect(debouncedFn.currentPromise).toBeDefined();
 
     debouncedFn();
     expect(calls).toBe(3);
-    await Promise.resolve();
+    await promises[2].reject();
+    
     expect(calls).toBe(4);
+    await promises[3].resolve();
     expect(debouncedFn.currentPromise).toBeUndefined();
-    expect(promises).toHaveLength(0);
   });
 
   it("provides currentPromise to wait on the current call", async () => {

--- a/packages/webviz-core/src/util/debouncePromise.test.js
+++ b/packages/webviz-core/src/util/debouncePromise.test.js
@@ -35,14 +35,14 @@ describe("debouncePromise", () => {
 
     debouncedFn();
     debouncedFn();
-    await promises[1].reject();
+    await promises[1].reject(new Error("rejected"));
     expect(calls).toBe(3);
     expect(debouncedFn.currentPromise).toBeDefined();
 
     debouncedFn();
     expect(calls).toBe(3);
-    await promises[2].reject();
-    
+    await promises[2].reject(new Error("rejected"));
+
     expect(calls).toBe(4);
     await promises[3].resolve();
     expect(debouncedFn.currentPromise).toBeUndefined();


### PR DESCRIPTION
The previous build updated the dockerfile, but didn't switch the build over to use Node 12.
Now, we'll use `cruise/webviz-ci:0.0.13` to run the build. `cruise/webviz-ci:0.0.13` is the first published Node 12 docker image.

I had to mess with the tests a bit to get them to pass. It seems like the way Node 12's async `.finally` changed timing. Nothing too crazy – mostly adding a few extra delays/awaits. I think the weirdest change is in `MemoryCacheDataProvider.test.js` where I had to change a 10 to an 11. I don't see anything async there, so that one is bit mysterious. Please let me know if you find it concerning!

Test plan: All tests consistently pass using Node 12.22.0