### PR TITLE
Allow absolute import paths everywhere

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -13,5 +13,7 @@ module.exports = {
     "@babel/plugin-proposal-optional-chaining",
     "@babel/plugin-syntax-dynamic-import",
     ["@babel/plugin-proposal-object-rest-spread", { useBuiltIns: true }],
+    // module-resolver allows us to use absolute import paths
+    ["module-resolver", { root: ["packages"] }],
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9111,7 +9111,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -10279,6 +10279,54 @@
       "dev": true,
       "requires": {
         "babel-helper-is-void-0": "^0.4.3"
+      }
+    },
+    "babel-plugin-module-resolver": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.1.0.tgz",
+      "integrity": "sha512-MlX10UDheRr3lb3P0WcaIdtCSRlxdQsB1sBqL7W0raF070bGl1HQQq5K3T2vf2XAYie+ww+5AKC/WrkjRO2knA==",
+      "dev": true,
+      "requires": {
+        "find-babel-config": "^1.2.0",
+        "glob": "^7.1.6",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.0.0",
+        "resolve": "^1.13.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "pkg-up": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+          "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        },
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "babel-plugin-named-asset-import": {
@@ -15715,6 +15763,24 @@
         }
       }
     },
+    "find-babel-config": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
+      "integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
+      "dev": true,
+      "requires": {
+        "json5": "^0.5.1",
+        "path-exists": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+          "dev": true
+        }
+      }
+    },
     "find-cache-dir": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
@@ -16299,7 +16365,7 @@
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
@@ -16328,7 +16394,7 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true,
           "optional": true
@@ -16363,7 +16429,7 @@
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
@@ -16373,7 +16439,7 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "dev": true,
           "optional": true
@@ -16394,7 +16460,7 @@
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -16428,7 +16494,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "optional": true,
@@ -16450,7 +16516,7 @@
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "dev": true,
           "optional": true,
@@ -16460,7 +16526,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -16481,7 +16547,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
@@ -16522,14 +16588,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.2.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
           "optional": true,
@@ -16540,7 +16606,7 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "dev": true,
           "optional": true,
@@ -16550,7 +16616,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
@@ -16560,14 +16626,14 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "dev": true,
           "optional": true,
@@ -16579,7 +16645,7 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "dev": true,
           "optional": true,
@@ -16598,7 +16664,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -16609,14 +16675,14 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "dev": true,
           "optional": true,
@@ -16696,14 +16762,14 @@
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "dev": true,
           "optional": true,
@@ -16716,7 +16782,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -16725,7 +16791,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -16741,7 +16807,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "optional": true,
@@ -16751,7 +16817,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true,
           "optional": true
@@ -16772,7 +16838,7 @@
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true,
           "optional": true
@@ -16832,7 +16898,7 @@
         },
         "tar": {
           "version": "4.4.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "dev": true,
           "optional": true,
@@ -16855,7 +16921,7 @@
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
@@ -16872,7 +16938,7 @@
         },
         "yallist": {
           "version": "3.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
           "dev": true,
           "optional": true
@@ -18811,6 +18877,15 @@
       "dev": true,
       "requires": {
         "ci-info": "^1.5.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
+      "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
       }
     },
     "is-data-descriptor": {
@@ -27730,6 +27805,12 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==",
+      "dev": true
+    },
     "resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
@@ -32134,7 +32215,7 @@
     },
     "vm-browserify": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel-eslint": "^10.0.1",
     "babel-jest": "^23.4.2",
     "babel-loader": "^8.0.4",
+    "babel-plugin-module-resolver": "^4.1.0",
     "case-sensitive-paths-webpack-plugin": "^2.1.2",
     "css-loader": "^1.0.1",
     "enzyme": "^3.9.0",

--- a/packages/webviz-core/shared/recordVideo.js
+++ b/packages/webviz-core/shared/recordVideo.js
@@ -13,15 +13,15 @@ import rmfr from "rmfr";
 import util from "util";
 import uuid from "uuid";
 
-import type { VideoMetadata } from "../src/players/automatedRun/AutomatedRunPlayer";
-import type { VideoRecordingAction } from "../src/players/automatedRun/videoRecordingClient";
-import convertVideoToGif from "./convertVideoToGif";
-import delay from "./delay";
-import { withTempDirectory } from "./fileUtils";
-import globalEnvVars from "./globalEnvVars";
-import promiseTimeout from "./promiseTimeout";
-import runInBrowser from "./runInBrowser";
-import ServerLogger from "./ServerLogger";
+import convertVideoToGif from "webviz-core/shared/convertVideoToGif";
+import delay from "webviz-core/shared/delay";
+import { withTempDirectory } from "webviz-core/shared/fileUtils";
+import globalEnvVars from "webviz-core/shared/globalEnvVars";
+import promiseTimeout from "webviz-core/shared/promiseTimeout";
+import runInBrowser from "webviz-core/shared/runInBrowser";
+import ServerLogger from "webviz-core/shared/ServerLogger";
+import type { VideoMetadata } from "webviz-core/src/players/automatedRun/AutomatedRunPlayer";
+import type { VideoRecordingAction } from "webviz-core/src/players/automatedRun/videoRecordingClient";
 
 const exec = util.promisify(child_process.exec);
 const mkdir = util.promisify(fs.mkdir);


### PR DESCRIPTION
We already enabled this in the closed-source repo, but let's add it here as well.
This allows all code to import using paths like `import X from "webviz-core/any/path"`.

This allows script files like `record-local-bag-video.js` to use absolute import paths as well. I realized we needed this when the close-source repo started erroring when running the `test_with_open_source` due to this error: `Error: Cannot find module 'webviz-core/src/util/globalConstants'`. This was because this repo has relied on some import paths being relative, but this should resolve it going forward.

![image](https://user-images.githubusercontent.com/5104925/126833850-284fd450-e5cc-417e-aa71-d7b9570a3088.png)

