### PR TITLE
Add vertex offset before applying geometry's pose

### DIFF
--- a/packages/regl-worldview/package-lock.json
+++ b/packages/regl-worldview/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "regl-worldview",
-	"version": "0.18.0",
+	"version": "0.18.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "license": "Apache-2.0",
   "repository": "cruise-automation/webviz/tree/master/packages/regl-worldview",

--- a/packages/regl-worldview/src/utils/fromGeometry.js
+++ b/packages/regl-worldview/src/utils/fromGeometry.js
@@ -39,7 +39,7 @@ export default (positions: Vec3[], elements: Vec3[]) => (regl: any): ReglCommand
     #WITH_POSE
 
     void main () {
-      vec3 p = applyPose(scale * point) + offset;
+      vec3 p = applyPose(scale * point + offset);
       vColor = color;
       gl_Position = projection * view * vec4(p, 1);
     }


### PR DESCRIPTION
## Summary

Vertex offset is currently applied after the pose, but offset is in local space instead of world space.
This lead to a bug where marker orientations end up being ignored in some cases.

### Before
<img width="400" alt="Screen Shot 2022-03-10 at 11 09 54 AM" src="https://user-images.githubusercontent.com/1727802/157680984-2dce755f-a109-45d1-87cf-a6e2271e577c.png">

Notice how spheres are not in the correct final position for the object to the right of the screen. Orientation is not applied in this case (spheres have the same orientation as in the object to the left).


### After
<img width="400" alt="Screen Shot 2022-03-10 at 11 05 14 AM" src="https://user-images.githubusercontent.com/1727802/157681004-f6607234-7f9f-4d6f-86ca-8a84ba63f0ce.png">

Now spheres are in the correct position and orientation.

## Test plan

All existing tests must pass

## Versioning impact

This is a bug fix, so it should be a patch. 