### PR TITLE
Add dataTest to button props for testing

### DIFF
--- a/packages/@cruise-automation/button/package.json
+++ b/packages/@cruise-automation/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruise-automation/button",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "lib/index.js",
   "description": "Cruise button",
   "license": "Apache-2.0",

--- a/packages/@cruise-automation/button/src/index.js
+++ b/packages/@cruise-automation/button/src/index.js
@@ -82,6 +82,7 @@ type Props = {
   progressStyle?: { [key: string]: any },
   style?: { [key: string]: any },
   tooltip?: string,
+  dataTest?: string, // shows up on the button as data-test
 };
 
 type State = {
@@ -232,6 +233,7 @@ export default class Button extends React.Component<Props, State> {
       style,
       tooltip,
       onFocus,
+      dataTest,
     } = this.props;
     const classes = cx("button", className || "", {
       // support some bulma classes to be supplied in consumer either through bulma or custom classes
@@ -255,7 +257,8 @@ export default class Button extends React.Component<Props, State> {
         onMouseUp={this.onMouseUp}
         style={{ position: "relative", zIndex: 0, overflow: "hidden", ...style }}
         title={tooltip}
-        disabled={disabled}>
+        disabled={disabled}
+        data-test={dataTest}>
         {children}
         {this.renderProgressBar()}
       </button>

--- a/packages/webviz-core/src/components/Button.js
+++ b/packages/webviz-core/src/components/Button.js
@@ -19,6 +19,7 @@ export type Props = {
   tooltipProps?: $Shape<{ ...React.ElementConfig<typeof Tooltip> }>,
   style: { [string]: string | number },
   isPrimary?: boolean,
+  dataTest?: string,
 };
 
 export type { BaseButton };


### PR DESCRIPTION
## Summary

There seems to be no easy way to select buttons for clicking in tests. Added `data-test` tag to `<button>` so that it can be tested. Note: The prop is `dataTest`, but becomes `data-test` on the button to match existing patterns.

## Test plan

Tested manually to verify that the tag comes through.

## Versioning impact

This shouldn't affect versions.

<!-- Feel free to also ping us on Slack about your PR. See the README on how to join our Slack workspace. -->
