### PR TITLE
Fix repository update

### DIFF
--- a/integration-tests/install-ffmpeg-in-docker.sh
+++ b/integration-tests/install-ffmpeg-in-docker.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Install ffmpeg. Validity check disabled because the repository is no longer updated.
+# [check-valid-until=no]: https://unix.stackexchange.com/a/508728
+# [trusted=yes]: https://unix.stackexchange.com/a/602746
 sed -i "s/jessie main/jessie main contrib non-free/" /etc/apt/sources.list
-echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main contrib non-free" >> /etc/apt/sources.list
+echo "deb [check-valid-until=no, trusted=yes] http://archive.debian.org/debian jessie-backports main contrib non-free" >> /etc/apt/sources.list
 # Adding the keys to fix the error:
 # ```
 # #8 2.073 W: GPG error: http://archive.debian.org/debian jessie-backports InRelease:


### PR DESCRIPTION
Otherwise CI fails with the error:
```
[2022-03-10T19:29:48Z]   The following signatures were invalid: EXPKEYSIG 8B48AD6246925553 Debian Archive Automatic Signing Key (7.0/wheezy) <ftpmaster@debian.org> REVKEYSIG 7638D0442B90D010 Debian Archive Automatic Signing Key (8/jessie) <ftpmaster@debian.org>
--
  | Reading package lists... Done
  | [2022-03-10T19:29:49Z] W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list.d/google-chrome.list:3 and /etc/apt/sources.list.d/google.list:1
  | [2022-03-10T19:29:49Z] W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list.d/google-chrome.list:3 and /etc/apt/sources.list.d/google.list:1
  | [2022-03-10T19:29:49Z] W: GPG error: http://archive.debian.org/debian jessie-backports InRelease: The following signatures were invalid: EXPKEYSIG 8B48AD6246925553 Debian Archive Automatic Signing Key (7.0/wheezy) <ftpmaster@debian.org> REVKEYSIG 7638D0442B90D010 Debian Archive Automatic Signing Key (8/jessie) <ftpmaster@debian.org>

```