### PR TITLE
Install dirmngr when installing ffmpeg

### DIFF
--- a/integration-tests/install-ffmpeg-in-docker.sh
+++ b/integration-tests/install-ffmpeg-in-docker.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Install dirmng to be able to import keys
+# See https://unix.stackexchange.com/a/401548
+apt-get install dirmngr
+
 sed -i "s/jessie main/jessie main contrib non-free/" /etc/apt/sources.list
 echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main contrib non-free" >> /etc/apt/sources.list
 # Adding the keys to fix the error:


### PR DESCRIPTION
Otherwise adding the keys sometimes fails with the error:
```
gpg: keyserver receive failed: No dirmngr
```

## Test plan

* Green CI should be sufficient
