### PR TITLE
Remove references to artifactory.robot.car from package-lock.json

### DIFF
--- a/packages/webviz-core/package-lock.json
+++ b/packages/webviz-core/package-lock.json
@@ -377,8 +377,8 @@
     },
     "async-retry": {
       "version": "1.2.3",
-      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/async-retry/-/async-retry-1.2.3.tgz",
-      "integrity": "sha1-plIfM4NY0yKxoAEreQMMb0EdHOA=",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.2.3.tgz",
+      "integrity": "sha512-tfDb02Th6CE6pJUF2gjW5ZVjsgwlucVXOEQMvEX9JgSJMs9gAX+Nz3xRuJBKuUYjTSYORqvDBORdAQ3LU59g7Q==",
       "requires": {
         "retry": "0.12.0"
       }
@@ -2253,8 +2253,8 @@
     },
     "prettier": {
       "version": "1.16.0",
-      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/prettier/-/prettier-1.16.0.tgz",
-      "integrity": "sha1-EE3SX17j0MnQps5LtAzthIHVEhk="
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.0.tgz",
+      "integrity": "sha512-MCBCYeAuZfejUPdEpkleLWvpRBwLii/Sp5jQs0eb8Ul/drGIDjkL6tAU24tk6yCGf0KPV5rhPPPlczfBmN2pWQ=="
     },
     "process": {
       "version": "0.11.10",
@@ -3008,8 +3008,8 @@
     },
     "react-range": {
       "version": "1.8.6",
-      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/react-range/-/react-range-1.8.6.tgz",
-      "integrity": "sha1-dE5HxBDKHCzqPK5w7kwSTcnUyrY="
+      "resolved": "https://registry.npmjs.org/react-range/-/react-range-1.8.6.tgz",
+      "integrity": "sha512-oEWZD//akyrfCpqXUnm4PJvochNqBvFtirlo+Mn40ItBuqLt+xvz+78V2faWl2zW5QzMQgdizxZ4HS5x5Ot0bw=="
     },
     "react-reconciler": {
       "version": "0.26.1",
@@ -3353,7 +3353,7 @@
     },
     "retry": {
       "version": "0.12.0",
-      "resolved": "https://artifactory.robot.car/artifactory/api/npm/npm-virtual/retry/-/retry-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "rimraf": {


### PR DESCRIPTION
The package-lock file was referencing `artifactory.robot.car` which isn't available to open-source users. Replace them with npm registry entries.

I'll open a new PR to add a lint rule so this doesn't happen again, but I wanted to get this fix out asap.